### PR TITLE
Improve performance of transmitting multiple messages

### DIFF
--- a/src/StreamJsonRpc.Tests/DelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/DelimitedMessageHandlerTests.cs
@@ -112,27 +112,20 @@ public class DelimitedMessageHandlerTests : TestBase
     }
 
     /// <summary>
-    /// Tests that by default, WriteCoreAsync calls cannot be called again till
+    /// Tests that WriteCoreAsync calls cannot be called again till
     /// the Task returned from the prior call has completed.
     /// </summary>
-    /// <param name="optimized">A value indicating whether we simulate a derived type that expresses readiness for a perf optimization.</param>
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task WriteAsync_SemaphoreIncludesWriteCoreAsync_Task(bool optimized)
+    [Fact]
+    public async Task WriteAsync_SemaphoreIncludesWriteCoreAsync_Task()
     {
         var handler = new DelayedWriter(this.sendingStream, this.receivingStream, Encoding.UTF8);
-        handler.WriteCoreAsyncCallsWriteBeforeReturningPublic = optimized;
         var writeTask = handler.WriteAsync("content", CancellationToken.None);
         var write2Task = handler.WriteAsync("content", CancellationToken.None);
 
-        if (!optimized)
-        {
-            // Give the library extra time to do the wrong thing asynchronously.
-            await Task.Delay(ExpectedTimeout);
-        }
+        // Give the library extra time to do the wrong thing asynchronously.
+        await Task.Delay(ExpectedTimeout);
 
-        Assert.Equal(optimized ? 2 : 1, handler.WriteCoreCallCount);
+        Assert.Equal(1, handler.WriteCoreCallCount);
         handler.WriteBlock.Set();
         await Task.WhenAll(writeTask, write2Task).WithTimeout(UnexpectedTimeout);
         Assert.Equal(2, handler.WriteCoreCallCount);
@@ -185,10 +178,6 @@ public class DelimitedMessageHandlerTests : TestBase
             : base(sendingStream, receivingStream, encoding)
         {
         }
-
-        internal bool WriteCoreAsyncCallsWriteBeforeReturningPublic { get; set; }
-
-        protected override bool WriteCoreAsyncCallsWriteBeforeReturning => this.WriteCoreAsyncCallsWriteBeforeReturningPublic;
 
         protected override Task<string> ReadCoreAsync(CancellationToken cancellationToken)
         {

--- a/src/StreamJsonRpc.Tests/PerfTests.cs
+++ b/src/StreamJsonRpc.Tests/PerfTests.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using Nerdbank;
 using StreamJsonRpc;
 using Xunit;
@@ -21,34 +24,23 @@ public class PerfTests
         this.logger = logger;
     }
 
-    [Fact]
-    public async Task ChattyPerf_OverNamedPipes()
+    public static object[][] PipeTypes
     {
-        string pipeName = Guid.NewGuid().ToString();
-        var serverPipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, /*maxConnections*/ 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-#if NET452
-        var connectTask = Task.Run(() => serverPipe.WaitForConnection());
-#else
-        var connectTask = serverPipe.WaitForConnectionAsync();
-#endif
-        var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
-#if NET452
-        clientPipe.Connect();
-#else
-        await clientPipe.ConnectAsync();
-#endif
-        await connectTask; // rethrow any exception
-        await this.ChattyPerfAsync(serverPipe, clientPipe);
+        get
+        {
+            var duplex = FullDuplexStream.CreateStreams();
+            var pipes = GetNamedPipes();
+            return new object[][]
+            {
+                new object[] { duplex.Item1, duplex.Item2 },
+                new object[] { pipes.Item1, pipes.Item2 },
+            };
+        }
     }
 
-    [Fact]
-    public async Task ChattyPerf_OverFullDuplexStream()
-    {
-        var streams = FullDuplexStream.CreateStreams();
-        await this.ChattyPerfAsync(streams.Item1, streams.Item2);
-    }
-
-    private async Task ChattyPerfAsync(Stream serverStream, Stream clientStream)
+    [Theory]
+    [MemberData(nameof(PipeTypes))]
+    public async Task ChattyPerf(Stream serverStream, Stream clientStream)
     {
         using (JsonRpc.Attach(serverStream, new Server()))
         using (var client = JsonRpc.Attach(clientStream))
@@ -77,10 +69,83 @@ public class PerfTests
         }
     }
 
