### PR TITLE
Add support for individual RPC method registration

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcMethodAttributeTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMethodAttributeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
 using Xunit;
 using Xunit.Abstractions;
@@ -85,17 +86,17 @@ public class JsonRpcMethodAttributeTests : TestBase
     [Fact]
     public async Task NotifyAsync_OverrideMethodNameAttribute()
     {
-        await this.clientRpc.NotifyAsync("base/NotifyVirtualMethodOverride");
+        await this.clientRpc.NotifyAsync("base/NotifyVirtualMethodOverride").WithCancellation(this.TimeoutToken);
 
-        Assert.Equal("child NotifyVirtualMethodOverride", await this.server.NotificationReceived);
+        Assert.Equal("child NotifyVirtualMethodOverride", await this.server.NotificationReceived.WithCancellation(this.TimeoutToken));
     }
 
     [Fact]
     public async Task NotifyAsync_NoOverrideMethodNameAttribute()
     {
-        await this.clientRpc.NotifyAsync("base/NotifyVirtualMethodNoOverride");
+        await this.clientRpc.NotifyAsync("base/NotifyVirtualMethodNoOverride").WithCancellation(this.TimeoutToken);
 
-        Assert.Equal("child NotifyVirtualMethodNoOverride", await this.server.NotificationReceived);
+        Assert.Equal("child NotifyVirtualMethodNoOverride", await this.server.NotificationReceived.WithCancellation(this.TimeoutToken));
     }
 
     [Fact]

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -30,6 +30,8 @@ namespace StreamJsonRpc
         private static readonly object[] EmptyObjectArray = new object[0];
         private static readonly JsonSerializer DefaultJsonSerializer = JsonSerializer.CreateDefault();
 
+        private readonly object syncObject = new object();
+
         /// <summary>
         /// The object to lock when accessing the <see cref="resultDispatcherMap"/> or <see cref="inboundCancellationSources"/> objects.
         /// </summary>
@@ -66,7 +68,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// A collection of target objects and their map of clr method to <see cref="JsonRpcMethodAttribute"/> values.
         /// </summary>
-        private readonly List<Tuple<object, ReadOnlyDictionary<string, string>>> targetRequestMethodToClrMethodMap = new List<Tuple<object, ReadOnlyDictionary<string, string>>>();
+        private readonly Dictionary<string, List<MethodTarget>> targetRequestMethodToClrMethodMap = new Dictionary<string, List<MethodTarget>>(StringComparer.Ordinal);
 
         private readonly CancellationTokenSource disposeCts = new CancellationTokenSource();
 
@@ -234,13 +236,83 @@ namespace StreamJsonRpc
         /// should not inherit from each other and are invoked in the order which they are added.
         /// </summary>
         /// <param name="target">Target to invoke when incoming messages are received.</param>
