### PR TITLE
Add support for RPC method name transforms when adding a local target objects

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -117,6 +117,24 @@ public class Connection
 }
 ```
 
+If all your RPC method names follow a consistent transform from their C# method name equivalents,
+you can use the `AddLocalTargetObject` method to transform the method names and avoid decorating
+each one with an attribute. For example, given the same `Server` class above, but without the
+`JsonRpcMethod` attribute, you can add a `test/` prefix to the method name with:
+
+```csharp
+var serverRpc = new JsonRpc(sendingStream, receivingStream);
+serverRpc.AddLocalRpcTarget(new Server(), name => "test/" + name);
+serverRpc.StartListening();
+```
+
+Some common method name transformations are available on the `CommonMethodNameTransforms` class.
+For example:
+
+```csharp
+serverRpc.AddLocalRpcTarget(new Server(), CommonMethodNameTransforms.CamelCase);
+```
+
 ## Close stream on fatal errors
 In some cases, you may want to immediately close the streams if certain exceptions are thrown. In this case, overriding the `IsFatalException` method will give you the desired functionality. Through `IsFatalException` you can access and respond to exceptions as they are observed.
 ```csharp

--- a/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
@@ -19,10 +19,11 @@ public class CommonMethodNameTransformsTests
     [Fact]
     public void Prefix()
     {
-        Assert.Equal("Foo.Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo")("Do"));
-        Assert.Equal("Foo.Bar.Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo.Bar")("Do"));
-        Assert.Equal("Foo.Bar..Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo.Bar.")("Do"));
-        Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.AddNamespacePrefix(null));
-        Assert.Equal("Do", CommonMethodNameTransforms.AddNamespacePrefix(string.Empty)("Do"));
+        Assert.Equal("FooDo", CommonMethodNameTransforms.Prepend("Foo")("Do"));
+        Assert.Equal("Foo.Do", CommonMethodNameTransforms.Prepend("Foo.")("Do"));
+        Assert.Equal("Foo.Bar/Do", CommonMethodNameTransforms.Prepend("Foo.Bar/")("Do"));
+        Assert.Equal("Foo.Bar.Do", CommonMethodNameTransforms.Prepend("Foo.Bar.")("Do"));
+        Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.Prepend(null));
+        Assert.Equal("Do", CommonMethodNameTransforms.Prepend(string.Empty)("Do"));
     }
 }

--- a/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
@@ -12,6 +12,8 @@ public class CommonMethodNameTransformsTests
     {
         Assert.Equal("fireOne", CommonMethodNameTransforms.CamelCase("FireOne"));
         Assert.Equal("fireOne", CommonMethodNameTransforms.CamelCase("fireOne"));
+        Assert.Equal("fireOneAndTwo", CommonMethodNameTransforms.CamelCase("FIREOneAndTwo"));
+        Assert.Equal("fire", CommonMethodNameTransforms.CamelCase("FIRE"));
         Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.CamelCase(null));
         Assert.Equal(string.Empty, CommonMethodNameTransforms.CamelCase(string.Empty));
     }

--- a/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 public class CommonMethodNameTransformsTests
 {
-#if !NET452
     [Fact]
     public void CamelCase()
     {
@@ -18,7 +17,6 @@ public class CommonMethodNameTransformsTests
         Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.CamelCase(null));
         Assert.Equal(string.Empty, CommonMethodNameTransforms.CamelCase(string.Empty));
     }
-#endif
 
     [Fact]
     public void Prefix()

--- a/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 public class CommonMethodNameTransformsTests
 {
+#if !NET452
     [Fact]
     public void CamelCase()
     {
@@ -17,6 +18,7 @@ public class CommonMethodNameTransformsTests
         Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.CamelCase(null));
         Assert.Equal(string.Empty, CommonMethodNameTransforms.CamelCase(string.Empty));
     }
+#endif
 
     [Fact]
     public void Prefix()

