### PR TITLE
Add DelimitedMessageHandler.FlushCoreAsync() method

### DIFF
--- a/src/StreamJsonRpc/DelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/DelimitedMessageHandler.cs
@@ -158,7 +158,7 @@ namespace StreamJsonRpc
                         await this.WriteCoreAsync(content, contentEncoding, cts.Token).ConfigureAwait(false);
                     }
 
-                    await this.SendingStream.FlushAsync().ConfigureAwait(false);
+                    await this.FlushCoreAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -211,5 +211,12 @@ namespace StreamJsonRpc
         /// <param name="cancellationToken">A token to cancel the transmission.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         protected abstract Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Calls <see cref="Stream.FlushAsync()"/> on the <see cref="SendingStream"/>,
+        /// or equivalent sending stream if using an alternate transport.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> that completes when the write buffer has been transmitted.</returns>
+        protected virtual Task FlushCoreAsync() => this.SendingStream.FlushAsync();
     }
 }

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task


### PR DESCRIPTION
This further abstracts the use of Streams in `DelimitedMessageHandler` so that `WebSocket` can be used instead of Stream as the transport.