-        /// <remarks>This method must be called before JsonRpc starts listening for messages.</remarks>
         public void AddLocalRpcTarget(object target)
         {
             Requires.NotNull(target, nameof(target));
             Verify.Operation(!this.startedListening, Resources.AttachTargetAfterStartListeningError);
 
-            this.targetRequestMethodToClrMethodMap.Add(Tuple.Create(target, new ReadOnlyDictionary<string, string>(GetRequestMethodToClrMethodMap(target))));
+            var mapping = GetRequestMethodToClrMethodMap(target);
+            lock (this.syncObject)
+            {
+                foreach (var item in mapping)
+                {
+                    if (this.targetRequestMethodToClrMethodMap.TryGetValue(item.Key, out var existingList))
+                    {
+                        // Only add methods that do not have equivalent signatures to what we already have.
+                        foreach (var newMethod in item.Value)
+                        {
+                            if (!existingList.Any(e => e.Signature.Equals(newMethod.Signature)))
+                            {
+                                existingList.Add(newMethod);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        this.targetRequestMethodToClrMethodMap.Add(item.Key, item.Value);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a handler for an RPC method with a given name.
+        /// </summary>
+        /// <param name="rpcMethodName">
+        /// The name of the method as it is identified by the incoming JSON-RPC message.
+        /// It need not match the name of the CLR method/delegate given here.
+        /// </param>
+        /// <param name="handler">
+        /// The method or delegate to invoke when a matching RPC message arrives.
+        /// This method may accept parameters from the incoming JSON-RPC message.
+        /// </param>
+        public void AddLocalRpcMethod(string rpcMethodName, Delegate handler)
+        {
+            this.AddLocalRpcMethod(rpcMethodName, handler.GetMethodInfo(), handler.Target);
+        }
+
+        /// <summary>
+        /// Adds a handler for an RPC method with a given name.
+        /// </summary>
+        /// <param name="rpcMethodName">
+        /// The name of the method as it is identified by the incoming JSON-RPC message.
+        /// It need not match the name of the CLR method/delegate given here.
+        /// </param>
+        /// <param name="handler">
+        /// The method or delegate to invoke when a matching RPC message arrives.
+        /// This method may accept parameters from the incoming JSON-RPC message.
+        /// </param>
+        /// <param name="target">An instance of the type that defines <paramref name="handler"/> which should handle the invocation.</param>
+        public void AddLocalRpcMethod(string rpcMethodName, MethodInfo handler, object target)
+        {
+            Verify.Operation(!this.startedListening, Resources.AttachTargetAfterStartListeningError);
+            lock (this.syncObject)
+            {
+                var methodTarget = new MethodTarget(handler, target);
+                if (this.targetRequestMethodToClrMethodMap.TryGetValue(rpcMethodName, out var existingList))
+                {
+                    if (existingList.Any(m => m.Signature.Equals(methodTarget.Signature)))
+                    {
+                        throw new InvalidOperationException(Resources.ConflictMethodSignatureAlreadyRegistered);
+                    }
+
+                    existingList.Add(methodTarget);
+                }
+                else
+                {
+                    this.targetRequestMethodToClrMethodMap.Add(rpcMethodName, new List<MethodTarget> { methodTarget });
+                }
+            }
         }
 
         /// <summary>
@@ -652,12 +724,13 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="target">Object to reflect over and analyze its methods.</param>
         /// <returns>Dictionary which maps a request method name to its clr method name.</returns>
-        private static IDictionary<string, string> GetRequestMethodToClrMethodMap(object target)
+        private static Dictionary<string, List<MethodTarget>> GetRequestMethodToClrMethodMap(object target)
         {
             Requires.NotNull(target, nameof(target));
 
             var clrMethodToRequestMethodMap = new Dictionary<string, string>(StringComparer.Ordinal);
-            var requestMethodToClrMethodMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            var requestMethodToClrMethodNameMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            var requestMethodToDelegateMap = new Dictionary<string, List<MethodTarget>>(StringComparer.Ordinal);
             var candidateAliases = new Dictionary<string, string>(StringComparer.Ordinal);
 
             for (TypeInfo t = target.GetType().GetTypeInfo(); t != null && t != typeof(object).GetTypeInfo(); t = t.BaseType?.GetTypeInfo())
@@ -666,6 +739,12 @@ namespace StreamJsonRpc
                 {
                     var attribute = (JsonRpcMethodAttribute)method.GetCustomAttribute(typeof(JsonRpcMethodAttribute));
                     var requestName = attribute?.Name ?? method.Name;
+
+                    if (!requestMethodToDelegateMap.TryGetValue(requestName, out var methodTargetList))
+                    {
+                        methodTargetList = new List<MethodTarget>();
+                        requestMethodToDelegateMap.Add(requestName, methodTargetList);
+                    }
 
                     // Verify that all overloads of this CLR method also claim the same request method name.
                     if (clrMethodToRequestMethodMap.TryGetValue(method.Name, out string previousRequestNameUse))
@@ -681,7 +760,7 @@ namespace StreamJsonRpc
                     }
 
                     // Verify that all CLR methods that want to use this request method name are overloads of each other.
-                    if (requestMethodToClrMethodMap.TryGetValue(requestName, out string previousClrNameUse))
+                    if (requestMethodToClrMethodNameMap.TryGetValue(requestName, out string previousClrNameUse))
                     {
                         if (!string.Equals(method.Name, previousClrNameUse, StringComparison.Ordinal))
                         {
@@ -690,8 +769,17 @@ namespace StreamJsonRpc
                     }
                     else
                     {
-                        requestMethodToClrMethodMap.Add(requestName, method.Name);
+                        requestMethodToClrMethodNameMap.Add(requestName, method.Name);
                     }
+
+                    // Skip this method if its signature matches one from a derived type we have already scanned.
+                    MethodTarget methodTarget = new MethodTarget(method, target);
+                    if (methodTargetList.Contains(methodTarget))
+                    {
+                        continue;
+                    }
+
+                    methodTargetList.Add(methodTarget);
 
                     // If no explicit attribute has been applied, and the method ends with Async,
                     // register a request method name that does not include Async as well.
@@ -710,13 +798,14 @@ namespace StreamJsonRpc
             // if it would not introduce any collisions.
             foreach (var candidateAlias in candidateAliases)
             {
-                if (!requestMethodToClrMethodMap.ContainsKey(candidateAlias.Key))
+                if (!requestMethodToClrMethodNameMap.ContainsKey(candidateAlias.Key))
                 {
-                    requestMethodToClrMethodMap.Add(candidateAlias.Key, candidateAlias.Value);
+                    requestMethodToClrMethodNameMap.Add(candidateAlias.Key, candidateAlias.Value);
+                    requestMethodToDelegateMap[candidateAlias.Key] = requestMethodToDelegateMap[candidateAlias.Value].ToList();
                 }
             }
 
-            return requestMethodToClrMethodMap;
+            return requestMethodToDelegateMap;
         }
 
         private static RemoteRpcException CreateExceptionFromRpcError(JsonRpcMessage response, string targetName)
@@ -760,26 +849,29 @@ namespace StreamJsonRpc
             Requires.NotNull(request, nameof(request));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
 
-            if (this.targetRequestMethodToClrMethodMap.Count == 0)
-            {
-                string message = string.Format(CultureInfo.CurrentCulture, Resources.DroppingRequestDueToNoTargetObject, request.Method);
-                return JsonRpcMessage.CreateError(request.Id, JsonRpcErrorCode.NoCallbackObject, message);
-            }
-
             bool ctsAdded = false;
             try
             {
                 TargetMethod targetMethod = null;
-                foreach (var targetMap in this.targetRequestMethodToClrMethodMap)
+                lock (this.syncObject)
                 {
-                    targetMethod = new TargetMethod(request, targetMap.Item1, jsonSerializer, targetMap.Item2);
-                    if (targetMethod.IsFound)
+                    if (this.targetRequestMethodToClrMethodMap.Count == 0)
                     {
-                        break;
+                        string message = string.Format(CultureInfo.CurrentCulture, Resources.DroppingRequestDueToNoTargetObject, request.Method);
+                        return JsonRpcMessage.CreateError(request.Id, JsonRpcErrorCode.NoCallbackObject, message);
+                    }
+
+                    if (this.targetRequestMethodToClrMethodMap.TryGetValue(request.Method, out var candidateTargets))
+                    {
+                        targetMethod = new TargetMethod(request, jsonSerializer, candidateTargets);
                     }
                 }
 
-                if (targetMethod == null || !targetMethod.IsFound)
+                if (targetMethod == null)
+                {
+                    return JsonRpcMessage.CreateError(request.Id, JsonRpcErrorCode.MethodNotFound, string.Format(CultureInfo.CurrentCulture, Resources.RpcMethodNameNotFound, request.Method));
+                }
+                else if (!targetMethod.IsFound)
                 {
                     return JsonRpcMessage.CreateError(request.Id, JsonRpcErrorCode.MethodNotFound, targetMethod.LookupErrorMessage);
                 }
@@ -1122,6 +1214,38 @@ namespace StreamJsonRpc
         {
             string json = message.ToJson(this.JsonSerializerFormatting, this.MessageJsonSerializerSettings);
             return this.MessageHandler.WriteAsync(json, cancellationToken);
+        }
+
+        internal struct MethodTarget : IEquatable<MethodTarget>
+        {
+            public MethodTarget(MethodInfo method, object target)
+            {
+                Requires.NotNull(method, nameof(method));
+
+                this.Signature = new MethodSignature(method);
+                this.Target = target;
+            }
+
+            public MethodSignature Signature { get; }
+
+            public object Target { get; }
+
+            public override bool Equals(object obj)
+            {
+                return obj is MethodTarget other
+                    && this.Equals(other);
+            }
+
+            public bool Equals(MethodTarget other)
+            {
+                return this.Signature.Equals(other.Signature)
+                    && object.Equals(this.Target, other.Target);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.Signature.GetHashCode() + (this.Target?.GetHashCode() ?? 0);
+            }
         }
 
         private class OutstandingCallData

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} má parametry ref nebo out, což se nepodporuje.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} není veřejné.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">Název metody {0} má jinak velká a malá písmena než požadovaný objekt {1}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">Parametry {0} (vyjma jakýchkoli objektů CancellationToken): {1}, ale žádost poskytuje {2}.</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">Parametry {0} nejsou kompatibilní s žádostí: {1}.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Nalezena víc než jedna cílová metoda: {0}</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Metody .NET {0} i {1} se nemůžou současně mapovat ke stejnému názvu metody žádosti: {2}.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -34,16 +34,6 @@
           <target state="translated">"{0}" weist ref- oder out-Parameter auf. Dies wird nicht unterstützt</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">"{0}" ist nicht öffentlich.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">Der Methodenname "{0}" weist eine andere Groß-/Kleinschreibung als das angeforderte Objekt "{1}" auf.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0}-Parameter (ausschließlich CancellationToken): {1}, die Anforderung stellt aber {2} bereit.</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} Parameter sind nicht kompatibel mit der Anforderung: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Es wurden mehrere Zielmethoden gefunden: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Die .NET-Methoden "{0}" und "{1}" können nicht beide dem gleichen Anforderungsmethodennamen zugeordnet werden: "{2}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} tiene los parámetros out o ref no admitidos</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} no es público</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">En el nombre de método '{0}' se usan las mayúsculas y minúsculas de manera diferente a como se solicita en '{1}'</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} parámetro(s) (se excluirá cualquier CancellationToken): {1}, pero la solicitud suministra {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">Los parámetros {0} no son compatibles con la solicitud: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Se ha encontrado más de un método de destino: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Los métodos .NET "{0}" y "{1}" no pueden asignar ambos el mismo nombre de método de solicitud: "{2}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} a un ou des paramètres ref ou out non pris en charge</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} n’est pas public</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">Le nom de la méthode '{0}' a une casse différente du '{1}' demandé</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} paramètre(s) (CancellationToken exclu) : {1}, mais la demande fournit {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} paramètres ne sont pas compatibles avec la demande : {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Plusieurs méthodes cibles trouvées : {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Les méthodes .NET '{0}' et '{1}' ne peuvent pas mapper au même nom de méthode de demande : '{2}'.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} contiene parametri ref o out e questo comportamento non è supportato</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} non è pubblico</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">La combinazione di maiuscole/minuscole nel nome del metodo '{0}' è diversa da quella del metodo richiesto '{1}'</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">I parametri di {0} (escluso eventuali elementi CancellationToken) sono {1}, ma la richiesta ne fornisce {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">I parametri di {0} non sono compatibili con la richiesta: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">È stato trovato più di un metodo di destinazione: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Non è possibile eseguire il mapping dei metodi .NET '{0}' e '{1}' allo stesso nome di metodo di richiesta: '{2}'.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} は ref または out パラメーターを含んでいますが、サポートされていません</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} はパブリックではありません</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">'{0}' メソッド名は要求された '{1}' とは大文字と小文字が異なります</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} パラメーター (CancellationToken は除外します): {1}、しかし要求は {2} を提供します</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} パラメーターは、要求と互換性がありません: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">複数のターゲット メソッドが見つかりました: {0}。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">.NET メソッド '{0}' と '{1}' を両方とも同じ要求メソッド名 '{2}' にマッピングすることはできません。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0}에 ref 또는 지원되지 않는 출력 매개 변수가 있습니다.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0}이(가) public이 아닙니다.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">'{0}' 메서드 이름에 요청된 '{1}'과(와) 다른 대/소문자가 있습니다.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} 매개 변수(CancellationToken 제외)는 {1}이지만 요청에서는 {2}이(가) 제공됩니다.</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} 매개 변수가 {1} 요청과 호환되지 않습니다.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">둘 이상의 대상 메서드 발견: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">.NET 메서드 '{0}' 및 '{1}'이(가) 둘 다 동일한 요청 메서드 이름에 매핑될 수 없습니다. '{2}'.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -34,16 +34,6 @@
           <target state="translated">Metoda {0} ma parametry ref lub out, co nie jest obsługiwane</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">Metoda {0} nie jest publiczna</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">Nazwa metody „{0}” ma inną wielkość liter niż żądana nazwa „{1}”</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">Metoda {0} ma liczbę parametrów {1} (nie licząc wszelkich tokenów CancellationToken), ale żądanie dostarcza {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">Parametry metody {0} nie są zgodne z żądaniem: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Znaleziono więcej niż jedną metodę docelową: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Metody programu .NET „{0}” i „{1}” nie mogą mieć jednocześnie mapowania na tę samą nazwę metody żądania: „{2}”.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} tem os parâmetros ref ou out, que não têm suporte</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} não é público</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">O nome do método '{0}' tem maiúsculas/minúsculas diferentes do solicitado '{1}'</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} parâmetro(s) (excluindo qualquer CancellationToken): {1}, mas a solicitação fornece {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">Parâmetros {0} não são compatíveis com a solicitação: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Mais de um método de destino encontrado: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Os métodos .NET '{0}' e '{1}' não podem ser mapeados para o mesmo nome do método de solicitação: '{2}'.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} имеет параметры REF или OUT, что не поддерживается</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} не является открытым</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">Регистр имени метода "{0}" отличается от запрошенного "{1}"</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">Число параметров в {0} (исключая любые CancellationToken): {1}; в запросе же указано {2}.</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">Параметры {0} несовместимы с запросом: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Найдено более одного целевого метода: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">Методы .NET "{0}" и "{1}" не могут одновременно быть сопоставлены с одним и тем же именем метода запроса: "{2}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} desteklenmeyen ref veya out parametrelerine sahip</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} genel değil</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">'{0}' metot adı, istenen '{1}' metodundan farklı büyük-küçük harf kullanımına sahip</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} metodunun {1} parametresi var (İptal Belirteci’ni dışta tutarak), ancak istekte {2} parametre belirtildi</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} parametreleri istekle uyumlu değil: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">Birden fazla hedef metot bulundu: {0}.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">'{0}' ve '{1}' .NET metotlarının her ikisi de aynı istek metodu adıyla eşlenemez: '{2}'.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} 具有不受支持的 ref 或 out 参数</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} 不是公共的</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">“{0}”方法名具有与请求的“{1}”不同的事例</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} 参数（排除任何 CancellationToken）：{1}，但请求提供 {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} 个参数与请求 {1} 不兼容</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">找到多个目标方法 {0}。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">.NET 方法“{0}”和“{1}”不能映射到同一请求方法名“{2}”。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -34,16 +34,6 @@
           <target state="translated">{0} 有不支援的 ref 或 out 參數</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
         </trans-unit>
