### PR TITLE
Respect JsonRpcMethodAttribute appearing on interface methods

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -48,7 +48,7 @@ public class JsonRpcTests : TestBase
     private interface IServer
     {
         [JsonRpcMethod("AnotherName")]
-        string AManBy(string name);
+        string ARoseBy(string name);
 
         [JsonRpcMethod("IFaceNameForMethod")]
         int AddWithNameSubstitution(int a, int b);
@@ -1187,7 +1187,7 @@ public class JsonRpcTests : TestBase
     public async Task ServerRespondsWithMethodRenamedByInterfaceAttribute()
     {
         Assert.Equal("ANDREW", await this.clientRpc.InvokeAsync<string>("AnotherName", "andrew"));
-        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(IServer.AManBy), "andrew"));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(IServer.ARoseBy), "andrew"));
     }
 #endif
 
@@ -1490,7 +1490,7 @@ public class JsonRpcTests : TestBase
             i = i + 1;
         }
 
-        public string AManBy(string name) => name.ToUpperInvariant();
+        public string ARoseBy(string name) => name.ToUpperInvariant();
 
         [JsonRpcMethod("ClassNameForMethod")]
         public int AddWithNameSubstitution(int a, int b) => a + b;

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -45,6 +45,15 @@ public class JsonRpcTests : TestBase
         this.clientRpc = JsonRpc.Attach(this.clientStream);
     }
 
+    private interface IServer
+    {
+        [JsonRpcMethod("AnotherName")]
+        string AManBy(string name);
+
+        [JsonRpcMethod("IFaceNameForMethod")]
+        int AddWithNameSubstitution(int a, int b);
+    }
+
     [Fact]
     public void Attach_Null_Throws()
     {
@@ -1173,6 +1182,23 @@ public class JsonRpcTests : TestBase
         await Task.WhenAll(invocation1, invocation2);
     }
 
+#if NET452 || NET461 || NETCOREAPP2_0
+    [Fact]
+    public async Task ServerRespondsWithMethodRenamedByInterfaceAttribute()
+    {
+        Assert.Equal("ANDREW", await this.clientRpc.InvokeAsync<string>("AnotherName", "andrew"));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(IServer.AManBy), "andrew"));
+    }
+#endif
+
+    [Fact]
+    public async Task ClassDefinedNameOverridesInterfaceDefinedName()
+    {
+        Assert.Equal(3, await this.clientRpc.InvokeAsync<int>("ClassNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync("IFaceNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(IServer.AddWithNameSubstitution), "andrew"));
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -1224,7 +1250,7 @@ public class JsonRpcTests : TestBase
         public string RedeclaredBaseMethod() => "base";
     }
 
