### PR TITLE
Emit subtype header if it is nonstandard

### DIFF
--- a/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
@@ -87,4 +87,15 @@ CRLF +
         readContent = this.handler.ReadAsync(default(CancellationToken)).GetAwaiter().GetResult();
         Assert.Equal<string>("ABCDEFGHIJ", readContent);
     }
+
+    [Fact]
+    public async Task SubType_ForcesHeader()
+    {
+        this.handler.SubType = "nonstandard";
+        await this.handler.WriteAsync("hello", this.TimeoutToken);
+        this.sendingStream.Position = 0;
+        var sr = new StreamReader(this.sendingStream, this.handler.Encoding);
+        string writtenContent = sr.ReadToEnd();
+        Assert.Contains(this.handler.SubType, writtenContent);
+    }
 }

--- a/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
@@ -22,6 +22,17 @@ public class HeaderDelimitedMessageHandlerTests : TestBase
     }
 
     [Fact]
+    public async Task SubType_ForcesHeader()
+    {
+        this.handler.SubType = "nonstandard";
+        await this.handler.WriteAsync("hello", this.TimeoutToken);
+        this.sendingStream.Position = 0;
+        var sr = new StreamReader(this.sendingStream, this.handler.Encoding);
+        string writtenContent = sr.ReadToEnd();
+        Assert.Contains(this.handler.SubType, writtenContent);
+    }
+
+    [Fact]
     public void ReadCoreAsync_HandlesSpacingCorrectly()
     {
         string content =
@@ -86,16 +97,5 @@ CRLF +
 
         readContent = this.handler.ReadAsync(default(CancellationToken)).GetAwaiter().GetResult();
         Assert.Equal<string>("ABCDEFGHIJ", readContent);
-    }
-
-    [Fact]
-    public async Task SubType_ForcesHeader()
-    {
-        this.handler.SubType = "nonstandard";
-        await this.handler.WriteAsync("hello", this.TimeoutToken);
-        this.sendingStream.Position = 0;
-        var sr = new StreamReader(this.sendingStream, this.handler.Encoding);
-        string writtenContent = sr.ReadToEnd();
-        Assert.Contains(this.handler.SubType, writtenContent);
     }
 }

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -30,6 +30,7 @@ namespace StreamJsonRpc
         private const int MaxHeaderElementSize = 1024;
         private const string ContentLengthHeaderNameText = "Content-Length";
         private const string ContentTypeHeaderNameText = "Content-Type";
+        private const string DefaultSubType = "jsonrpc";
 
         /// <summary>
         /// The default encoding to use when writing content,
@@ -83,7 +84,7 @@ namespace StreamJsonRpc
         /// Gets or sets the value to use as the subtype in the Content-Type header (e.g. "application/SUBTYPE").
         /// </summary>
         /// <value>The default value is "jsonrpc".</value>
-        public string SubType { get; set; } = "jsonrpc";
+        public string SubType { get; set; } = DefaultSubType;
 
         private new ReadBufferingStream ReceivingStream => (ReadBufferingStream)base.ReceivingStream;
 
@@ -219,7 +220,7 @@ namespace StreamJsonRpc
             // Transmit the Content-Type header, but only when using a non-default encoding.
             // We suppress it when it is the default both for smaller messages and to avoid
             // having to load System.Net.Http on the receiving end in order to parse it.
-            if (DefaultContentEncoding.WebName != contentEncoding.WebName)
+            if (DefaultContentEncoding.WebName != contentEncoding.WebName || this.SubType != DefaultSubType)
             {
                 sendingBufferStream.Write(ContentTypeHeaderName, 0, ContentTypeHeaderName.Length);
                 sendingBufferStream.Write(HeaderKeyValueDelimiter, 0, HeaderKeyValueDelimiter.Length);


### PR DESCRIPTION
I noticed in writing some recent tests that if the `Subtype` property is changed on our delimited message writer, it would not emit the header anyway. This fixes that and adds the missing test.