--- a/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonMethodNameTransformsTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using Xunit;
+
+public class CommonMethodNameTransformsTests
+{
+    [Fact]
+    public void CamelCase()
+    {
+        Assert.Equal("fireOne", CommonMethodNameTransforms.CamelCase("FireOne"));
+        Assert.Equal("fireOne", CommonMethodNameTransforms.CamelCase("fireOne"));
+        Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.CamelCase(null));
+        Assert.Equal(string.Empty, CommonMethodNameTransforms.CamelCase(string.Empty));
+    }
+
+    [Fact]
+    public void Prefix()
+    {
+        Assert.Equal("Foo.Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo")("Do"));
+        Assert.Equal("Foo.Bar.Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo.Bar")("Do"));
+        Assert.Equal("Foo.Bar..Do", CommonMethodNameTransforms.AddNamespacePrefix("Foo.Bar.")("Do"));
+        Assert.Throws<ArgumentNullException>(() => CommonMethodNameTransforms.AddNamespacePrefix(null));
+        Assert.Equal("Do", CommonMethodNameTransforms.AddNamespacePrefix(string.Empty)("Do"));
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -860,7 +860,6 @@ public class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => localRpc.InvokeAsync<int>("PlusTwo", 5));
     }
 
-#if !NET452
     [Fact]
     public async Task AddLocalRpcTarget_CamelCaseTransform()
     {
@@ -876,7 +875,6 @@ public class JsonRpcTests : TestBase
         Assert.Equal("hi!", await rpc.InvokeAsync<string>("serverMethod", "hi"));
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<string>("ServerMethod", "hi"));
     }
-#endif
 
     [Fact]
     public async Task AddLocalRpcMethod_ActionWith0Args()

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -860,6 +860,7 @@ public class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => localRpc.InvokeAsync<int>("PlusTwo", 5));
     }
 
+#if !NET452
     [Fact]
     public async Task AddLocalRpcTarget_CamelCaseTransform()
     {
@@ -875,6 +876,7 @@ public class JsonRpcTests : TestBase
         Assert.Equal("hi!", await rpc.InvokeAsync<string>("serverMethod", "hi"));
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<string>("ServerMethod", "hi"));
     }
+#endif
 
     [Fact]
     public async Task AddLocalRpcMethod_ActionWith0Args()

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -851,7 +851,7 @@ public class JsonRpcTests : TestBase
         var serverRpc = new JsonRpc(streams.Item1, streams.Item1);
         serverRpc.AddLocalRpcTarget(new Server());
         serverRpc.AddLocalRpcTarget(new AdditionalServerTargetOne(), n => "one." + n);
-        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), CommonMethodNameTransforms.AddNamespacePrefix("two"));
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), CommonMethodNameTransforms.Prepend("two."));
         serverRpc.StartListening();
 
         Assert.Equal("hi!", await localRpc.InvokeAsync<string>("ServerMethod", "hi"));

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -851,7 +851,7 @@ public class JsonRpcTests : TestBase
         var serverRpc = new JsonRpc(streams.Item1, streams.Item1);
         serverRpc.AddLocalRpcTarget(new Server());
         serverRpc.AddLocalRpcTarget(new AdditionalServerTargetOne(), n => "one." + n);
-        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), n => "two." + n);
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), CommonMethodNameTransforms.AddNamespacePrefix("two"));
         serverRpc.StartListening();
 
         Assert.Equal("hi!", await localRpc.InvokeAsync<string>("ServerMethod", "hi"));
@@ -869,7 +869,7 @@ public class JsonRpcTests : TestBase
         // Now set up a server with a camel case transform and verify that it works (and that the original casing doesn't).
         var streams = FullDuplexStream.CreateStreams();
         var rpc = new JsonRpc(streams.Item1, streams.Item2);
