### PR TITLE
Update StyleCop package and fix up new warnings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.25" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.35" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -165,9 +165,9 @@ public class JsonRpcClientInteropTests : InteropTestBase
                 data = new
                 {
                     stack = "   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.GetProjectScope()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsCoreAsync>d__20.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsAsync>d__19.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindReferencesAsync>d__13.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetTagsForReferencedSymbolAsync>d__4.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsInCurrentProcessAsync>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsAsync>d__0.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.Remote.CodeAnalysisService.<GetDocumentHighlightsAsync>d__5.MoveNext()",
-                    code = "-2147467261"
-                }
-            }
+                    code = "-2147467261",
+                },
+            },
         };
         this.Send(errorObject);
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
@@ -190,9 +190,9 @@ public class JsonRpcClientInteropTests : InteropTestBase
                 data = new
                 {
                     stack = "   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.GetProjectScope()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsCoreAsync>d__20.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<DetermineAllSymbolsAsync>d__19.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__10.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindReferencesAsync>d__13.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetTagsForReferencedSymbolAsync>d__4.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsInCurrentProcessAsync>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.DocumentHighlighting.AbstractDocumentHighlightsService.<GetDocumentHighlightsAsync>d__0.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Microsoft.CodeAnalysis.Remote.CodeAnalysisService.<GetDocumentHighlightsAsync>d__5.MoveNext()",
-                    code = -2147467261
-                }
-            }
+                    code = -2147467261,
+                },
+            },
         };
         this.Send(errorObject);
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
@@ -217,8 +217,8 @@ public class JsonRpcClientInteropTests : InteropTestBase
                 {
                     stack = new { foo = 3 },
                     code = new { bar = "-2147467261" },
-                }
-            }
+                },
+            },
         };
         this.Send(errorObject);
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
@@ -241,8 +241,8 @@ public class JsonRpcClientInteropTests : InteropTestBase
                 message = "Object reference not set to an instance of an object.",
                 data = new
                 {
-                }
-            }
+                },
+            },
         });
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
     }
@@ -260,7 +260,7 @@ public class JsonRpcClientInteropTests : InteropTestBase
             {
                 code = -32000,
                 message = "Object reference not set to an instance of an object.",
-            }
+            },
         });
         await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -150,7 +150,9 @@ public class JsonRpcTests : TestBase
     [Fact]
     public async Task CanPassExceptionFromServer()
     {
+#pragma warning disable SA1139 // Use literal suffix notation instead of casting
         const int COR_E_UNAUTHORIZEDACCESS = unchecked((int)0x80070005);
+#pragma warning restore SA1139 // Use literal suffix notation instead of casting
         RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.MethodThatThrowsUnauthorizedAccessException)));
         Assert.NotNull(exception.RemoteStackTrace);
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS.ToString(CultureInfo.InvariantCulture), exception.RemoteErrorCode);

--- a/src/StreamJsonRpc/DataContracts/JsonRpcErrorCode.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcErrorCode.cs
@@ -38,6 +38,6 @@ namespace StreamJsonRpc
         /// <summary>
         /// Internal JSON-RPC error.
         /// </summary>
-        InternalError = -32603
+        InternalError = -32603,
     }
 }

--- a/src/StreamJsonRpc/EventArgs/DisconnectedReason.cs
+++ b/src/StreamJsonRpc/EventArgs/DisconnectedReason.cs
@@ -26,6 +26,6 @@ namespace StreamJsonRpc
         /// <summary>
         /// The stream was disposed.
         /// </summary>
-        Disposed
+        Disposed,
     }
 }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -293,7 +293,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="Result">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="argument">Method argument, must be serializable to JSON.</param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