-        <trans-unit id="MethodIsNotPublic" translate="yes" xml:space="preserve">
-          <source>{0} is not public</source>
-          <target state="translated">{0} 不是公用的</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature.</note>
-        </trans-unit>
-        <trans-unit id="MethodNameCaseIsDifferent" translate="yes" xml:space="preserve">
-          <source>'{0}' method name has different case from requested '{1}'</source>
-          <target state="translated">'{0}' 方法名稱，其大小寫與所要求的 '{1}' 不同</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the requested method name.</note>
-        </trans-unit>
         <trans-unit id="MethodParameterCountDoesNotMatch" translate="yes" xml:space="preserve">
           <source>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</source>
           <target state="translated">{0} 個參數 (排除任何 CancellationToken): {1}，但要求提供 {2}</target>
@@ -53,11 +43,6 @@
           <source>{0} parameters are not compatible with the request: {1}</source>
           <target state="translated">{0} 參數與下列要求不相容: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method signature, {1} is the error message.</note>
-        </trans-unit>
-        <trans-unit id="MoreThanOneMethodFound" translate="yes" xml:space="preserve">
-          <source>More than one target method found: {0}.</source>
-          <target state="translated">找到多個目標方法: {0}。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">{0} is the list of method signatures.</note>
         </trans-unit>
         <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
           <source>Reached end of stream.</source>