-        rpc.AddLocalRpcTarget(new Server(), n => n.Substring(0, 1).ToLowerInvariant() + n.Substring(1));
+        rpc.AddLocalRpcTarget(new Server(), CommonMethodNameTransforms.CamelCase);
         rpc.StartListening();
 
         Assert.Equal("hi!", await rpc.InvokeAsync<string>("serverMethod", "hi"));

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -12,7 +12,7 @@ namespace StreamJsonRpc
     public static class CommonMethodNameTransforms
     {
         /// <summary>
-        /// Gets a function that converts a given string's first character to lowercase.
+        /// Gets a function that converts a given string from PascalCase to camelCase.
         /// </summary>
         public static Func<string, string> CamelCase
         {
@@ -30,7 +30,45 @@ namespace StreamJsonRpc
                         return string.Empty;
                     }
 
-                    return name.Substring(0, 1).ToLowerInvariant() + name.Substring(1);
+                    // The remainder of this function is taken from https://github.com/JamesNK/Newtonsoft.Json/blob/94a4dbf7fe9aca9ce5ee1039dc44dfd8353bf17c/Src/Newtonsoft.Json/Utilities/StringUtils.cs#L151-L187
+                    // with a few alterations.
+                    if (!char.IsUpper(name[0]))
+                    {
+                        return name;
+                    }
+
+                    char[] chars = name.ToCharArray();
+
+                    for (int i = 0; i < chars.Length; i++)
+                    {
+                        if (i == 1 && !char.IsUpper(chars[i]))
+                        {
+                            break;
+                        }
+
+                        bool hasNext = i + 1 < chars.Length;
+                        if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                        {
+                            // if the next character is a space, which is not considered uppercase
+                            // (otherwise we wouldn't be here...)
+                            // we want to ensure that the following:
+                            // 'FOO bar' is rewritten as 'foo bar', and not as 'foO bar'
+                            // The code was written in such a way that the first word in uppercase
+                            // ends when if finds an uppercase letter followed by a lowercase letter.
+                            // now a ' ' (space, (char)32) is considered not upper
+                            // but in that case we still want our current character to become lowercase
+                            if (char.IsSeparator(chars[i + 1]))
+                            {
+                                chars[i] = char.ToLowerInvariant(chars[i]);
+                            }
+
+                            break;
+                        }
+
+                        chars[i] = char.ToLowerInvariant(chars[i]);
+                    }
+
+                    return new string(chars);
                 };
             }
         }

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -5,12 +5,19 @@ namespace StreamJsonRpc
 {
     using System;
     using Microsoft;
+    using Newtonsoft.Json.Serialization;
 
     /// <summary>
     /// Common RPC method transform functions that may be supplied to <see cref="JsonRpc.AddLocalRpcTarget(object, System.Func{string, string})"/>.
     /// </summary>
     public static class CommonMethodNameTransforms
     {
+#if !NET45
+        /// <summary>
+        /// The Newtonsoft.Json camel casing converter.
+        /// </summary>
+        private static readonly NamingStrategy CamelCaseStrategy = new CamelCaseNamingStrategy();
+
         /// <summary>
         /// Gets a function that converts a given string from PascalCase to camelCase.
         /// </summary>
@@ -30,48 +37,11 @@ namespace StreamJsonRpc
                         return string.Empty;
                     }
 
-                    // The remainder of this function is taken from https://github.com/JamesNK/Newtonsoft.Json/blob/94a4dbf7fe9aca9ce5ee1039dc44dfd8353bf17c/Src/Newtonsoft.Json/Utilities/StringUtils.cs#L151-L187
-                    // with a few alterations.
-                    if (!char.IsUpper(name[0]))
-                    {
-                        return name;
-                    }
-
-                    char[] chars = name.ToCharArray();
-
-                    for (int i = 0; i < chars.Length; i++)
-                    {
-                        if (i == 1 && !char.IsUpper(chars[i]))
-                        {
-                            break;
-                        }
-
-                        bool hasNext = i + 1 < chars.Length;
-                        if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
-                        {
-                            // if the next character is a space, which is not considered uppercase
-                            // (otherwise we wouldn't be here...)
-                            // we want to ensure that the following:
-                            // 'FOO bar' is rewritten as 'foo bar', and not as 'foO bar'
-                            // The code was written in such a way that the first word in uppercase
-                            // ends when if finds an uppercase letter followed by a lowercase letter.
-                            // now a ' ' (space, (char)32) is considered not upper
-                            // but in that case we still want our current character to become lowercase
-                            if (char.IsSeparator(chars[i + 1]))
-                            {
-                                chars[i] = char.ToLowerInvariant(chars[i]);
-                            }
-
-                            break;
-                        }
-
-                        chars[i] = char.ToLowerInvariant(chars[i]);
-                    }
-
-                    return new string(chars);
+                    return CamelCaseStrategy.GetPropertyName(name, hasSpecifiedName: false);
                 };
             }
         }
+#endif
 
         /// <summary>
         /// Gets a function that prepends a particular string in front of any RPC method name.

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -12,7 +12,6 @@ namespace StreamJsonRpc
     /// </summary>
     public static class CommonMethodNameTransforms
     {
-#if !NET45
         /// <summary>
         /// The Newtonsoft.Json camel casing converter.
         /// </summary>
@@ -41,7 +40,6 @@ namespace StreamJsonRpc
                 };
             }
         }