@@ -311,17 +311,17 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
-        public Task<Result> InvokeAsync<Result>(string targetName, object argument)
+        public Task<TResult> InvokeAsync<TResult>(string targetName, object argument)
         {
             var arguments = new object[] { argument };
 
-            return this.InvokeWithCancellationAsync<Result>(targetName, arguments, CancellationToken.None);
+            return this.InvokeWithCancellationAsync<TResult>(targetName, arguments, CancellationToken.None);
         }
 
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="Result">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
@@ -339,20 +339,20 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
-        public Task<Result> InvokeAsync<Result>(string targetName, params object[] arguments)
+        public Task<TResult> InvokeAsync<TResult>(string targetName, params object[] arguments)
         {
             // If somebody calls InvokeInternal<T>(id, "method", null), the null is not passed as an item in the array.
             // Instead, the compiler thinks that the null is the array itself and it'll pass null directly.
             // To account for this case, we check for null below.
             arguments = arguments ?? new object[] { null };
 
-            return this.InvokeWithCancellationAsync<Result>(targetName, arguments, CancellationToken.None);
+            return this.InvokeWithCancellationAsync<TResult>(targetName, arguments, CancellationToken.None);
         }
 
         /// <summary>
         /// Invoke a method on the server and get back the result.  The parameter is passed as an object.
         /// </summary>
-        /// <typeparam name="Result">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="argument">Method argument, must be serializable to JSON.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
@@ -371,12 +371,12 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
-        public Task<Result> InvokeWithParameterObjectAsync<Result>(string targetName, object argument = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object argument = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // If argument is null, this indicates that the method does not take any parameters.
             object[] argumentToPass = argument == null ? null : new object[] { argument };
             int id = Interlocked.Increment(ref this.nextId);
-            return this.InvokeCoreAsync<Result>(id, targetName, argumentToPass, cancellationToken, isParameterObject: true);
+            return this.InvokeCoreAsync<TResult>(id, targetName, argumentToPass, cancellationToken, isParameterObject: true);
         }
 
         /// <summary>
@@ -410,7 +410,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="Result">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
@@ -431,10 +431,10 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
-        public Task<Result> InvokeWithCancellationAsync<Result>(string targetName, IReadOnlyList<object> arguments = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object> arguments = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             int id = Interlocked.Increment(ref this.nextId);
-            return this.InvokeCoreAsync<Result>(id, targetName, arguments, cancellationToken);
+            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken);
         }
 
         /// <summary>
@@ -523,22 +523,22 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invokes the specified RPC method
         /// </summary>
-        /// <typeparam name="ReturnType">RPC method return type</typeparam>
+        /// <typeparam name="TResult">RPC method return type</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>
         /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
-        protected virtual Task<ReturnType> InvokeCoreAsync<ReturnType>(int? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
+        protected virtual Task<TResult> InvokeCoreAsync<TResult>(int? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            return this.InvokeCoreAsync<ReturnType>(id, targetName, arguments, cancellationToken, isParameterObject: false);
+            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken, isParameterObject: false);
         }
 
         /// <summary>
         /// Invokes the specified RPC method
         /// </summary>
-        /// <typeparam name="ReturnType">RPC method return type</typeparam>
+        /// <typeparam name="TResult">RPC method return type</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>
@@ -546,7 +546,7 @@ namespace StreamJsonRpc
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
-        protected virtual async Task<ReturnType> InvokeCoreAsync<ReturnType>(int? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken, bool isParameterObject)
+        protected virtual async Task<TResult> InvokeCoreAsync<TResult>(int? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken, bool isParameterObject)
         {
             Requires.NotNullOrEmpty(targetName, nameof(targetName));
 
@@ -581,11 +581,11 @@ namespace StreamJsonRpc
                 if (id == null)
                 {
                     await this.TransmitAsync(request, cts.Token).ConfigureAwait(false);
-                    return default(ReturnType);
+                    return default(TResult);
                 }
 
                 Verify.Operation(this.readLinesTask != null, Resources.InvalidBeforeListenHasStarted);
-                var tcs = new TaskCompletionSource<ReturnType>();
+                var tcs = new TaskCompletionSource<TResult>();
                 Action<JsonRpcMessage> dispatcher = (response) =>
                 {
                     lock (this.dispatcherMapLock)
@@ -605,7 +605,7 @@ namespace StreamJsonRpc
                         }
                         else
                         {
-                            tcs.TrySetResult(response.GetResult<ReturnType>(this.JsonSerializer));
+                            tcs.TrySetResult(response.GetResult<TResult>(this.JsonSerializer));
                         }
                     }
                     catch (Exception ex)