@@ -160,6 +145,14 @@
           <source>.NET methods '{0}' and '{1}' cannot both map to the same request method name: '{2}'.</source>
           <target state="translated">.NET 方法 '{0}' 與 '{1}' 不得同時對應到同一個要求方法名稱: '{2}'。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the first method name, {1} is the second method name, {2} is the attribute property value.</note>
+        </trans-unit>
+        <trans-unit id="RpcMethodNameNotFound" translate="yes" xml:space="preserve">
+          <source>No method by the name '{0}' is found.</source>
+          <target state="new">No method by the name '{0}' is found.</target>
+        </trans-unit>
+        <trans-unit id="ConflictMethodSignatureAlreadyRegistered" translate="yes" xml:space="preserve">
+          <source>A method with the same name and equivalent parameters has already been registered.</source>
+          <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
         <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
           <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
+StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void

--- a/src/StreamJsonRpc/Reflection/MethodSignature.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignature.cs
@@ -64,6 +64,8 @@ namespace StreamJsonRpc
                 }
             }
 
+            // We intentionally omit equating the MethodInfo itself because we want to consider
+            // overrides to be equal across types in the type hierarchy.
             return true;
         }
 

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Reflection;
+    using Microsoft;
+
+    internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
+    {
+        public MethodSignatureAndTarget(MethodInfo method, object target)
+        {
+            Requires.NotNull(method, nameof(method));
+
+            this.Signature = new MethodSignature(method);
+            this.Target = target;
+        }
+
+        public MethodSignature Signature { get; }
+
+        public object Target { get; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MethodSignatureAndTarget other
+                && this.Equals(other);
+        }
+
+        public bool Equals(MethodSignatureAndTarget other)
+        {
+            return this.Signature.Equals(other.Signature)
+                && object.Equals(this.Target, other.Target);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Signature.GetHashCode() + (this.Target?.GetHashCode() ?? 0);
+        }
+    }
+}

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -5,6 +5,7 @@ namespace StreamJsonRpc
 {
     using System;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using Microsoft;
 
     internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
@@ -30,12 +31,12 @@ namespace StreamJsonRpc
         public bool Equals(MethodSignatureAndTarget other)
         {
             return this.Signature.Equals(other.Signature)
-                && object.Equals(this.Target, other.Target);
+                && object.ReferenceEquals(this.Target, other.Target);
         }
 
         public override int GetHashCode()
         {
-            return this.Signature.GetHashCode() + (this.Target?.GetHashCode() ?? 0);
+            return this.Signature.GetHashCode() + RuntimeHelpers.GetHashCode(this.Target);
         }
     }
 }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -23,42 +23,28 @@ namespace StreamJsonRpc
 
         internal TargetMethod(
             JsonRpcMessage request,
-            object target,
             JsonSerializer jsonSerializer,
-            IReadOnlyDictionary<string, string> requestMethodToClrMethodMap)
+            IEnumerable<JsonRpc.MethodTarget> candidateMethodTargets)
         {
             Requires.NotNull(request, nameof(request));
-            Requires.NotNull(target, nameof(target));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
-            Requires.NotNull(requestMethodToClrMethodMap, nameof(requestMethodToClrMethodMap));
+            Requires.NotNull(candidateMethodTargets, nameof(candidateMethodTargets));
 
             this.request = request;
-            this.target = target;
 
-            if (requestMethodToClrMethodMap.TryGetValue(request.Method, out string clrMethodName))
+            var targetMethods = new Dictionary<JsonRpc.MethodTarget, object[]>();
+            foreach (var method in candidateMethodTargets)
             {
-                var targetMethods = new Dictionary<MethodSignature, object[]>();
-                for (TypeInfo t = target.GetType().GetTypeInfo(); t != null; t = t.BaseType?.GetTypeInfo())
-                {
-                    foreach (MethodInfo method in t.GetDeclaredMethods(clrMethodName))
-                    {
-                        this.TryAddMethod(request, targetMethods, method, jsonSerializer, request.Method);
-                    }
-                }
+                this.TryAddMethod(request, targetMethods, method, jsonSerializer);
+            }
 
-                if (targetMethods.Count == 1)
-                {
-                    KeyValuePair<MethodSignature, object[]> methodWithParameters = targetMethods.First();
-                    this.method = methodWithParameters.Key.MethodInfo;
-                    this.parameters = methodWithParameters.Value;
-                    this.AcceptsCancellationToken = methodWithParameters.Key.HasCancellationTokenParameter;
-                }
-                else if (targetMethods.Count > 1)
-                {
-                    this.method = null;
-                    this.parameters = null;
-                    this.errorMessages.Add(string.Format(CultureInfo.CurrentCulture, Resources.MoreThanOneMethodFound, string.Join("; ", targetMethods.Keys)));
-                }
+            KeyValuePair<JsonRpc.MethodTarget, object[]> methodWithParameters = targetMethods.FirstOrDefault();
+            if (methodWithParameters.Key.Signature != null)
+            {
+                this.target = methodWithParameters.Key.Target;
+                this.method = methodWithParameters.Key.Signature.MethodInfo;
+                this.parameters = methodWithParameters.Value;
+                this.AcceptsCancellationToken = methodWithParameters.Key.Signature.HasCancellationTokenParameter;
             }
         }
 
