### PR TITLE
Additional WebSocket tests and a double-disposal fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,19 +27,19 @@ test_script:
     "%userprofile%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe"
     -register:user
     -target:"%xunit20%\xunit.console.x86.exe"
-    -targetargs:"bin\StreamJsonRpc.Tests\Release\net46\StreamJsonRpc.Tests.dll -noshadow -html bin\StreamJsonRpc.Tests\Release\net46\testresults.html -xml bin\StreamJsonRpc.Tests\Release\net46\testresults.xml -appveyor -notrait TestCategory=FailsInCloudTest -nologo"
+    -targetargs:"bin\StreamJsonRpc.Tests\Release\net461\StreamJsonRpc.Tests.dll -noshadow -html bin\StreamJsonRpc.Tests\Release\net461\testresults.html -xml bin\StreamJsonRpc.Tests\Release\net461\testresults.xml -appveyor -notrait TestCategory=FailsInCloudTest -nologo"
     -returntargetcode
     -excludebyattribute:*.ExcludeFromCodeCoverage*
     -excludebyfile:*\*Designer.cs
     -filter:"+[StreamJsonRpc]*"
     -hideskipped:All
-    -output:bin\StreamJsonRpc.Tests\Release\net46\code_coverage.xml
+    -output:bin\StreamJsonRpc.Tests\Release\net461\code_coverage.xml
 
     SET PATH=C:\Python34;C:\Python34\Scripts;%PATH%
 
     pip install codecov
 
-    codecov -f "bin\StreamJsonRpc.Tests\Release\net46\code_coverage.xml"
+    codecov -f "bin\StreamJsonRpc.Tests\Release\net461\code_coverage.xml"
 
     dotnet test .\src\StreamJsonRpc.Tests\StreamJsonRpc.Tests.csproj --no-build
 artifacts:

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StreamJsonRpc.Tests.ruleset</CodeAnalysisRuleSet>
     <RootNamespace />
@@ -14,6 +14,9 @@
 
     <!-- VS2017 Test Explorer test navigation and callstack links don't work with portable PDBs yet. -->
     <DebugType>Full</DebugType>
+
+    <AspNetCoreHost Condition=" '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'net461' ">true</AspNetCoreHost>
+    <DefineConstants Condition=" '$(AspNetCoreHost)' == 'true' ">$(DefineConstants);ASPNETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
@@ -39,13 +42,17 @@
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <!-- PackageReference Include="Nerdbank.FullDuplexStream" Version="1.0.9" /-->
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.3" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.32" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(AspNetCoreHost)' == 'true' ">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\StreamJsonRpc\ReadBufferingStream.cs">

--- a/src/StreamJsonRpc.sln
+++ b/src/StreamJsonRpc.sln
@@ -9,7 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StreamJsonRpc.Tests", "Stre
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{68DDB820-140B-4178-B030-3E47C460376B}"
 	ProjectSection(SolutionItems) = preProject
-		..\appveyor.yml = ..\appveyor.yml
+		..\.appveyor.yml = ..\.appveyor.yml
+		..\.vsts-ci.yml = ..\.vsts-ci.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		nuget.config = nuget.config

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1092,7 +1092,12 @@ namespace StreamJsonRpc
             EventHandler<JsonRpcDisconnectedEventArgs> handlersToInvoke = null;
             lock (this.disconnectedEventLock)
             {
-                if (!this.hasDisconnectedEventBeenRaised)
+                if (this.hasDisconnectedEventBeenRaised)
+                {
+                    // Someone else has done all this work.
+                    return;
+                }
+                else
                 {
                     this.hasDisconnectedEventBeenRaised = true;
                     handlersToInvoke = this.DisconnectedPrivate;


### PR DESCRIPTION
This adds a real ASP.NET Core (Kestral) web server based `WebSocket` that we test with.

While in there, I discovered a couple other minor things to fix up, including double-disposal of the `DelimitedMessageHandler` and solution items for build definitions.