### PR TITLE
Add JsonRpc.Completion property

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -72,6 +72,11 @@ namespace StreamJsonRpc
 
         private readonly CancellationTokenSource disposeCts = new CancellationTokenSource();
 
+        /// <summary>
+        /// The completion source behind <see cref="Completion"/>.
+        /// </summary>
+        private readonly TaskCompletionSource<bool> completionSource = new TaskCompletionSource<bool>();
+
         private Task readLinesTask;
         private int nextId = 1;
         private bool disposed;
@@ -173,6 +178,24 @@ namespace StreamJsonRpc
         /// </summary>
         public DelimitedMessageHandler MessageHandler { get; }
 
+        /// <summary>
+        /// Gets a <see cref="Task"/> that completes when listening has stopped,
+        /// whether by error, disposal or the stream closing.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="StartListening"/> has not yet been called.</exception>
+        /// <remarks>
+        /// The returned <see cref="Task"/> may transition to a faulted state
+        /// for exceptions fatal to the protocol or this instance.
+        /// </remarks>
+        public Task Completion
+        {
+            get
+            {
+                Verify.Operation(this.startedListening, Resources.MustBeListening);
+                return this.completionSource.Task;
+            }
+        }
+
         /// <inheritdoc />
         bool IDisposableObservable.IsDisposed => this.disposeCts.IsCancellationRequested;
 
@@ -239,7 +262,7 @@ namespace StreamJsonRpc
         public void AddLocalRpcTarget(object target)
         {
             Requires.NotNull(target, nameof(target));
-            Verify.Operation(!this.startedListening, Resources.AttachTargetAfterStartListeningError);
+            Verify.Operation(!this.startedListening, Resources.MustNotBeListening);
 
             var mapping = GetRequestMethodToClrMethodMap(target);
             lock (this.syncObject)
@@ -299,7 +322,7 @@ namespace StreamJsonRpc
             Requires.NotNull(handler, nameof(handler));
             Requires.Argument(handler.IsStatic == (target == null), nameof(target), Resources.TargetObjectAndMethodStaticFlagMismatch);
 
-            Verify.Operation(!this.startedListening, Resources.AttachTargetAfterStartListeningError);
+            Verify.Operation(!this.startedListening, Resources.MustNotBeListening);
             lock (this.syncObject)
             {
                 var methodTarget = new MethodSignatureAndTarget(handler, target);
@@ -1001,6 +1024,16 @@ namespace StreamJsonRpc
                 this.disposeCts.Cancel();
                 this.MessageHandler.Dispose();
                 this.CancelPendingRequests();
+
+                // Ensure the Task we may have returned from Completion is completed.
+                if (eventArgs.Exception != null)
+                {
+                    this.completionSource.TrySetException(eventArgs.Exception);
+                }
+                else
+                {
+                    this.completionSource.TrySetResult(true);
+                }
             }
         }
 
@@ -1063,6 +1096,7 @@ namespace StreamJsonRpc
             }
             finally
             {
+                this.completionSource.TrySetResult(true);
                 if (disconnectedEventArgs == null)
                 {
                     disconnectedEventArgs = new JsonRpcDisconnectedEventArgs(Resources.StreamDisposed, DisconnectedReason.Disposed);

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -154,14 +154,18 @@
           <source>A method with the same name and equivalent parameters has already been registered.</source>
           <target state="new">A method with the same name and equivalent parameters has already been registered.</target>
         </trans-unit>
-        <trans-unit id="AttachTargetAfterStartListeningError" translate="yes" xml:space="preserve">
-          <source>Cannot attach additional target once JsonRpc has started listening for messages.</source>
-          <target state="new">Cannot attach additional target once JsonRpc has started listening for messages.</target>
-        </trans-unit>
         <trans-unit id="TargetObjectAndMethodStaticFlagMismatch" translate="yes" xml:space="preserve">
           <source>A target object should be supplied if and only if the method is not static.</source>
           <target state="new">A target object should be supplied if and only if the method is not static.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">"static" is a C# keyword and should not be translated.</note>
+        </trans-unit>
+        <trans-unit id="MustBeListening" translate="yes" xml:space="preserve">
+          <source>Listening must be started first.</source>
+          <target state="new">Listening must be started first.</target>
+        </trans-unit>
+        <trans-unit id="MustNotBeListening" translate="yes" xml:space="preserve">
+          <source>This cannot be done after listening has started.</source>
+          <target state="new">This cannot be done after listening has started.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -62,15 +62,6 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot attach additional target once JsonRpc has started listening for messages..
-        /// </summary>
-        internal static string AttachTargetAfterStartListeningError {
-            get {
-                return ResourceManager.GetString("AttachTargetAfterStartListeningError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Both readable and writable are null..
         /// </summary>
         internal static string BothReadableWritableAreNull {
@@ -211,6 +202,24 @@ namespace StreamJsonRpc {
         internal static string MethodParametersNotCompatible {
             get {
                 return ResourceManager.GetString("MethodParametersNotCompatible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Listening must be started first..
+        /// </summary>
+        internal static string MustBeListening {
+            get {
+                return ResourceManager.GetString("MustBeListening", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This cannot be done after listening has started..
+        /// </summary>
+        internal static string MustNotBeListening {
+            get {
+                return ResourceManager.GetString("MustNotBeListening", resourceCulture);
             }
         }
         

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AttachTargetAfterStartListeningError" xml:space="preserve">
-    <value>Cannot attach additional target once JsonRpc has started listening for messages.</value>
+  <data name="MustBeListening" xml:space="preserve">
+    <value>Listening must be started first.</value>
   </data>
   <data name="BothReadableWritableAreNull" xml:space="preserve">
     <value>Both readable and writable are null.</value>
@@ -238,5 +238,8 @@
   <data name="TargetObjectAndMethodStaticFlagMismatch" xml:space="preserve">
     <value>A target object should be supplied if and only if the method is not static.</value>
     <comment>"static" is a C# keyword and should not be translated.</comment>
+  </data>
+  <data name="MustNotBeListening" xml:space="preserve">
+    <value>This cannot be done after listening has started.</value>
   </data>
 </root>


### PR DESCRIPTION
This adds a Task property that folks can await on when they want to proceed only after the client is done talking and has closed the pipe.

I rename and update the string resource for the exception we throw for operations that require listening to have started so that it is more generally applicable.