-#endif
 
         /// <summary>
         /// Gets a function that prepends a particular string in front of any RPC method name.

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using Microsoft;
+
+    /// <summary>
+    /// Common RPC method transform functions that may be supplied to <see cref="JsonRpc.AddLocalRpcTarget(object, System.Func{string, string})"/>.
+    /// </summary>
+    public static class CommonMethodNameTransforms
+    {
+        /// <summary>
+        /// Gets a function that converts a given string's first character to lowercase.
+        /// </summary>
+        public static Func<string, string> CamelCase
+        {
+            get
+            {
+                return name =>
+                {
+                    if (name == null)
+                    {
+                        throw new ArgumentNullException();
+                    }
+
+                    if (name.Length == 0)
+                    {
+                        return string.Empty;
+                    }
+
+                    return name.Substring(0, 1).ToLowerInvariant() + name.Substring(1);
+                };
+            }
+        }
+
+        /// <summary>
+        /// Gets a function that prepends a particular namespace and a period in front of any RPC method name.
+        /// </summary>
+        /// <param name="ns">
+        /// The namespace to prefix to a method name, not including the trailing period.
+        /// This value must not be null.
+        /// When this value is the empty string, no transformation is performed by the returned function.
+        /// </param>
+        /// <returns>The transform function.</returns>
+        public static Func<string, string> AddNamespacePrefix(string ns)
+        {
+            Requires.NotNull(ns, nameof(ns));
+
+            if (ns.Length == 0)
+            {
+                return name => name;
+            }
+
+            return name => ns + "." + name;
+        }
+    }
+}

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -36,24 +36,24 @@ namespace StreamJsonRpc
         }
 
         /// <summary>
-        /// Gets a function that prepends a particular namespace and a period in front of any RPC method name.
+        /// Gets a function that prepends a particular string in front of any RPC method name.
         /// </summary>
-        /// <param name="ns">
-        /// The namespace to prefix to a method name, not including the trailing period.
+        /// <param name="prefix">
+        /// The prefix to prepend to any method name.
         /// This value must not be null.
         /// When this value is the empty string, no transformation is performed by the returned function.
         /// </param>
         /// <returns>The transform function.</returns>
-        public static Func<string, string> AddNamespacePrefix(string ns)
+        public static Func<string, string> Prepend(string prefix)
         {
-            Requires.NotNull(ns, nameof(ns));
+            Requires.NotNull(prefix, nameof(prefix));
 
-            if (ns.Length == 0)
+            if (prefix.Length == 0)
             {
                 return name => name;
             }
 
-            return name => ns + "." + name;
+            return name => prefix + name;
         }
     }
 }

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+StreamJsonRpc.CommonMethodNameTransforms
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
@@ -12,4 +13,6 @@ StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.Web
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void
 override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+static StreamJsonRpc.CommonMethodNameTransforms.AddNamespacePrefix(string ns) -> System.Func<string, string>
+static StreamJsonRpc.CommonMethodNameTransforms.CamelCase.get -> System.Func<string, string>
 virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
+StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, System.Func<string, string> methodNameTransform) -> void
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -13,6 +13,6 @@ StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.Web
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void
 override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
 override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-static StreamJsonRpc.CommonMethodNameTransforms.AddNamespacePrefix(string ns) -> System.Func<string, string>
 static StreamJsonRpc.CommonMethodNameTransforms.CamelCase.get -> System.Func<string, string>
+static StreamJsonRpc.CommonMethodNameTransforms.Prepend(string prefix) -> System.Func<string, string>
 virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -30,8 +30,7 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.20" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="6.0.6" Condition=" '$(TargetFramework)' == 'net45' " />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(TargetFramework)' != 'net45' " />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
This allows for patterns already in use by the language server protocol and others where multiple target objects are added to the server side, with logical boundaries between these objects observable from the client by virtue of a 'namespace' being added to each method. Currently this is achievable by adding `JsonRpcMethodAttribute` to each method to change its name. This enhancement eliminates the need for manually transforming each individual method name.

It also gives the ability to do other interesting RPC method name transforms such as converting the typical PascalCase C# methods to be exposed with camelCase.

The method name transform is exposed as a `Func<string, string>` for maximum flexibility. But I add a `CommonMethodNameTransforms` static class with these two use cases (namespaced methods and camelCase) predefined as reusable functions.