+    [Theory]
+    [MemberData(nameof(PipeTypes))]
+    public async Task BurstNotifyMessages(Stream serverStream, Stream clientStream)
+    {
+        var notifyServer = new NotifyServer();
+        using (JsonRpc.Attach(serverStream, notifyServer))
+        using (var client = JsonRpc.Attach(clientStream))
+        {
+            // warmup
+            await client.InvokeAsync("NoOp");
+
+            const int maxIterations = 10000;
+            var notifyTasks = new List<Task>(maxIterations);
+            var timer = Stopwatch.StartNew();
+            int i;
+            for (i = 0; i < maxIterations; i++)
+            {
+                notifyTasks.Add(client.NotifyAsync("NoOp"));
+
+                if (timer.ElapsedMilliseconds > 2000 && i > 0)
+                {
+                    // It's taking too long to reach maxIterations. Break out.
+                    break;
+                }
+            }
+
+            notifyServer.RequestSignalAfter(notifyTasks.Count);
+            await Task.WhenAll(notifyTasks);
+            await notifyServer.Signal;
+
+            timer.Stop();
+            this.logger.WriteLine($"{i} iterations completed in {timer.ElapsedMilliseconds} ms.");
+            this.logger.WriteLine($"Rate: {i / timer.Elapsed.TotalSeconds} invocations per second.");
+            this.logger.WriteLine($"Overhead: {(double)timer.ElapsedMilliseconds / i} ms per invocation.");
+        }
+    }
+
+    private static (Stream, Stream) GetNamedPipes()
+    {
+        string pipeName = Guid.NewGuid().ToString();
+        var serverPipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, /*maxConnections*/ 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var connectTask = Task.Run(() => serverPipe.WaitForConnection());
+        var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        clientPipe.Connect();
+        connectTask.GetAwaiter().GetResult(); // rethrow any exception
+
+        return (serverPipe, clientPipe);
+    }
+
     public class Server
     {
         public void NoOp()
         {
+        }
+    }
+
+    public class NotifyServer
+    {
+        internal readonly AsyncManualResetEvent Signal = new AsyncManualResetEvent();
+        internal int InvocationCounter;
+        private int signalAfter;
+
+        public void NoOp()
+        {
+            if (Interlocked.Increment(ref this.InvocationCounter) >= this.signalAfter && this.signalAfter > 0)
+            {
+                this.Signal.Set();
+            }
+        }
+
+        internal void RequestSignalAfter(int count)
+        {
+            Volatile.Write(ref this.signalAfter, count);
+            if (Volatile.Read(ref this.InvocationCounter) >= this.signalAfter)
+            {
+                this.Signal.Set();
+            }
         }
     }
 }

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.3" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.32" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\StreamJsonRpc\ReadBufferingStream.cs">

--- a/src/StreamJsonRpc/DelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/DelimitedMessageHandler.cs
@@ -157,6 +157,8 @@ namespace StreamJsonRpc
                     {
                         await this.WriteCoreAsync(content, contentEncoding, cts.Token).ConfigureAwait(false);
                     }
+
+                    await this.SendingStream.FlushAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/StreamJsonRpc/DelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/DelimitedMessageHandler.cs
@@ -105,17 +105,6 @@ namespace StreamJsonRpc
         protected CancellationToken DisposalToken => this.disposalTokenSource.Token;
 
         /// <summary>
