### PR TITLE
Fix package restore in init.ps1

### DIFF
--- a/tools/Restore-NuGetPackages.ps1
+++ b/tools/Restore-NuGetPackages.ps1
@@ -17,5 +17,5 @@ Param(
 $nugetPath = & "$PSScriptRoot\Get-NuGetTool.ps1"
 
 Write-Host "Restoring NuGet packages for $Path" -ForegroundColor Yellow
-& $nugetPath restore $Path -MSBuildVersion 14.0 -Verbosity $Verbosity
+& $nugetPath restore $Path -MSBuildVersion 14.0 -Verbosity $Verbosity -ConfigFile "$PSScriptRoot\..\src\nuget.config"
 if ($lastexitcode -ne 0) { throw }


### PR DESCRIPTION
When restoring packages for a `project.json` directly, as init.ps1 will do for nuproj projects, the config file is _not_ automatically found by nuget.exe. This forces it to consider that, which lets the package restore succeed since the packages come from sources other than nuget.org.
