### PR TITLE
Remove use of C# dynamic to avoid bizarre crash

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -194,4 +194,22 @@ public class JsonRpcClientInteropTests : InteropTestBase
         });
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
     }
+
+    [Fact]
+    public async Task ErrorResponseOmitsDataObject()
+    {
+        var requestTask = this.clientRpc.InvokeAsync("SomeMethod");
+        var remoteReceivedMessage = await this.ReceiveAsync();
+        this.Send(new
+        {
+            jsonrpc = "2.0",
+            id = remoteReceivedMessage["id"],
+            error = new
+            {
+                code = -32000,
+                message = "Object reference not set to an instance of an object.",
+            }
+        });
+        await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
+    }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -148,4 +148,50 @@ public class JsonRpcClientInteropTests : InteropTestBase
             Assert.Equal("testSucceeded", stringResult);
         }
     }
+
+    [Fact]
+    public async Task ErrorResponseIncludesCallstack()
+    {
+        var requestTask = this.clientRpc.InvokeAsync("SomeMethod");
+        var remoteReceivedMessage = await this.ReceiveAsync();
+        var errorObject = new
+        {
+            jsonrpc = "2.0",
+            id = remoteReceivedMessage["id"],
+            error = new
+            {
+                code = -32000,
+                message = "Object reference not set to an instance of an object.",
+                data = new
+                {
+                    stack = "   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.GetProjectScope()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsCoreAsync>d__20.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsAsync>d__19.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindReferencesAsync>d__13.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetTagsForReferencedSymbolAsync>d__4.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsInCurrentProcessAsync>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsAsync>d__0.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.Remote.CodeAnalysisService.<GetDocumentHighlightsAsync>d__5.MoveNext()",
+                    code = "-2147467261"
+                }
+            }
+        };
+        this.Send(errorObject);
+        await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
+        Assert.Equal(errorObject.error.data.stack, ((RemoteInvocationException)requestTask.Exception.InnerException).RemoteStackTrace);
+    }
+
+    [Fact]
+    public async Task ErrorResponseOmitsFieldsInDataObject()
+    {
+        var requestTask = this.clientRpc.InvokeAsync("SomeMethod");
+        var remoteReceivedMessage = await this.ReceiveAsync();
+        this.Send(new
+        {
+            jsonrpc = "2.0",
+            id = remoteReceivedMessage["id"],
+            error = new
+            {
+                code = -32000,
+                message = "Object reference not set to an instance of an object.",
+                data = new
+                {
+                }
+            }
+        });
+        await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
+    }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -175,6 +175,58 @@ public class JsonRpcClientInteropTests : InteropTestBase
     }
 
     [Fact]