-        /// Gets a value indicating whether the derived type's <see cref="WriteCoreAsync"/> method
-        /// makes all <see cref="Stream.WriteAsync(byte[], int, int)" /> calls synchronously before
-        /// returning.
-        /// </summary>
-        /// <remarks>
-        /// See the remarks section of the <see cref="WriteCoreAsync(string, Encoding, CancellationToken)"/> method
-        /// for more information.
-        /// </remarks>
-        protected virtual bool WriteCoreAsyncCallsWriteBeforeReturning => false;
-
-        /// <summary>
         /// Reads a distinct and complete message from the stream, waiting for one if necessary.
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the read request.</param>
@@ -164,17 +153,11 @@ namespace StreamJsonRpc
             {
                 try
                 {
-                    Task writeTask;
                     using (await this.sendingSemaphore.EnterAsync(cts.Token).ConfigureAwait(false))
                     {
-                        writeTask = this.WriteCoreAsync(content, contentEncoding, cts.Token);
-                        if (!this.WriteCoreAsyncCallsWriteBeforeReturning)
-                        {
-                            await writeTask.ConfigureAwait(false);
-                        }
+                        await this.WriteCoreAsync(content, contentEncoding, cts.Token).ConfigureAwait(false);
                     }
 
-                    await writeTask.ConfigureAwait(false);
                     await this.SendingStream.FlushAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
@@ -227,20 +210,6 @@ namespace StreamJsonRpc
         /// <param name="contentEncoding">The encoding to use for <paramref name="content"/>.</param>
         /// <param name="cancellationToken">A token to cancel the transmission.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        /// <remarks>
-        /// Implementations of this method should perform all writes to <see cref="SendingStream"/>
-        /// before returning or yielding back to the caller since only the synchronous portion of the call
-        /// to this method is protected by the sending semaphore.
-        /// Note that the writes to <see cref="SendingStream"/> themselves can and should be asynchronous,
-        /// and tracked by the returned <see cref="Task"/>. The implementation can simply directly return the
-        /// <see cref="Task"/> returned from the write to <see cref="SendingStream"/>.
-        /// If multiple calls are required, call <see cref="Stream.WriteAsync(byte[], int, int)"/> multiple times
-        /// and store a collection of the returned <see cref="Task"/> objects, then finally return a single
-        /// <see cref="Task"/> that tracks them all using <see cref="Task.WhenAll(System.Collections.Generic.IEnumerable{Task})"/>.
-        /// If these guidelines are met, the derived class should override and return true from the
-        /// <see cref="WriteCoreAsyncCallsWriteBeforeReturning"/> property to enable the base class to optimize
-        /// for it.
-        /// </remarks>
         protected abstract Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken);
     }
 }

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -85,9 +85,6 @@ namespace StreamJsonRpc
         /// <value>The default value is "jsonrpc".</value>
         public string SubType { get; set; } = "jsonrpc";
 
-        /// <inheritdoc />
-        protected override bool WriteCoreAsyncCallsWriteBeforeReturning => true;
-
         private new ReadBufferingStream ReceivingStream => (ReadBufferingStream)base.ReceivingStream;
 
         /// <inheritdoc />

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -200,7 +200,7 @@ namespace StreamJsonRpc
         }
 
         /// <inheritdoc />
