### PR TITLE
Add support for WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ StreamJsonRpc
 StreamJsonRpc is a cross-platform, .NET portable library that implements the
 [JSON-RPC][JSONRPC] wire protocol.
 
-Its transport is a standard System.IO.Stream so you can use it with any transport.
+It works over [Stream](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream) or [WebSocket](https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.websocket) independent of the underlying transport.
 
 ## Supported platforms
 
 * .NET 4.5
 * Windows 8
 * Windows Phone 8.1
-* .NET Portable (Profile111, or .NET Standard 1.1)
+* .NET Portable (Profile111)
+* .NET Standard 1.1
 
 ## Compatibility
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,32 @@
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
 
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft, VisualStudioExtensibility</Owners>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/Microsoft/vs-streamjsonrpc</PackageProjectUrl>
+    <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
+    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
+
     <MicroBuildPackageVersion>2.0.44</MicroBuildPackageVersion>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.35" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
+    <PackageReference Include="GitLink" Version="3.2.0-unstable0014" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/vs-streamjsonrpc/$(GitCommitIdShort)/LICENSE</PackageLicenseUrl>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/StreamJsonRpc.Tests/TestBase.cs
+++ b/src/StreamJsonRpc.Tests/TestBase.cs
@@ -33,9 +33,9 @@ public abstract class TestBase : IDisposable
 
     protected ITestOutputHelper Logger { get; }
 
-    protected CancellationToken TimeoutToken => this.timeoutTokenSource.Token;
+    protected CancellationToken TimeoutToken => Debugger.IsAttached ? CancellationToken.None : this.timeoutTokenSource.Token;
 
-    private static TimeSpan TestTimeout => Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(5);
+    private static TimeSpan TestTimeout => UnexpectedTimeout;
 
     public void Dispose()
     {

--- a/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
@@ -52,11 +52,10 @@ public class WebSocketMessageHandlerTests : TestBase
     }
 
     [Fact]
