### PR TITLE
Simplify package restore, and use latest NuProj

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -15,11 +15,6 @@ Push-Location $PSScriptRoot
 try {
     $toolsPath = "$PSScriptRoot\tools"
 
-    # First restore NuProj packages since the solution restore depends on NuProj evaluation succeeding.
-    gci "$PSScriptRoot\src\project.json" -rec |? { $_.FullName -imatch 'nuget' } |% {
-        & "$toolsPath\Restore-NuGetPackages.ps1" -Path $_
-    }
-
     & "$toolsPath\Restore-NuGetPackages.ps1" -Path "$PSScriptRoot\src"
 
     $MicroBuildPackageSource = 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuProj" version="0.10.48-beta-gea4a31bbc5" developmentDependency="true" />
+  <package id="NuProj" version="0.11.14-beta" developmentDependency="true" />
 </packages>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NuProj" version="0.10.48-beta-gea4a31bbc5" developmentDependency="true" />
+</packages>

--- a/src/StreamJsonRpc.NuGet/StreamJsonRpc.NuGet.nuproj
+++ b/src/StreamJsonRpc.NuGet/StreamJsonRpc.NuGet.nuproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NuSpecTemplate>StreamJsonRpc.nuspec</NuSpecTemplate>
-    <NuProjPath>$(UserProfile)\.nuget\packages\NuProj\0.10.48-beta-gea4a31bbc5\tools\</NuProjPath>
+    <NuProjPath>..\..\packages\NuProj.0.10.48-beta-gea4a31bbc5\tools\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">

--- a/src/StreamJsonRpc.NuGet/StreamJsonRpc.NuGet.nuproj
+++ b/src/StreamJsonRpc.NuGet/StreamJsonRpc.NuGet.nuproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NuSpecTemplate>StreamJsonRpc.nuspec</NuSpecTemplate>
-    <NuProjPath>..\..\packages\NuProj.0.10.48-beta-gea4a31bbc5\tools\</NuProjPath>
+    <NuProjPath>..\..\packages\NuProj.0.11.14-beta\tools\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">

--- a/src/StreamJsonRpc.NuGet/project.json
+++ b/src/StreamJsonRpc.NuGet/project.json
@@ -15,7 +15,6 @@
       "version": "1.5.46",
       "suppressParent": "none"
     },
-    "NuProj": "0.10.48-beta-gea4a31bbc5",
     "ReadOnlySourceTree": {
       "version": "0.1.36-beta",
       "suppressParent": "none"


### PR DESCRIPTION
Per the doc updates to NuProj found here:
nuproj/nuproj@883121f
We don't need to run "nuget restore project.json" on the NuProj directory directly any more. Using a solution-level packages.config file solves it in a simpler way.

Yes, this does mean that each solution has a local copy of the NuProj package after restore completes, but that's not too bad. And at least for this repo, that means that "nuget restore" on the solution always just works. And that's valuable.