@@ -890,8 +890,8 @@ namespace StreamJsonRpc
                     {
                         var e = new JsonRpcDisconnectedEventArgs(
                             string.Format(CultureInfo.CurrentCulture, Resources.ReadingJsonRpcStreamFailed, exception.GetType().Name, exception.Message),
-                                                                 DisconnectedReason.StreamError,
-                                                                 exception);
+                            DisconnectedReason.StreamError,
+                            exception);
 
                         // Fatal error. Raise disconnected event.
                         this.OnJsonRpcDisconnected(e);
@@ -990,8 +990,8 @@ namespace StreamJsonRpc
                     {
                         var e = new JsonRpcDisconnectedEventArgs(
                             string.Format(CultureInfo.CurrentCulture, Resources.ErrorWritingJsonRpcResult, exception.GetType().Name, exception.Message),
-                                                                    DisconnectedReason.StreamError,
-                                                                    exception);
+                            DisconnectedReason.StreamError,
+                            exception);
 
                         // Fatal error. Raise disconnected event.
                         this.OnJsonRpcDisconnected(e);

--- a/src/StreamJsonRpc/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Shipped.txt
@@ -27,9 +27,9 @@ StreamJsonRpc.JsonRpc.Dispose() -> void
 StreamJsonRpc.JsonRpc.Encoding.get -> System.Text.Encoding
 StreamJsonRpc.JsonRpc.Encoding.set -> void
 StreamJsonRpc.JsonRpc.InvokeAsync(string targetName, params object[] arguments) -> System.Threading.Tasks.Task
-StreamJsonRpc.JsonRpc.InvokeAsync<Result>(string targetName, params object[] arguments) -> System.Threading.Tasks.Task<Result>
+StreamJsonRpc.JsonRpc.InvokeAsync<TResult>(string targetName, params object[] arguments) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<Result>(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Result>
+StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.JsonRpc(StreamJsonRpc.DelimitedMessageHandler messageHandler, object target = null) -> void
 StreamJsonRpc.JsonRpc.JsonRpc(System.IO.Stream sendingStream, System.IO.Stream receivingStream, object target = null) -> void
 StreamJsonRpc.JsonRpc.JsonSerializer.get -> Newtonsoft.Json.JsonSerializer
@@ -67,13 +67,13 @@ static StreamJsonRpc.JsonRpc.Attach(System.IO.Stream sendingStream, System.IO.St
 static StreamJsonRpc.JsonRpc.Attach(System.IO.Stream stream, object target = null) -> StreamJsonRpc.JsonRpc
 virtual StreamJsonRpc.DelimitedMessageHandler.Dispose(bool disposing) -> void
 virtual StreamJsonRpc.JsonRpc.Dispose(bool disposing) -> void
-virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<ReturnType>(int? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<ReturnType>
+virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(int? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.NotifyAsync(string targetName, object argument) -> System.Threading.Tasks.Task
 StreamJsonRpc.JsonRpc.InvokeAsync(string targetName, object argument) -> System.Threading.Tasks.Task
-StreamJsonRpc.JsonRpc.InvokeAsync<Result>(string targetName, object argument) -> System.Threading.Tasks.Task<Result>
-StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync<Result>(string targetName, object argument = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Result>
+StreamJsonRpc.JsonRpc.InvokeAsync<TResult>(string targetName, object argument) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync<TResult>(string targetName, object argument = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string targetName, object argument = null) -> System.Threading.Tasks.Task
-virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<ReturnType>(int? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<ReturnType>
+virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(int? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute(string name) -> void
 StreamJsonRpc.JsonRpcMethodAttribute.Name.get -> string


### PR DESCRIPTION
Note this includes changes to PublicAPI.Shipped.txt but the renaming a generic type parameter is *not* a breaking change.