-    public void Dispose_DisposesSocket()
+    public void Dispose_DoesNotDisposeSocket()
     {
-        Assert.Equal(0, this.socket.DisposalCount);
         this.handler.Dispose();
-        Assert.Equal(1, this.socket.DisposalCount);
+        Assert.Equal(0, this.socket.DisposalCount);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
@@ -1,0 +1,242 @@
+﻿#if NETCOREAPP2_0 || NET452 || NET46
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class WebSocketMessageHandlerTests : TestBase
+{
+    private const int BufferSize = 9; // an odd number so as to split multi-byte encoded characters
+    private static readonly IReadOnlyList<Encoding> Encodings = new Encoding[] { Encoding.UTF8, Encoding.Unicode, Encoding.UTF32 };
+    private Random random = new Random();
+    private MockWebSocket socket;
+    private WebSocketMessageHandler handler;
+
+    public WebSocketMessageHandlerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.socket = new MockWebSocket();
+        this.handler = new WebSocketMessageHandler(this.socket, BufferSize);
+    }
+
+    public static object[][] EncodingTheoryData
+    {
+        get
+        {
+            return Encodings.Select(encoding => new object[] { encoding }).ToArray();
+        }
+    }
+
+    [Fact]
+    public void CtorInputValidation()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WebSocketMessageHandler(null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new WebSocketMessageHandler(new MockWebSocket(), 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new WebSocketMessageHandler(new MockWebSocket(), -1));
+        new WebSocketMessageHandler(new MockWebSocket(), 1);
+        new WebSocketMessageHandler(new MockWebSocket(), 1 * 1024 * 1024);
+    }
+
+    [Fact]
+    public void WebSocket_Property()
+    {
+        Assert.Same(this.socket, this.handler.WebSocket);
+    }
+
+    [Fact]
+    public void Dispose_DisposesSocket()
+    {
+        Assert.Equal(0, this.socket.DisposalCount);
+        this.handler.Dispose();
+        Assert.Equal(1, this.socket.DisposalCount);
+    }
+
+    [Fact]
+    public void Dispose_TwiceDoesNotThrow()
+    {
+        this.handler.Dispose();
+        this.handler.Dispose();
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodingTheoryData))]
+    public async Task ReadMessage_UnderBufferSize(Encoding encoding)
+    {
+        this.handler.Encoding = encoding;
+        string msg = new string('a', GetMaxCharsThatFitInBuffer(encoding) - 1);
+        byte[] buffer = encoding.GetBytes(msg);
+        this.socket.EnqueueRead(buffer);
+        string result = await this.handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(msg, result);
+    }
+
+    [Fact]
+    public async Task ReadMessage_ExactBufferSize()
+    {
+        var encoding = Encoding.UTF8;
+        this.handler.Encoding = encoding;
+        string msg = new string('a', GetMaxCharsThatFitInBuffer(encoding));
+        byte[] buffer = encoding.GetBytes(msg);
+        this.socket.EnqueueRead(buffer);
+        string result = await this.handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(msg, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodingTheoryData))]
+    public async Task ReadMessage_ExceedsBufferSize(Encoding encoding)
+    {
+        this.handler.Encoding = encoding;
+        string msg = new string('a', (int)(BufferSize * 2.5));
+        byte[] buffer = encoding.GetBytes(msg);
+        this.socket.EnqueueRead(buffer);
+        string result = await this.handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(msg, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodingTheoryData))]
+    public async Task WriteMessage_UnderBufferSize(Encoding encoding)
+    {
+        this.handler.Encoding = encoding;
+        string msg = new string('a', GetMaxCharsThatFitInBuffer(encoding) - 1);
+        await this.handler.WriteAsync(msg, this.TimeoutToken);
+        var writtenBuffer = this.socket.WrittenQueue.Dequeue();
+        string writtenString = encoding.GetString(writtenBuffer.Buffer.Array, writtenBuffer.Buffer.Offset, writtenBuffer.Buffer.Count);
+        Assert.Equal(msg, writtenString);
+    }
+
+    [Fact]
+    public async Task WriteMessage_ExactBufferSize()
+    {
+        Encoding encoding = Encoding.UTF8;
+        this.handler.Encoding = encoding;
+        string msg = new string('a', GetMaxCharsThatFitInBuffer(encoding));
+        await this.handler.WriteAsync(msg, this.TimeoutToken);
+        var writtenBuffer = this.socket.WrittenQueue.Dequeue();
+        string writtenString = encoding.GetString(writtenBuffer.Buffer.Array, writtenBuffer.Buffer.Offset, writtenBuffer.Buffer.Count);
+        Assert.Equal(msg, writtenString);
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodingTheoryData))]
+    public async Task WriteMessage_ExceedsBufferSize(Encoding encoding)
+    {
+        this.handler.Encoding = encoding;
+        string msg = new string('a', (int)(BufferSize * 2.5));
+        await this.handler.WriteAsync(msg, this.TimeoutToken);
+        var writtenBuffer = this.socket.WrittenQueue.Dequeue();
+        string writtenString = encoding.GetString(writtenBuffer.Buffer.Array, writtenBuffer.Buffer.Offset, writtenBuffer.Buffer.Count);
+        Assert.Equal(msg, writtenString);
+    }
+
+    [Fact]
+    public async Task WriteMessage_BufferIsSmallerThanOneEncodedChar()
+    {
+        this.handler = new WebSocketMessageHandler(this.socket, 2);
+        this.handler.Encoding = Encoding.UTF32;
+        await Assert.ThrowsAsync<ArgumentException>(() => this.handler.WriteAsync("a", this.TimeoutToken));
+    }
+
+    private static int GetMaxCharsThatFitInBuffer(Encoding encoding) => BufferSize / encoding.GetMaxByteCount(1);
+
+    private byte[] GetRandomBuffer(int count)
+    {
+        byte[] buffer = new byte[count];
+        this.random.NextBytes(buffer);
+        return buffer;
+    }
+
+    private class Message
+    {
+        internal ArraySegment<byte> Buffer { get; set; }
+    }
+
+    private class MockWebSocket : WebSocket
+    {
+        private Message writingInProgress;
+
+        public override WebSocketCloseStatus? CloseStatus => throw new NotImplementedException();
+
+        public override string CloseStatusDescription => throw new NotImplementedException();
+
+        public override string SubProtocol => throw new NotImplementedException();
+
+        public override WebSocketState State => throw new NotImplementedException();
+
+        /// <summary>
+        /// Gets the queue of messages to be returned from the <see cref="ReceiveAsync(ArraySegment{byte}, CancellationToken)"/> method.
+        /// </summary>
+        internal Queue<Message> ReadQueue { get; } = new Queue<Message>();
+
+        internal Queue<Message> WrittenQueue { get; } = new Queue<Message>();
+
+        internal int DisposalCount { get; private set; }
+
+        public override void Abort() => throw new NotImplementedException();
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        public override void Dispose() => this.DisposalCount++;
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> output, CancellationToken cancellationToken)
+        {
+            var input = this.ReadQueue.Peek();
+            int bytesToCopy = Math.Min(input.Buffer.Count, output.Count);
+            Buffer.BlockCopy(input.Buffer.Array, input.Buffer.Offset, output.Array, output.Offset, bytesToCopy);
+            bool finishedMessage = bytesToCopy == input.Buffer.Count;
+            if (finishedMessage)
+            {
+                this.ReadQueue.Dequeue();
+            }
+            else
+            {
+                input.Buffer = new ArraySegment<byte>(input.Buffer.Array, input.Buffer.Offset + bytesToCopy, input.Buffer.Count - bytesToCopy);
+            }
+
+            return Task.FromResult(new WebSocketReceiveResult(bytesToCopy, WebSocketMessageType.Text, finishedMessage));
+        }
+
+        public override Task SendAsync(ArraySegment<byte> input, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            if (this.writingInProgress == null)
+            {
+                var bufferCopy = new byte[input.Count];
+                Buffer.BlockCopy(input.Array, input.Offset, bufferCopy, 0, input.Count);
+                this.writingInProgress = new Message { Buffer = new ArraySegment<byte>(bufferCopy) };
+            }
+            else
+            {
+                var bufferCopy = this.writingInProgress.Buffer.Array;
+                Array.Resize(ref bufferCopy, bufferCopy.Length + input.Count);
+                Buffer.BlockCopy(input.Array, input.Offset, bufferCopy, this.writingInProgress.Buffer.Count, input.Count);
+                this.writingInProgress.Buffer = new ArraySegment<byte>(bufferCopy);
+            }
+
+            if (endOfMessage)
+            {
+                this.WrittenQueue.Enqueue(this.writingInProgress);
+                this.writingInProgress = null;
+            }
+
+            return TplExtensions.CompletedTask;
+        }
+
+        internal void EnqueueRead(byte[] buffer)
+        {
+            this.ReadQueue.Enqueue(new Message { Buffer = new ArraySegment<byte>(buffer) });
+        }
+    }
+}
+
+#endif

