### PR TITLE
removed stack from exception message

### DIFF
--- a/src/StreamJsonRpc.Shared/JsonRpc.cs
+++ b/src/StreamJsonRpc.Shared/JsonRpc.cs
@@ -624,9 +624,8 @@ namespace StreamJsonRpc
                 exception = exception.InnerException;
             }
 
-            string message = $"{exception.Message}{Environment.NewLine}{exception.StackTrace}";
             var data = new { stack = exception.StackTrace, code = exception.HResult.ToString(CultureInfo.InvariantCulture) };
-            return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, message, data);
+            return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, exception.Message, data);
         }
 
         private async Task ReadAndHandleRequestsAsync()


### PR DESCRIPTION
Exception message contained message and stack in one string. Related to [bug 392869](https://devdiv.visualstudio.com/DevDiv/Connected%20Experience/_workitems?id=392869)