### PR TITLE
Avoid loading an assembly that defines parameter types unless necessary

### DIFF
--- a/src/StreamJsonRpc/Reflection/MethodSignature.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignature.cs
@@ -17,16 +17,20 @@ namespace StreamJsonRpc
         private static readonly ParameterInfo[] EmptyParameterInfoArray = new ParameterInfo[0];
         private static readonly StringComparer TypeNameComparer = StringComparer.Ordinal;
 
+        /// <summary>
+        /// Backing field for the lazily initialized <see cref="Parameters"/> property.
+        /// </summary>
+        private ParameterInfo[] parameters;
+
         internal MethodSignature(MethodInfo methodInfo)
         {
             Requires.NotNull(methodInfo, nameof(methodInfo));
             this.MethodInfo = methodInfo;
-            this.Parameters = methodInfo.GetParameters() ?? EmptyParameterInfoArray;
         }
 
         internal MethodInfo MethodInfo { get; }
 
-        internal ParameterInfo[] Parameters { get; }
+        internal ParameterInfo[] Parameters => this.parameters ?? (this.parameters = this.MethodInfo.GetParameters() ?? EmptyParameterInfoArray);
 
         internal bool IsPublic => this.MethodInfo.IsPublic;
 


### PR DESCRIPTION
This fixes a perf regression since v1.3.6 because a local RPC target included public methods that were never invoked, but had a parameter whose type was defined in an assembly that did not need to load.