@@ -75,7 +61,7 @@ namespace StreamJsonRpc
                     Resources.UnableToFindMethod,
                     this.request.Method,
                     this.request.ParameterCount,
-                    this.target.GetType().FullName,
+                    this.target?.GetType().FullName ?? "{no object}",
                     string.Join("; ", this.errorMessages));
             }
         }
@@ -109,12 +95,6 @@ namespace StreamJsonRpc
             Requires.NotNull(errors, nameof(errors));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
             Requires.NotNullOrEmpty(requestMethodName, nameof(requestMethodName));
-
-            if (!method.IsPublic)
-            {
-                errors.Add(string.Format(CultureInfo.CurrentCulture, Resources.MethodIsNotPublic, method));
-                return null;
-            }
 
             // ref and out parameters aren't supported.
             if (method.HasOutOrRefParameters)
@@ -175,23 +155,17 @@ namespace StreamJsonRpc
             }
         }
 
-        private bool TryAddMethod(JsonRpcMessage request, Dictionary<MethodSignature, object[]> targetMethods, MethodInfo method, JsonSerializer jsonSerializer, string requestMethodName)
+        private bool TryAddMethod(JsonRpcMessage request, Dictionary<JsonRpc.MethodTarget, object[]> targetMethods, JsonRpc.MethodTarget method, JsonSerializer jsonSerializer)
         {
             Requires.NotNull(request, nameof(request));
             Requires.NotNull(targetMethods, nameof(targetMethods));
-            Requires.NotNull(method, nameof(method));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
-            Requires.NotNullOrEmpty(requestMethodName, nameof(requestMethodName));
 
-            var methodSignature = new MethodSignature(method);
-            if (!targetMethods.ContainsKey(methodSignature))
+            object[] parameters = TryGetParameters(request, method.Signature, this.errorMessages, jsonSerializer, request.Method);
+            if (parameters != null)
             {
-                object[] parameters = TryGetParameters(request, methodSignature, this.errorMessages, jsonSerializer, requestMethodName);
-                if (parameters != null)
-                {
-                    targetMethods.Add(methodSignature, parameters);
-                    return true;
-                }
+                targetMethods.Add(method, parameters);
+                return true;
             }
 
             return false;

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -24,7 +24,7 @@ namespace StreamJsonRpc
         internal TargetMethod(
             JsonRpcMessage request,
             JsonSerializer jsonSerializer,
-            IEnumerable<JsonRpc.MethodTarget> candidateMethodTargets)
+            IEnumerable<MethodSignatureAndTarget> candidateMethodTargets)
         {
             Requires.NotNull(request, nameof(request));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
@@ -32,13 +32,13 @@ namespace StreamJsonRpc
 
             this.request = request;
 
-            var targetMethods = new Dictionary<JsonRpc.MethodTarget, object[]>();
+            var targetMethods = new Dictionary<MethodSignatureAndTarget, object[]>();
             foreach (var method in candidateMethodTargets)
             {
                 this.TryAddMethod(request, targetMethods, method, jsonSerializer);
             }
 
-            KeyValuePair<JsonRpc.MethodTarget, object[]> methodWithParameters = targetMethods.FirstOrDefault();
+            KeyValuePair<MethodSignatureAndTarget, object[]> methodWithParameters = targetMethods.FirstOrDefault();
             if (methodWithParameters.Key.Signature != null)
             {
                 this.target = methodWithParameters.Key.Target;
@@ -155,7 +155,7 @@ namespace StreamJsonRpc
             }
         }
 