--- a/src/StreamJsonRpc.sln
+++ b/src/StreamJsonRpc.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\appveyor.yml = ..\appveyor.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		nuget.config = nuget.config
 		stylecop.json = stylecop.json
 		version.json = version.json

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
 StreamJsonRpc.WebSocketMessageHandler
 StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.WebSocket
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void
-override StreamJsonRpc.WebSocketMessageHandler.Dispose(bool disposing) -> void
 override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+StreamJsonRpc.WebSocketMessageHandler
+StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.WebSocket
+StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void
+override StreamJsonRpc.WebSocketMessageHandler.Dispose(bool disposing) -> void
+override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
+override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -4,6 +4,8 @@
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);WEBSOCKETS</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);EXCLUDEFROMCODECOVERAGEATTRIBUTE</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' ">$(DefineConstants);TRYSETCANCELED_CT</DefineConstants>

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -10,7 +10,7 @@
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);EXCLUDEFROMCODECOVERAGEATTRIBUTE</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' ">$(DefineConstants);TRYSETCANCELED_CT</DefineConstants>
 
-    <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol. Its transport is a standard System.IO.Stream so you can use it with any transport.</Description>
+    <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol and can use System.IO.Stream or WebSocket so you can use it with any transport.</Description>
     <PackageTags>visualstudio stream json rpc</PackageTags>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;portable-net45+win8+wpa81;net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
