### PR TITLE
Add targets for net46, netstandard1.3, netstandard2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ test_script:
 
     codecov -f "bin\StreamJsonRpc.Tests\Release\net46\code_coverage.xml"
 
-    dotnet test .\src\StreamJsonRpc.Tests\StreamJsonRpc.Tests.csproj --no-build -f netcoreapp1.0
+    dotnet test .\src\StreamJsonRpc.Tests\StreamJsonRpc.Tests.csproj --no-build
 artifacts:
 - path: bin\**\*.nupkg
   name: NuGet Package

--- a/src/StreamJsonRpc.Tests/DirectMessageHandler.cs
+++ b/src/StreamJsonRpc.Tests/DirectMessageHandler.cs
@@ -30,6 +30,6 @@ public class DirectMessageHandler : DelimitedMessageHandler
     protected override Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken)
     {
         this.WrittenMessages.Enqueue(content);
-        return Task.CompletedTask;
+        return TplExtensions.CompletedTask;
     }
 }

--- a/src/StreamJsonRpc.Tests/PerfTests.cs
+++ b/src/StreamJsonRpc.Tests/PerfTests.cs
@@ -26,9 +26,17 @@ public class PerfTests
     {
         string pipeName = Guid.NewGuid().ToString();
         var serverPipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, /*maxConnections*/ 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+#if NET452
+        var connectTask = Task.Run(() => serverPipe.WaitForConnection());
+#else
         var connectTask = serverPipe.WaitForConnectionAsync();
+#endif
         var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+#if NET452
+        clientPipe.Connect();
+#else
         await clientPipe.ConnectAsync();
+#endif
         await connectTask; // rethrow any exception
         await this.ChattyPerfAsync(serverPipe, clientPipe);
     }

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StreamJsonRpc.Tests.ruleset</CodeAnalysisRuleSet>
     <RootNamespace />
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\StreamJsonRpc\StreamJsonRpc.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes" Version="4.0.0" />
+    <PackageReference Include="System.IO.Pipes" Version="4.0.0" Condition=" '$(TargetFramework)' != 'net452' " />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <!-- PackageReference Include="Nerdbank.FullDuplexStream" Version="1.0.9" /-->

--- a/src/StreamJsonRpc/Exceptions/BadRpcHeaderException.cs
+++ b/src/StreamJsonRpc/Exceptions/BadRpcHeaderException.cs
@@ -9,7 +9,7 @@ namespace StreamJsonRpc
     /// An exception thrown when a deserialized message has a bad header.
     /// </summary>
     /// <seealso cref="RemoteRpcException" />
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
     [Serializable]
 #endif
     public class BadRpcHeaderException : RemoteRpcException
@@ -33,7 +33,7 @@ namespace StreamJsonRpc
         {
         }
 
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Initializes a new instance of the <see cref="BadRpcHeaderException"/> class.
         /// </summary>

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -11,7 +11,7 @@ namespace StreamJsonRpc
     /// <remarks>
     /// The details of the target method exception can be found on <see cref="RemoteStackTrace"/> and <see cref="RemoteErrorCode"/>.
     /// </remarks>
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
     [System.Serializable]
 #endif
     public class RemoteInvocationException : RemoteRpcException
@@ -38,7 +38,7 @@ namespace StreamJsonRpc
         {
         }
 
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
         /// </summary>

--- a/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
@@ -14,7 +14,7 @@ namespace StreamJsonRpc
     /// there was a method with the matching name, but it was not public, had ref or out params, or
     /// its arguments were incompatible with the arguments supplied by the client.
     /// </remarks>
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
     [System.Serializable]
 #endif
     public class RemoteMethodNotFoundException : RemoteRpcException
@@ -32,7 +32,7 @@ namespace StreamJsonRpc
             this.TargetMethod = targetMethod;
         }
 
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteMethodNotFoundException"/> class.
         /// </summary>

--- a/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
@@ -8,7 +8,7 @@ namespace StreamJsonRpc
     /// <summary>
     /// Base exception class for any exception that happens while receiving an JSON RPC communication.
     /// </summary>
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
     [System.Serializable]
 #endif
     public abstract class RemoteRpcException : Exception
@@ -32,7 +32,7 @@ namespace StreamJsonRpc
         {
         }
 
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteRpcException"/> class.
         /// </summary>

--- a/src/StreamJsonRpc/Exceptions/RemoteTargetNotSetException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteTargetNotSetException.cs
@@ -9,7 +9,7 @@ namespace StreamJsonRpc
     /// Remote RPC exception that indicates that the server has no target object.
     /// </summary>
     /// <seealso cref="RemoteRpcException" />
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
     [System.Serializable]
 #endif
     public class RemoteTargetNotSetException : RemoteRpcException
@@ -23,7 +23,7 @@ namespace StreamJsonRpc
         {
         }
 
-#if NET45
+#if SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteTargetNotSetException"/> class.
         /// </summary>

--- a/src/StreamJsonRpc/ExcludeFromCodeCoverageAttribute.cs
+++ b/src/StreamJsonRpc/ExcludeFromCodeCoverageAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !NET45
+#if !EXCLUDEFROMCODECOVERAGEATTRIBUTE
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;portable-net45+win8+wpa81;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;portable-net45+win8+wpa81;net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);EXCLUDEFROMCODECOVERAGEATTRIBUTE</DefineConstants>
 
     <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol. Its transport is a standard System.IO.Stream so you can use it with any transport.</Description>
     <PackageTags>visualstudio stream json rpc</PackageTags>
@@ -40,6 +42,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.6" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(TargetFramework)' != 'net45' " />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
@@ -47,9 +50,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">


### PR DESCRIPTION
This allows for exception serialization on .NET Standard 2.0 and prepares to use .NET Standard 1.3's support for TrySetCanceled