### PR TITLE
Allow JsonRpc modification while listening

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -985,6 +985,13 @@ public class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public void StartListening_ThrowsWhenAlreadyListening_WhileAllowModifications()
+    {
+        this.serverRpc.AllowModificationWhileListening = true;
+        Assert.Throws<InvalidOperationException>(() => this.serverRpc.StartListening());
+    }
+
+    [Fact]
     public async Task AddLocalRpcMethod_AllowedAfterListeningIfOptIn()
     {
         this.serverRpc.AllowModificationWhileListening = true;

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
+StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
+StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
 StreamJsonRpc.WebSocketMessageHandler
 StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.WebSocket
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void
 override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task
-StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task


### PR DESCRIPTION
Note that enabling this requires thread-safety in configuration modifications while receiving messages concurrently. This is already implemented before this change.

Closes #62 