-    <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>
@@ -12,13 +10,6 @@
 
     <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol. Its transport is a standard System.IO.Stream so you can use it with any transport.</Description>
     <PackageTags>visualstudio stream json rpc</PackageTags>
-    <Authors>Microsoft</Authors>
-    <Owners>Microsoft, VisualStudioExtensibility</Owners>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/Microsoft/vs-streamjsonrpc</PackageProjectUrl>
-    <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">
     <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
@@ -34,18 +25,12 @@
     <XliffResource Include="MultilingualResources\*.xlf" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="..\stylecop.json" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.20" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.6" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(TargetFramework)' != 'net45' " />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <PackageReference Include="GitLink" Version="3.2.0-unstable0014" PrivateAssets="all" />
-    <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -63,10 +48,5 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" />
   <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
-  </Target>
-  <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
-    <PropertyGroup>
-      <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/vs-streamjsonrpc/$(GitCommitIdShort)/LICENSE</PackageLicenseUrl>
-    </PropertyGroup>
   </Target>
 </Project>

--- a/src/StreamJsonRpc/WebSocketMessageHandler.cs
+++ b/src/StreamJsonRpc/WebSocketMessageHandler.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WEBSOCKETS
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.IO;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+
+    /// <summary>
+    /// A message handler for the <see cref="JsonRpc"/> class
+    /// that uses <see cref="System.Net.WebSockets.WebSocket"/> as the transport.
+    /// </summary>
+    public class WebSocketMessageHandler : DelimitedMessageHandler
+    {
+        private readonly ArraySegment<byte> readBuffer;
+        private readonly byte[] writeBuffer;
+        private Decoder readDecoder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebSocketMessageHandler"/> class.
+        /// </summary>
+        /// <param name="webSocket">The <see cref="System.Net.WebSockets.WebSocket"/> used to communicate.</param>
+        /// <param name="bufferSize">
+        /// The size of the buffer to use for reading JSON-RPC messages.
+        /// Messages which exceed this size will be handled properly but may require multiple I/O operations.
+        /// </param>
+        public WebSocketMessageHandler(WebSocket webSocket, int bufferSize = 4096)
+            : base(Stream.Null, Stream.Null, Encoding.UTF8)
+        {
+            Requires.NotNull(webSocket, nameof(webSocket));
+            Requires.Range(bufferSize > 0, nameof(bufferSize));
+
+            this.WebSocket = webSocket;
+            this.readBuffer = new ArraySegment<byte>(new byte[bufferSize]);
+            this.writeBuffer = new byte[bufferSize];
+        }
+
+        /// <summary>
+        /// Gets the <see cref="System.Net.WebSockets.WebSocket"/> used to communicate.
+        /// </summary>
+        public WebSocket WebSocket { get; }
+
+        /// <inheritdoc />
+        protected async override Task<string> ReadCoreAsync(CancellationToken cancellationToken)
+        {
+            WebSocketReceiveResult result = await this.WebSocket.ReceiveAsync(this.readBuffer, cancellationToken).ConfigureAwait(false);
+            if (result.EndOfMessage)
+            {
+                // fast path: the entire message fit within the buffer.
+                return this.Encoding.GetString(this.readBuffer.Array, 0, result.Count);
+            }
+            else
+            {
+                // The message exceeds the size of our buffer.
+                if (this.readDecoder == null)
+                {
+                    this.readDecoder = this.Encoding.GetDecoder();
+                }
+
+                var jsonBuilder = new StringBuilder();
+                char[] decodedChars = new char[this.readBuffer.Array.Length];
+                void DecodeInput()
+                {
+                    int decodedCharsCount = this.readDecoder.GetChars(this.readBuffer.Array, 0, result.Count, decodedChars, 0, result.EndOfMessage);
+                    jsonBuilder.Append(decodedChars, 0, decodedCharsCount);
+                }
+
+                DecodeInput();
+                while (!result.EndOfMessage)
+                {
+                    result = await this.WebSocket.ReceiveAsync(this.readBuffer, cancellationToken).ConfigureAwait(false);
+                    DecodeInput();
+                }
+
+                return jsonBuilder.ToString();
+            }
+        }
+
+        /// <inheritdoc />
+        protected async override Task WriteCoreAsync(string content, Encoding contentEncoding, CancellationToken cancellationToken)
+        {
+            Requires.NotNull(content, nameof(content));
+            Requires.NotNull(contentEncoding, nameof(contentEncoding));
+
+            if (contentEncoding.GetByteCount(content) <= this.writeBuffer.Length)
+            {
+                // Fast path: send the whole message as a single chunk.
+                int bytesWritten = contentEncoding.GetBytes(content, 0, content.Length, this.writeBuffer, 0);
+                var bufferSegment = new ArraySegment<byte>(this.writeBuffer, 0, bytesWritten);
+                await this.WebSocket.SendAsync(bufferSegment, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var encoder = contentEncoding.GetEncoder();
+                bool completed;
+                int bytesUsed;
+                int charsLeftToConvert = content.Length;
+                while (charsLeftToConvert > 0)
+                {
+                    unsafe
+                    {
+                        fixed (byte* writeBuffer = this.writeBuffer)
+                        fixed (char* pContent = content)
+                        {
+                            char* pStart = pContent + content.Length - charsLeftToConvert;
+                            encoder.Convert(pStart, charsLeftToConvert, writeBuffer, this.writeBuffer.Length, false, out int charsUsed, out bytesUsed, out completed);
+                            charsLeftToConvert -= charsUsed;
+                        }
+                    }
+
+                    var bufferSegment = new ArraySegment<byte>(this.writeBuffer, 0, bytesUsed);
+                    await this.WebSocket.SendAsync(bufferSegment, WebSocketMessageType.Text, completed, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.WebSocket.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}
+
+#endif

--- a/src/StreamJsonRpc/WebSocketMessageHandler.cs
+++ b/src/StreamJsonRpc/WebSocketMessageHandler.cs
@@ -26,7 +26,10 @@ namespace StreamJsonRpc
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketMessageHandler"/> class.
         /// </summary>
-        /// <param name="webSocket">The <see cref="System.Net.WebSockets.WebSocket"/> used to communicate.</param>
+        /// <param name="webSocket">
+        /// The <see cref="System.Net.WebSockets.WebSocket"/> used to communicate.
+        /// This will <em>not</em> be automatically disposed of with this <see cref="WebSocketMessageHandler"/>.
+        /// </param>
         /// <param name="bufferSize">
         /// The size of the buffer to use for reading JSON-RPC messages.
         /// Messages which exceed this size will be handled properly but may require multiple I/O operations.
@@ -119,17 +122,6 @@ namespace StreamJsonRpc
                     await this.WebSocket.SendAsync(bufferSegment, WebSocketMessageType.Text, completed, cancellationToken).ConfigureAwait(false);
                 }
             }
-        }
-
-        /// <inheritdoc />
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                this.WebSocket.Dispose();
-            }
-
-            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Adds the `WebSocketMessageHandler` class to support the `WebSocket` class in .NET so this library can be used on a web server. `WebSocket` doesn't employ standard .NET `Stream` so it was necessary to add special support for it. This could have been done outside the library as well, but it seems like a reasonably common use case so this change makes it an included part of the library.

Note I take special care to handle messages that exceed the buffer size.

Tests included.