### PR TITLE
Reference MS.VS.Threading 15.0.116-pre-g43c3d919cd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# MSBuild logs
+msbuild.err
+msbuild.wrn

--- a/src/StreamJsonRpc.Desktop/project.json
+++ b/src/StreamJsonRpc.Desktop/project.json
@@ -22,7 +22,7 @@
       "suppressParent": "none"
     },
     "Newtonsoft.Json": "6.0.6",
-    "Microsoft.VisualStudio.Threading": "15.0.109-pre"
+    "Microsoft.VisualStudio.Threading": "15.0.116-pre-g43c3d919cd"
   },
   "frameworks": {
     "net45": { }

--- a/src/StreamJsonRpc.NuGet/StreamJsonRpc.nuspec
+++ b/src/StreamJsonRpc.NuGet/StreamJsonRpc.nuspec
@@ -14,7 +14,7 @@
       <group targetFramework="dotnet">
         <dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
         <dependency id="Microsoft.CSharp" version="4.0.0" />
-        <dependency id="Microsoft.VisualStudio.Threading" version="15.0.109-pre" />
+        <dependency id="Microsoft.VisualStudio.Threading" version="15.0.116-pre-g43c3d919cd" />
         <dependency id="Microsoft.VisualStudio.Validation" version="15.0.55-pre" />
         <dependency id="Newtonsoft.Json" version="6.0.6" />
         <dependency id="System.Collections" version="4.0.0" />
@@ -34,7 +34,7 @@
         <dependency id="System.Threading.Tasks" version="4.0.0" />
       </group>
       <group targetFramework="net45">
-        <dependency id="Microsoft.VisualStudio.Threading" version="15.0.109-pre" />
+        <dependency id="Microsoft.VisualStudio.Threading" version="15.0.116-pre-g43c3d919cd" />
         <dependency id="Newtonsoft.Json" version="6.0.6" />
       </group>
     </dependencies>

--- a/src/StreamJsonRpc/project.json
+++ b/src/StreamJsonRpc/project.json
@@ -18,7 +18,7 @@
     },
     "Newtonsoft.Json": "6.0.6",
     "NuSpec.ReferenceGenerator": "1.4.2",
-    "Microsoft.VisualStudio.Threading": "15.0.109-pre",
+    "Microsoft.VisualStudio.Threading": "15.0.116-pre-g43c3d919cd",
     "PdbGit": "3.0.32",
     "ReadOnlySourceTree": {
       "version": "0.1.36-beta",


### PR DESCRIPTION
This is a fix for DevDiv bug [#293892](https://devdiv.visualstudio.com/DevDiv/Connected%20Experience/_workitems?id=293892&_a=edit) Update references to MS.VS.Threading and Validation in StreamJsonRpc and ServiceHub to use the same versions as VS.

