### PR TITLE
Fix WebSocketMessageHandler's handling of closed sockets

### DIFF
--- a/src/StreamJsonRpc.Tests/DelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/DelimitedMessageHandlerTests.cs
@@ -140,6 +140,13 @@ public class DelimitedMessageHandlerTests : TestBase
         Assert.Throws<OperationCanceledException>(() => this.handler.ReadAsync(PrecanceledToken).GetAwaiter().GetResult());
     }
 
+    [Fact]
+    public async Task ReadCoreAsync_ReturnsEmptyString()
+    {
+        this.handler.MessagesToRead.Enqueue(string.Empty);
+        await Assert.ThrowsAnyAsync<Exception>(() => this.handler.ReadAsync(CancellationToken.None));
+    }
+
     /// <summary>
     /// Verifies that when both <see cref="ObjectDisposedException"/> and <see cref="OperationCanceledException"/> are appropriate
     /// when we first invoke the method, the <see cref="OperationCanceledException"/> is thrown.

--- a/src/StreamJsonRpc/DelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/DelimitedMessageHandler.cs
@@ -121,7 +121,9 @@ namespace StreamJsonRpc
                 {
                     using (await this.receivingSemaphore.EnterAsync(cts.Token).ConfigureAwait(false))
                     {
-                        return await this.ReadCoreAsync(cts.Token).ConfigureAwait(false);
+                        string result = await this.ReadCoreAsync(cts.Token).ConfigureAwait(false);
+                        Assumes.True(result != string.Empty); // null is allowed, but an empty string is not.
+                        return result;
                     }
                 }
                 catch (ObjectDisposedException)
@@ -200,7 +202,11 @@ namespace StreamJsonRpc
         /// Reads a distinct and complete message from the stream, waiting for one if necessary.
         /// </summary>
         /// <param name="cancellationToken">A token to cancel the read request.</param>
-        /// <returns>A task whose result is the received messages.</returns>
+        /// <returns>
+        /// A task whose result is the received message.
+        /// A null string indicates the stream has ended.
+        /// An empty string should never be returned.
+        /// </returns>
         protected abstract Task<string> ReadCoreAsync(CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1078,6 +1078,7 @@ namespace StreamJsonRpc
             try
             {
                 rpc = JsonRpcMessage.FromJson(json, this.MessageJsonDeserializerSettings);
+                Assumes.NotNull(rpc);
             }
             catch (JsonException exception)
             {

--- a/src/StreamJsonRpc/WebSocketMessageHandler.cs
+++ b/src/StreamJsonRpc/WebSocketMessageHandler.cs
@@ -54,6 +54,12 @@ namespace StreamJsonRpc
         protected async override Task<string> ReadCoreAsync(CancellationToken cancellationToken)
         {
             WebSocketReceiveResult result = await this.WebSocket.ReceiveAsync(this.readBuffer, cancellationToken).ConfigureAwait(false);
+            if (result.CloseStatus.HasValue)
+            {
+                await this.WebSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
+                return null;
+            }
+
             if (result.EndOfMessage)
             {
                 // fast path: the entire message fit within the buffer.


### PR DESCRIPTION
In applying the new `WebSocket` functionality of StreamJsonRpc to my project, I discovered that it throws `NullReferenceException` if the socket is closed, even if done so properly.

This fixes the `WebSocketMessageHandler` to handle the close scenario, and adds some defenses to its callers in case any other bad `DelimitedMessageHandler`-derived types similarly return empty strings.