### PR TITLE
Pin nuget.exe tool version to 4.6.2

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -25,6 +25,11 @@ steps:
       del /s /q "%AppData%\tsd-cache"
   displayName: Purge package caches
   condition: and(succeeded(), ne(variables['Hosted'], 'true'))
+  
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: 4.6.2
+  displayName: Pin nuget.exe version
 
 - task: MicroBuildIBCMergePlugin@0
   inputs:


### PR DESCRIPTION
This brings VSTS up from its 4.1.0 default and should fix the package restore failure we're seeing.