+    public async Task ErrorResponseIncludesCallstackAndNumericErrorCode()
+    {
+        var requestTask = this.clientRpc.InvokeAsync("SomeMethod");
+        var remoteReceivedMessage = await this.ReceiveAsync();
+        var errorObject = new
+        {
+            jsonrpc = "2.0",
+            id = remoteReceivedMessage["id"],
+            error = new
+            {
+                code = -32000,
+                message = "Object reference not set to an instance of an object.",
+                data = new
+                {
+                    stack = "   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.GetProjectScope()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsCoreAsync>d__20.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsAsync>d__19.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindReferencesAsync>d__13.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetTagsForReferencedSymbolAsync>d__4.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsInCurrentProcessAsync>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsAsync>d__0.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.Remote.CodeAnalysisService.<GetDocumentHighlightsAsync>d__5.MoveNext()",
+                    code = -2147467261
+                }
+            }
+        };
+        this.Send(errorObject);
+        await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
+        Assert.Equal(errorObject.error.data.stack, ((RemoteInvocationException)requestTask.Exception.InnerException).RemoteStackTrace);
+        Assert.Equal("-2147467261", ((RemoteInvocationException)requestTask.Exception.InnerException).RemoteErrorCode);
+    }
+
+    [Fact]
+    public async Task ErrorResponseUsesUnexpectedDataTypes()
+    {
+        var requestTask = this.clientRpc.InvokeAsync("SomeMethod");
+        var remoteReceivedMessage = await this.ReceiveAsync();
+        var errorObject = new
+        {
+            jsonrpc = "2.0",
+            id = remoteReceivedMessage["id"],
+            error = new
+            {
+                code = -32000,
+                message = "Object reference not set to an instance of an object.",
+                data = new
+                {
+                    stack = new { foo = 3 },
+                    code = new { bar = "-2147467261" },
+                }
+            }
+        };
+        this.Send(errorObject);
+        await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
+        Assert.Null(((RemoteInvocationException)requestTask.Exception.InnerException).RemoteStackTrace);
+        Assert.Null(((RemoteInvocationException)requestTask.Exception.InnerException).RemoteErrorCode);
+    }
+
+    [Fact]
     public async Task ErrorResponseOmitsFieldsInDataObject()
     {
         var requestTask = this.clientRpc.InvokeAsync("SomeMethod");

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -6,6 +6,8 @@
     <RootNamespace />
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsPackable>false</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 
     <!-- VS2017 Test Explorer test navigation and callstack links don't work with portable PDBs yet. -->
     <DebugType>Full</DebugType>

--- a/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
@@ -9,6 +9,16 @@ namespace StreamJsonRpc
     [JsonObject(MemberSerialization.OptIn)]
     internal sealed class JsonRpcError
     {
+        /// <summary>
+        /// The name of the error object's "data.stack" field within the data object.
+        /// </summary>
+        private const string DataStackFieldName = "stack";
+
+        /// <summary>
+        /// The name of the error object's "data.code" field within the data object.
+        /// </summary>
+        private const string DataCodeFieldName = "code";
+
         internal JsonRpcError(int code, string message)
             : this(code, message, data: null)
         {
@@ -22,9 +32,9 @@ namespace StreamJsonRpc
             this.Data = data;
         }
 
-        public string ErrorStack => this.Data?["stack"]?.Type == JTokenType.String ? this.Data.Value<string>("stack") : null;
+        public string ErrorStack => this.Data?[DataStackFieldName]?.Type == JTokenType.String ? this.Data.Value<string>(DataStackFieldName) : null;
 
-        public string ErrorCode => this.Data?["code"]?.Type == JTokenType.String || this.Data?["code"]?.Type == JTokenType.Integer ? this.Data.Value<string>("code") : null;
+        public string ErrorCode => this.Data?[DataCodeFieldName]?.Type == JTokenType.String || this.Data?[DataCodeFieldName]?.Type == JTokenType.Integer ? this.Data.Value<string>(DataCodeFieldName) : null;
 
         [JsonProperty("code", Required = Required.Always)]
         internal int Code { get; private set; }

--- a/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
@@ -4,6 +4,7 @@
 namespace StreamJsonRpc
 {
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     [JsonObject(MemberSerialization.OptIn)]
     internal sealed class JsonRpcError
@@ -14,16 +15,16 @@ namespace StreamJsonRpc
         }
 
         [JsonConstructor]
-        internal JsonRpcError(int code, string message, dynamic data)
+        internal JsonRpcError(int code, string message, JObject data)
         {
             this.Code = code;
             this.Message = message;
             this.Data = data;
         }
 
-        public string ErrorStack => this.Data?.stack;
+        public string ErrorStack => this.Data?.Value<string>("stack");
 
-        public string ErrorCode => this.Data?.code;
+        public string ErrorCode => this.Data?.Value<string>("code");
 
         [JsonProperty("code", Required = Required.Always)]
         internal int Code { get; private set; }
@@ -32,6 +33,6 @@ namespace StreamJsonRpc
         internal string Message { get; private set; }
 
         [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
-        internal dynamic Data { get; private set; }
+        internal JObject Data { get; private set; }
     }
 }

--- a/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcError.cs
@@ -22,9 +22,9 @@ namespace StreamJsonRpc
             this.Data = data;
         }
 
-        public string ErrorStack => this.Data?.Value<string>("stack");
+        public string ErrorStack => this.Data?["stack"]?.Type == JTokenType.String ? this.Data.Value<string>("stack") : null;
 
-        public string ErrorCode => this.Data?.Value<string>("code");
+        public string ErrorCode => this.Data?["code"]?.Type == JTokenType.String || this.Data?["code"]?.Type == JTokenType.Integer ? this.Data.Value<string>("code") : null;
 
         [JsonProperty("code", Required = Required.Always)]
         internal int Code { get; private set; }

--- a/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
@@ -94,7 +94,7 @@ namespace StreamJsonRpc
             return CreateError(id, (int)error, message);
         }
 
-        public static JsonRpcMessage CreateError(JToken id, JsonRpcErrorCode error, string message, object data)
+        public static JsonRpcMessage CreateError(JToken id, JsonRpcErrorCode error, string message, JObject data)
         {
             return CreateError(id, (int)error, message, data);
         }
@@ -104,7 +104,7 @@ namespace StreamJsonRpc
             return CreateError(id, error, message, data: null);
         }
 
-        public static JsonRpcMessage CreateError(JToken id, int error, string message, object data)
+        public static JsonRpcMessage CreateError(JToken id, int error, string message, JObject data)
         {
             return new JsonRpcMessage()
             {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -736,7 +736,7 @@ namespace StreamJsonRpc
             }
 
             var data = new { stack = exception.StackTrace, code = exception.HResult.ToString(CultureInfo.InvariantCulture) };
-            return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, exception.Message, data);
+            return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, exception.Message, JObject.FromObject(data, DefaultJsonSerializer));
         }
 
         private async Task<JsonRpcMessage> DispatchIncomingRequestAsync(JsonRpcMessage request, JsonSerializer jsonSerializer)

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Net.Http" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">


### PR DESCRIPTION
Fixes #44 (although we haven't figured out why C# dynamic fails sometimes).

This removes the last use of `dynamic` from the library.