-    public class Server : BaseClass
+    public class Server : BaseClass, IServer
     {
         internal const string ThrowAfterCancellationMessage = "Throw after cancellation";
 
@@ -1463,6 +1489,11 @@ public class JsonRpcTests : TestBase
         {
             i = i + 1;
         }
+
+        public string AManBy(string name) => name.ToUpperInvariant();
+
+        [JsonRpcMethod("ClassNameForMethod")]
+        public int AddWithNameSubstitution(int a, int b) => a + b;
 
         internal void InternalMethod()
         {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -846,12 +846,14 @@ namespace StreamJsonRpc
             var requestMethodToDelegateMap = new Dictionary<string, List<MethodSignatureAndTarget>>(StringComparer.Ordinal);
             var candidateAliases = new Dictionary<string, string>(StringComparer.Ordinal);
 
+            var mapping = new MethodNameMap(target.GetType().GetTypeInfo());
+
             for (TypeInfo t = target.GetType().GetTypeInfo(); t != null && t != typeof(object).GetTypeInfo(); t = t.BaseType?.GetTypeInfo())
             {
                 foreach (MethodInfo method in t.DeclaredMethods)
                 {
-                    var attribute = (JsonRpcMethodAttribute)method.GetCustomAttribute(typeof(JsonRpcMethodAttribute));
-                    var requestName = attribute?.Name ?? method.Name;
+                    var attribute = mapping.FindAttribute(method);
+                    var requestName = mapping.GetRpcMethodName(method);
 
                     if (!requestMethodToDelegateMap.TryGetValue(requestName, out var methodTargetList))
                     {
@@ -1387,6 +1389,58 @@ namespace StreamJsonRpc
         private void ThrowIfConfigurationLocked()
         {
             Verify.Operation(!this.startedListening || this.AllowModificationWhileListening, Resources.MustNotBeListening);
+        }
+
+        internal class MethodNameMap
+        {
+            private readonly List<InterfaceMapping> interfaceMaps;
+
+            internal MethodNameMap(TypeInfo typeInfo)
+            {
+                Requires.NotNull(typeInfo, nameof(typeInfo));
+#if NET45 || NET46 || NETSTANDARD2_0
+                this.interfaceMaps = typeInfo.ImplementedInterfaces.Select(i => typeInfo.GetInterfaceMap(i)).ToList();
+#else
+                this.interfaceMaps = new List<InterfaceMapping>();
+#endif
+            }
+
+            internal string GetRpcMethodName(MethodInfo method)
+            {
+                Requires.NotNull(method, nameof(method));
+
+                return this.FindAttribute(method)?.Name ?? method.Name;
+            }
+
+            internal JsonRpcMethodAttribute FindAttribute(MethodInfo method)
+            {
+                Requires.NotNull(method, nameof(method));
+
+                // Get the custom attribute, which may appear on the method itself or the interface definition of the method where applicable.
+                var attribute = (JsonRpcMethodAttribute)method.GetCustomAttribute(typeof(JsonRpcMethodAttribute));
+                if (attribute == null)
+                {
+                    attribute = (JsonRpcMethodAttribute)this.FindMethodOnInterface(method)?.GetCustomAttribute(typeof(JsonRpcMethodAttribute));
+                }
+
+                return attribute;
+            }
+
+            private MethodInfo FindMethodOnInterface(MethodInfo methodImpl)
+            {
+                Requires.NotNull(methodImpl, nameof(methodImpl));
+
+                foreach (var map in this.interfaceMaps)
+                {
+                    int methodIndex = Array.IndexOf(map.TargetMethods, methodImpl);
+                    if (methodIndex >= 0)
+                    {
+                        return map.InterfaceMethods[methodIndex];
+                    }
+                }
+
+                return null;
+            }
         }
 
         private class OutstandingCallData

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -852,7 +852,6 @@ namespace StreamJsonRpc
             {
                 foreach (MethodInfo method in t.DeclaredMethods)
                 {
-                    var attribute = mapping.FindAttribute(method);
                     var requestName = mapping.GetRpcMethodName(method);
 
                     if (!requestMethodToDelegateMap.TryGetValue(requestName, out var methodTargetList))
@@ -898,6 +897,7 @@ namespace StreamJsonRpc
 
                     // If no explicit attribute has been applied, and the method ends with Async,
                     // register a request method name that does not include Async as well.
+                    var attribute = mapping.FindAttribute(method);
                     if (attribute == null && method.Name.EndsWith(ImpliedMethodNameAsyncSuffix, StringComparison.Ordinal))
                     {
                         string nonAsyncMethodName = method.Name.Substring(0, method.Name.Length - ImpliedMethodNameAsyncSuffix.Length);


### PR DESCRIPTION
Previous to this change, a target object passed to StreamJsonRpc might look like this:

```cs
class Server
{
    public void Foo() { }

    [JsonRpcMethod("bar/soap")]
    public void Whatever() { }
}
```

The `JsonRpcMethodAttribute` that appears changes the name of the method over RPC from `Whatever` to `bar/soap` (which isn't a legal CLR name). 

But as we look at proxy generation based on interface, we find that these special name-changing attributes need to be able to appear on interfaces as well so that the client proxy can generate code that invokes the method by the proper name (`bar/soap`, in this case). So with this change, you can now do this:

```cs
interface IServer
{
    [JsonRpcMethod("bar/soap")]
    void Whatever();
}

class Server : IServer
{
    public void Foo() { }

    public void Whatever() { }
}
```

The `Server` object is still passed to the `JsonRpc` class as the target object and both methods are invokable, but the name change is inherited from the interface that `Whatever` happens to implement. But soon, when we can generate client proxies based on `IServer`, the generated client will know to invoke `bar/soap` instead of `Whatever`.