### PR TITLE
Fix Microbuild.NonShipping Duplicate Reference 

### DIFF
--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -26,13 +26,12 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Pipes" Version="4.0.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.34" PrivateAssets="all"/>
+    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" PrivateAssets="all"/>
     <PackageReference Include="Nerdbank.FullDuplexStream" Version="1.0.9" />
     <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MicroBuild.Nonshipping" Version="2.0.40" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\StreamJsonRpc\ReadBufferingStream.cs">


### PR DESCRIPTION
This additional line causes VS to complain regarding a duplicate package reference.