-        protected override Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken)
+        protected override async Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken)
         {
             var sendingBufferStream = new MemoryStream(MaxHeaderElementSize);
 
@@ -241,13 +241,11 @@ namespace StreamJsonRpc
             // Transmit the headers.
             // Ignore the cancellation token so we don't write the header without the content.
             sendingBufferStream.Position = 0;
-            Task headersTask = sendingBufferStream.CopyToAsync(this.SendingStream, MaxHeaderElementSize);
+            await sendingBufferStream.CopyToAsync(this.SendingStream, MaxHeaderElementSize).ConfigureAwait(false);
 
             // Transmit the content itself.
             // Ignore the cancellation token so we don't write the header without the content.
-            Task contentTask = this.SendingStream.WriteAsync(contentBytes, 0, contentBytes.Length);
-
-            return Task.WhenAll(headersTask, contentTask);
+            await this.SendingStream.WriteAsync(contentBytes, 0, contentBytes.Length).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -85,6 +85,9 @@ namespace StreamJsonRpc
         /// <value>The default value is "jsonrpc".</value>
         public string SubType { get; set; } = "jsonrpc";
 
+        /// <inheritdoc />
+        protected override bool WriteCoreAsyncCallsWriteBeforeReturning => true;
+
         private new ReadBufferingStream ReceivingStream => (ReadBufferingStream)base.ReceivingStream;
 
         /// <inheritdoc />

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -246,7 +246,6 @@ namespace StreamJsonRpc
             // Transmit the content itself.
             // Ignore the cancellation token so we don't write the header without the content.
             await this.SendingStream.WriteAsync(contentBytes, 0, contentBytes.Length).ConfigureAwait(false);
-            await this.SendingStream.FlushAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+override StreamJsonRpc.HeaderDelimitedMessageHandler.WriteCoreAsyncCallsWriteBeforeReturning.get -> bool
+virtual StreamJsonRpc.DelimitedMessageHandler.WriteCoreAsyncCallsWriteBeforeReturning.get -> bool

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
-override StreamJsonRpc.HeaderDelimitedMessageHandler.WriteCoreAsyncCallsWriteBeforeReturning.get -> bool
-virtual StreamJsonRpc.DelimitedMessageHandler.WriteCoreAsyncCallsWriteBeforeReturning.get -> bool


### PR DESCRIPTION
This change adjusts the timing of flushing the stream and how quickly we exit the sending semaphore, allowing multiple message transmissions to line up right next to each other rather than being necessarily spaced apart for the entire time required to flush the previous message.

Fixes #52 
Probably also fixes #37 because we will hold the semaphore for a much smaller period of time.

This doesn't seem to significantly impact the "chatty" perf test we had before (or it makes it slightly slower). I added a new perf test for a burst of "notify" messages with these demonstrably improved results (*doubles* throughput):

```
BEFORE

Test Name:	PerfTests.BurstNotifyMessages(serverStream: FullDuplexStream { BeforeWrite = null, CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, ... }, clientStream: FullDuplexStream { BeforeWrite = null, CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, ... })
Test Outcome:	Passed
Result StandardOutput:	
10000 iterations completed in 418 ms.
Rate: 23875.9159099792 invocations per second.
Overhead: 0.0418 ms per invocation.

Test Name:	PerfTests.BurstNotifyMessages(serverStream: NamedPipeServerStream { CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, InBufferSize = 0, ... }, clientStream: NamedPipeClientStream { CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, InBufferSize = 0, ... })
Test Outcome:	Passed
Result StandardOutput:	
10000 iterations completed in 985 ms.
Rate: 10147.2209552289 invocations per second.
Overhead: 0.0985 ms per invocation.



AFTER

Test Name:	PerfTests.BurstNotifyMessages(serverStream: FullDuplexStream { BeforeWrite = null, CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, ... }, clientStream: FullDuplexStream { BeforeWrite = null, CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, ... })
Test Outcome:	Passed
Result StandardOutput:	
10000 iterations completed in 233 ms.
Rate: 42809.88685775 invocations per second.
Overhead: 0.0233 ms per invocation.

Test Name:	PerfTests.BurstNotifyMessages(serverStream: NamedPipeServerStream { CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, InBufferSize = 0, ... }, clientStream: NamedPipeClientStream { CanRead = True, CanSeek = False, CanTimeout = False, CanWrite = True, InBufferSize = 0, ... })
Test Outcome:	Passed
Result StandardOutput:	
10000 iterations completed in 499 ms.
Rate: 20016.477564331 invocations per second.
Overhead: 0.0499 ms per invocation.
```