### PR TITLE
Fix test method AddLocalRpcTarget_NoTargetContainsRequestedMethod

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -655,14 +655,15 @@ public class JsonRpcTests : TestBase
     [Fact]
     public async Task AddLocalRpcTarget_NoTargetContainsRequestedMethod()
     {
-        var streams = Nerdbank.FullDuplexStream.CreateStreams();
-        var rpc = new JsonRpc(streams.Item1, streams.Item2);
-        rpc.AddLocalRpcTarget(new Server());
-        rpc.AddLocalRpcTarget(new AdditionalServerTargetOne());
-        rpc.AddLocalRpcTarget(new AdditionalServerTargetTwo());
-        rpc.StartListening();
+        var streams = FullDuplexStream.CreateStreams();
+        var localRpc = JsonRpc.Attach(streams.Item2);
+        var serverRpc = new JsonRpc(streams.Item1, streams.Item1);
+        serverRpc.AddLocalRpcTarget(new Server());
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetOne());
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo());
+        serverRpc.StartListening();
 
-        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync("PlusThree", 1));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => localRpc.InvokeAsync("PlusThree", 1));
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
This wasn't actually testing what it claimed to be, since it was sending the request to the same JsonRpc instance that was hosting the local objects. To actually test whether it will bind against a server object, the request must be sent from the *client* JsonRpc instance.