-        private bool TryAddMethod(JsonRpcMessage request, Dictionary<JsonRpc.MethodTarget, object[]> targetMethods, JsonRpc.MethodTarget method, JsonSerializer jsonSerializer)
+        private bool TryAddMethod(JsonRpcMessage request, Dictionary<MethodSignatureAndTarget, object[]> targetMethods, MethodSignatureAndTarget method, JsonSerializer jsonSerializer)
         {
             Requires.NotNull(request, nameof(request));
             Requires.NotNull(targetMethods, nameof(targetMethods));

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -98,6 +98,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A method with the same name and equivalent parameters has already been registered..
+        /// </summary>
+        internal static string ConflictMethodSignatureAlreadyRegistered {
+            get {
+                return ResourceManager.GetString("ConflictMethodSignatureAlreadyRegistered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Got a request to execute &apos;{0}&apos; but have no callback object. Dropping the request..
         /// </summary>
         internal static string DroppingRequestDueToNoTargetObject {
@@ -188,24 +197,6 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not public.
-        /// </summary>
-        internal static string MethodIsNotPublic {
-            get {
-                return ResourceManager.GetString("MethodIsNotPublic", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method name has different case from requested &apos;{1}&apos;.
-        /// </summary>
-        internal static string MethodNameCaseIsDifferent {
-            get {
-                return ResourceManager.GetString("MethodNameCaseIsDifferent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}.
         /// </summary>
         internal static string MethodParameterCountDoesNotMatch {
@@ -220,15 +211,6 @@ namespace StreamJsonRpc {
         internal static string MethodParametersNotCompatible {
             get {
                 return ResourceManager.GetString("MethodParametersNotCompatible", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to More than one target method found: {0}..
-        /// </summary>
-        internal static string MoreThanOneMethodFound {
-            get {
-                return ResourceManager.GetString("MoreThanOneMethodFound", resourceCulture);
             }
         }
         
@@ -283,6 +265,15 @@ namespace StreamJsonRpc {
         internal static string ResponseIsNotError {
             get {
                 return ResourceManager.GetString("ResponseIsNotError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No method by the name &apos;{0}&apos; is found..
+        /// </summary>
+        internal static string RpcMethodNameNotFound {
+            get {
+                return ResourceManager.GetString("RpcMethodNameNotFound", resourceCulture);
             }
         }
         

--- a/src/StreamJsonRpc/Resources.cs.resx
+++ b/src/StreamJsonRpc/Resources.cs.resx
@@ -34,14 +34,6 @@
     <value>{0} má parametry ref nebo out, což se nepodporuje.</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} není veřejné.</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>Název metody {0} má jinak velká a malá písmena než požadovaný objekt {1}.</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>Parametry {0} (vyjma jakýchkoli objektů CancellationToken): {1}, ale žádost poskytuje {2}.</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>Parametry {0} nejsou kompatibilní s žádostí: {1}.</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Nalezena víc než jedna cílová metoda: {0}</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Bylo dosaženo konce streamu.</value>

--- a/src/StreamJsonRpc/Resources.de.resx
+++ b/src/StreamJsonRpc/Resources.de.resx
@@ -34,14 +34,6 @@
     <value>"{0}" weist ref- oder out-Parameter auf. Dies wird nicht unterstützt</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>"{0}" ist nicht öffentlich.</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>Der Methodenname "{0}" weist eine andere Groß-/Kleinschreibung als das angeforderte Objekt "{1}" auf.</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0}-Parameter (ausschließlich CancellationToken): {1}, die Anforderung stellt aber {2} bereit.</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} Parameter sind nicht kompatibel mit der Anforderung: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Es wurden mehrere Zielmethoden gefunden: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Das Ende des Datenstroms wurde erreicht.</value>

--- a/src/StreamJsonRpc/Resources.es.resx
+++ b/src/StreamJsonRpc/Resources.es.resx
@@ -34,14 +34,6 @@
     <value>{0} tiene los parámetros out o ref no admitidos</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} no es público</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>En el nombre de método '{0}' se usan las mayúsculas y minúsculas de manera diferente a como se solicita en '{1}'</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} parámetro(s) (se excluirá cualquier CancellationToken): {1}, pero la solicitud suministra {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>Los parámetros {0} no son compatibles con la solicitud: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Se ha encontrado más de un método de destino: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Se alcanzó el final de la secuencia.</value>

--- a/src/StreamJsonRpc/Resources.fr.resx
+++ b/src/StreamJsonRpc/Resources.fr.resx
@@ -34,14 +34,6 @@
     <value>{0} a un ou des paramètres ref ou out non pris en charge</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} n’est pas public</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>Le nom de la méthode '{0}' a une casse différente du '{1}' demandé</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} paramètre(s) (CancellationToken exclu) : {1}, mais la demande fournit {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} paramètres ne sont pas compatibles avec la demande : {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Plusieurs méthodes cibles trouvées : {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Fin de flux atteinte.</value>

--- a/src/StreamJsonRpc/Resources.it.resx
+++ b/src/StreamJsonRpc/Resources.it.resx
@@ -34,14 +34,6 @@
     <value>{0} contiene parametri ref o out e questo comportamento non è supportato</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} non è pubblico</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>La combinazione di maiuscole/minuscole nel nome del metodo '{0}' è diversa da quella del metodo richiesto '{1}'</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>I parametri di {0} (escluso eventuali elementi CancellationToken) sono {1}, ma la richiesta ne fornisce {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>I parametri di {0} non sono compatibili con la richiesta: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>È stato trovato più di un metodo di destinazione: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>È stata raggiunta la fine del flusso.</value>

--- a/src/StreamJsonRpc/Resources.ja.resx
+++ b/src/StreamJsonRpc/Resources.ja.resx
@@ -34,14 +34,6 @@
     <value>{0} は ref または out パラメーターを含んでいますが、サポートされていません</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} はパブリックではありません</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>'{0}' メソッド名は要求された '{1}' とは大文字と小文字が異なります</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} パラメーター (CancellationToken は除外します): {1}、しかし要求は {2} を提供します</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} パラメーターは、要求と互換性がありません: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>複数のターゲット メソッドが見つかりました: {0}。</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>ストリームの終わりに達しました。</value>

--- a/src/StreamJsonRpc/Resources.ko.resx
+++ b/src/StreamJsonRpc/Resources.ko.resx
@@ -34,14 +34,6 @@
     <value>{0}에 ref 또는 지원되지 않는 출력 매개 변수가 있습니다.</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0}이(가) public이 아닙니다.</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>'{0}' 메서드 이름에 요청된 '{1}'과(와) 다른 대/소문자가 있습니다.</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} 매개 변수(CancellationToken 제외)는 {1}이지만 요청에서는 {2}이(가) 제공됩니다.</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} 매개 변수가 {1} 요청과 호환되지 않습니다.</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>둘 이상의 대상 메서드 발견: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>스트림 끝에 도달했습니다.</value>

--- a/src/StreamJsonRpc/Resources.pl.resx
+++ b/src/StreamJsonRpc/Resources.pl.resx
@@ -34,14 +34,6 @@
     <value>Metoda {0} ma parametry ref lub out, co nie jest obsługiwane</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>Metoda {0} nie jest publiczna</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>Nazwa metody „{0}” ma inną wielkość liter niż żądana nazwa „{1}”</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>Metoda {0} ma liczbę parametrów {1} (nie licząc wszelkich tokenów CancellationToken), ale żądanie dostarcza {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>Parametry metody {0} nie są zgodne z żądaniem: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Znaleziono więcej niż jedną metodę docelową: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Osiągnięto koniec strumienia.</value>

--- a/src/StreamJsonRpc/Resources.pt-BR.resx
+++ b/src/StreamJsonRpc/Resources.pt-BR.resx
@@ -34,14 +34,6 @@
     <value>{0} tem os parâmetros ref ou out, que não têm suporte</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} não é público</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>O nome do método '{0}' tem maiúsculas/minúsculas diferentes do solicitado '{1}'</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} parâmetro(s) (excluindo qualquer CancellationToken): {1}, mas a solicitação fornece {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>Parâmetros {0} não são compatíveis com a solicitação: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Mais de um método de destino encontrado: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Fim do fluxo alcançado.</value>

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -131,6 +131,9 @@
     <value>All overloads and overrides of the '{0}' method must share a common value for {1}.{2}.</value>
     <comment>{0} is the method name, {1} is the attribute name, {2} is the attribute property name.</comment>
   </data>
+  <data name="ConflictMethodSignatureAlreadyRegistered" xml:space="preserve">
+    <value>A method with the same name and equivalent parameters has already been registered.</value>
+  </data>
   <data name="DroppingRequestDueToNoTargetObject" xml:space="preserve">
     <value>Got a request to execute '{0}' but have no callback object. Dropping the request.</value>
     <comment>{0} is the method name to execute.</comment>
@@ -166,14 +169,6 @@
     <value>{0} has ref or out parameter(s), which is not supported</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} is not public</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>'{0}' method name has different case from requested '{1}'</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} parameter(s) (excluding any CancellationToken): {1}, but the request supplies {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -181,10 +176,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} parameters are not compatible with the request: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>More than one target method found: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="NonNegativeIntegerRequired" xml:space="preserve">
     <value>A non-negative integer is required.</value>
@@ -204,6 +195,9 @@
   </data>
   <data name="ResponseIsNotError" xml:space="preserve">
     <value>Response is not error.</value>
+  </data>
+  <data name="RpcMethodNameNotFound" xml:space="preserve">
+    <value>No method by the name '{0}' is found.</value>
   </data>
   <data name="StreamDisposed" xml:space="preserve">
     <value>Stream has been disposed</value>

--- a/src/StreamJsonRpc/Resources.ru.resx
+++ b/src/StreamJsonRpc/Resources.ru.resx
@@ -34,14 +34,6 @@
     <value>{0} имеет параметры REF или OUT, что не поддерживается</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} не является открытым</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>Регистр имени метода "{0}" отличается от запрошенного "{1}"</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>Число параметров в {0} (исключая любые CancellationToken): {1}; в запросе же указано {2}.</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>Параметры {0} несовместимы с запросом: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Найдено более одного целевого метода: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Достигнут конец потока.</value>

--- a/src/StreamJsonRpc/Resources.tr.resx
+++ b/src/StreamJsonRpc/Resources.tr.resx
@@ -34,14 +34,6 @@
     <value>{0} desteklenmeyen ref veya out parametrelerine sahip</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} genel değil</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>'{0}' metot adı, istenen '{1}' metodundan farklı büyük-küçük harf kullanımına sahip</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} metodunun {1} parametresi var (İptal Belirteci’ni dışta tutarak), ancak istekte {2} parametre belirtildi</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} parametreleri istekle uyumlu değil: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>Birden fazla hedef metot bulundu: {0}.</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Akışın sonuna ulaşıldı.</value>

--- a/src/StreamJsonRpc/Resources.zh-Hans.resx
+++ b/src/StreamJsonRpc/Resources.zh-Hans.resx
@@ -34,14 +34,6 @@
     <value>{0} 具有不受支持的 ref 或 out 参数</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} 不是公共的</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>“{0}”方法名具有与请求的“{1}”不同的事例</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} 参数（排除任何 CancellationToken）：{1}，但请求提供 {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} 个参数与请求 {1} 不兼容</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>找到多个目标方法 {0}。</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>已达到流结尾。</value>

--- a/src/StreamJsonRpc/Resources.zh-Hant.resx
+++ b/src/StreamJsonRpc/Resources.zh-Hant.resx
@@ -34,14 +34,6 @@
     <value>{0} 有不支援的 ref 或 out 參數</value>
     <comment>{0} is the method signature.</comment>
   </data>
-  <data name="MethodIsNotPublic" xml:space="preserve">
-    <value>{0} 不是公用的</value>
-    <comment>{0} is the method signature.</comment>
-  </data>
-  <data name="MethodNameCaseIsDifferent" xml:space="preserve">
-    <value>'{0}' 方法名稱，其大小寫與所要求的 '{1}' 不同</value>
-    <comment>{0} is the method signature, {1} is the requested method name.</comment>
-  </data>
   <data name="MethodParameterCountDoesNotMatch" xml:space="preserve">
     <value>{0} 個參數 (排除任何 CancellationToken): {1}，但要求提供 {2}</value>
     <comment>{0} is the method signature, {1} is the method parameter count, {2} is the request parameter count.</comment>
@@ -49,10 +41,6 @@
   <data name="MethodParametersNotCompatible" xml:space="preserve">
     <value>{0} 參數與下列要求不相容: {1}</value>
     <comment>{0} is the method signature, {1} is the error message.</comment>
-  </data>
-  <data name="MoreThanOneMethodFound" xml:space="preserve">
-    <value>找到多個目標方法: {0}。</value>
-    <comment>{0} is the list of method signatures.</comment>
   </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>已到達資料流結尾。</value>


### PR DESCRIPTION
This lets an endpoint register individual methods or delegates to RPC method names.
This complements the existing feature of being able to register target objects where all public methods are automatically registered.

While at it, I had to revise the way we record RPC methods. Now we have a dictionary that translates the name of an RPC method to a list of all MethodInfos (and target objects) that may respond to that method. It's more than one since there can be overloads.

Closes #49