### PR TITLE
Add support for target object events

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -859,8 +859,8 @@ public class JsonRpcTests : TestBase
         var localRpc = JsonRpc.Attach(streams.Item2);
         var serverRpc = new JsonRpc(streams.Item1, streams.Item1);
         serverRpc.AddLocalRpcTarget(new Server());
-        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetOne(), n => "one." + n);
-        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), CommonMethodNameTransforms.Prepend("two."));
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetOne(), new JsonRpcTargetOptions { MethodNameTransform = n => "one." + n });
+        serverRpc.AddLocalRpcTarget(new AdditionalServerTargetTwo(), new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.Prepend("two.") });
         serverRpc.StartListening();
 
         Assert.Equal("hi!", await localRpc.InvokeAsync<string>("ServerMethod", "hi"));
@@ -878,7 +878,7 @@ public class JsonRpcTests : TestBase
         // Now set up a server with a camel case transform and verify that it works (and that the original casing doesn't).
         var streams = FullDuplexStream.CreateStreams();
         var rpc = new JsonRpc(streams.Item1, streams.Item2);
-        rpc.AddLocalRpcTarget(new Server(), CommonMethodNameTransforms.CamelCase);
+        rpc.AddLocalRpcTarget(new Server(), new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase });
         rpc.StartListening();
 
         Assert.Equal("hi!", await rpc.InvokeAsync<string>("serverMethod", "hi"));

--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -77,6 +77,13 @@ public class TargetObjectEventsTests : TestBase
         Assert.Null(this.server.ServerEventWithCustomArgsAccessor);
     }
 
+    [Fact]
+    public void IncompatibleEventHandlerType()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        Assert.Throws<NotSupportedException>(() => JsonRpc.Attach(streams.Item1, new ServerWithIncompatibleEvents()));
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -122,6 +129,15 @@ public class TargetObjectEventsTests : TestBase
         protected virtual void OnServerEvent(EventArgs args) => this.ServerEvent?.Invoke(this, args);
 
         protected virtual void OnServerEventWithCustomArgs(CustomEventArgs args) => this.ServerEventWithCustomArgs?.Invoke(this, args);
+    }
+
+    private class ServerWithIncompatibleEvents
+    {
+        public delegate int MyDelegate(double d);
+
+#pragma warning disable CS0067 // Unused member (It's here for reflection to discover)
+        public event MyDelegate MyEvent;
+#pragma warning restore CS0067
     }
 
     private class CustomEventArgs : EventArgs

--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -37,28 +37,95 @@ public class TargetObjectEventsTests : TestBase
     [Fact]
     public async Task ServerEventRaisesCallback()
     {
-        var evt = new AsyncManualResetEvent();
-        this.client.ServerEventRaised = (sender, args) => evt.Set();
-        await this.clientRpc.InvokeAsync(nameof(Server.TriggerEvent));
-        await evt.WaitAsync().WithCancellation(this.TimeoutToken);
+        var tcs = new TaskCompletionSource<EventArgs>();
+        this.client.ServerEventRaised = (sender, args) => tcs.SetResult(args);
+        this.server.TriggerEvent(EventArgs.Empty);
+        var actualArgs = await tcs.Task.WithCancellation(this.TimeoutToken);
+        Assert.NotNull(actualArgs);
+    }
+
+    [Fact]
+    public async Task GenericServerEventRaisesCallback()
+    {
+        var tcs = new TaskCompletionSource<CustomEventArgs>();
+        var expectedArgs = new CustomEventArgs { Seeds = 5 };
+        this.client.GenericServerEventRaised = (sender, args) => tcs.SetResult(args);
+        this.server.TriggerGenericEvent(expectedArgs);
+        var actualArgs = await tcs.Task.WithCancellation(this.TimeoutToken);
+        Assert.Equal(expectedArgs.Seeds, actualArgs.Seeds);
+    }
+
+    /// <summary>
+    /// Verifies that events on target objects are subscribed to, and unsubscribed after the JsonRpc instance is disposed of.
+    /// </summary>
+    [Fact]
+    public void ServerEventSubscriptionLifetime()
+    {
+        Assert.NotNull(this.server.ServerEventAccessor);
+        this.serverRpc.Dispose();
+        Assert.Null(this.server.ServerEventAccessor);
+    }
+
+    /// <summary>
+    /// Verifies that generic event handler events on target objects are subscribed to, and unsubscribed after the JsonRpc instance is disposed of.
+    /// </summary>
+    [Fact]
+    public void GenericServerEventSubscriptionLifetime()
+    {
+        Assert.NotNull(this.server.ServerEventWithCustomArgsAccessor);
+        this.serverRpc.Dispose();
+        Assert.Null(this.server.ServerEventWithCustomArgsAccessor);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.serverRpc.Dispose();
+            this.clientRpc.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     private class Client
     {
         internal Action<object, EventArgs> ServerEventRaised { get; set; }
 
+        internal Action<object, CustomEventArgs> GenericServerEventRaised { get; set; }
+
         public void ServerEvent(object sender, EventArgs args) => this.ServerEventRaised?.Invoke(sender, args);
+
+        public void ServerEventWithCustomArgs(object sender, CustomEventArgs args) => this.GenericServerEventRaised?.Invoke(sender, args);
     }
 
     private class Server
     {
         public event EventHandler ServerEvent;
 
+        public event EventHandler<CustomEventArgs> ServerEventWithCustomArgs;
+
+        internal EventHandler ServerEventAccessor => this.ServerEvent;
+
+        internal EventHandler<CustomEventArgs> ServerEventWithCustomArgsAccessor => this.ServerEventWithCustomArgs;
+
         public void TriggerEvent(EventArgs args)
         {
             this.OnServerEvent(args);
         }
 
+        public void TriggerGenericEvent(CustomEventArgs args)
+        {
+            this.OnServerEventWithCustomArgs(args);
+        }
+
         protected virtual void OnServerEvent(EventArgs args) => this.ServerEvent?.Invoke(this, args);
+
+        protected virtual void OnServerEventWithCustomArgs(CustomEventArgs args) => this.ServerEventWithCustomArgs?.Invoke(this, args);
+    }
+
+    private class CustomEventArgs : EventArgs
+    {
+        public int Seeds { get; set; }
     }
 }

--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class TargetObjectEventsTests : TestBase
+{
+    private readonly Server server;
+    private readonly Client client;
+
+    private FullDuplexStream serverStream;
+    private JsonRpc serverRpc;
+
+    private FullDuplexStream clientStream;
+    private JsonRpc clientRpc;
+
+    public TargetObjectEventsTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.server = new Server();
+        this.client = new Client();
+
+        var streams = FullDuplexStream.CreateStreams();
+        this.serverStream = streams.Item1;
+        this.clientStream = streams.Item2;
+
+        this.serverRpc = JsonRpc.Attach(this.serverStream, this.server);
+        this.clientRpc = JsonRpc.Attach(this.clientStream, this.client);
+    }
+
+    [Fact]
+    public async Task ServerEventRaisesCallback()
+    {
+        var evt = new AsyncManualResetEvent();
+        this.client.ServerEventRaised = (sender, args) => evt.Set();
+        await this.clientRpc.InvokeAsync(nameof(Server.TriggerEvent));
+        await evt.WaitAsync().WithCancellation(this.TimeoutToken);
+    }
+
+    private class Client
+    {
+        internal Action<object, EventArgs> ServerEventRaised { get; set; }
+
+        public void ServerEvent(object sender, EventArgs args) => this.ServerEventRaised?.Invoke(sender, args);
+    }
+
+    private class Server
+    {
+        public event EventHandler ServerEvent;
+
+        public void TriggerEvent(EventArgs args)
+        {
+            this.OnServerEvent(args);
+        }
+
+        protected virtual void OnServerEvent(EventArgs args) => this.ServerEvent?.Invoke(this, args);
+    }
+}

--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -34,6 +34,28 @@ public class TargetObjectEventsTests : TestBase
         this.clientRpc = JsonRpc.Attach(this.clientStream, this.client);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ServerEventRespondsToOptions(bool registerOn)
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        var rpc = new JsonRpc(streams.Item1, streams.Item1);
+        var options = new JsonRpcTargetOptions { NotifyClientOfEvents = registerOn };
+        var server = new Server();
+        rpc.AddLocalRpcTarget(server, options);
+        if (registerOn)
+        {
+            Assert.NotNull(server.ServerEventAccessor);
+            Assert.NotNull(server.ServerEventWithCustomArgsAccessor);
+        }
+        else
+        {
+            Assert.Null(server.ServerEventAccessor);
+            Assert.Null(server.ServerEventWithCustomArgsAccessor);
+        }
+    }
+
     [Fact]
     public async Task ServerEventRaisesCallback()
     {

--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -8,7 +8,8 @@ namespace StreamJsonRpc
     using Newtonsoft.Json.Serialization;
 
     /// <summary>
-    /// Common RPC method transform functions that may be supplied to <see cref="JsonRpc.AddLocalRpcTarget(object, System.Func{string, string})"/>.
+    /// Common RPC method transform functions that may be supplied to <see cref="JsonRpc.AddLocalRpcTarget(object, JsonRpcTargetOptions)"/>
+    /// by way of <see cref="JsonRpcTargetOptions.MethodNameTransform"/>.
     /// </summary>
     public static class CommonMethodNameTransforms
     {

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+
+    /// <summary>
+    /// Options that may customize how a target object is added to a <see cref="JsonRpc"/> instance.
+    /// </summary>
+    public class JsonRpcTargetOptions
+    {
+        /// <summary>
+        /// Gets or sets a function that takes the CLR method name and returns the RPC method name.
+        /// This method is useful for adding prefixes to all methods, or making them camelCased.
+        /// </summary>
+        public Func<string, string> MethodNameTransform { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether events raised on the target object
+        /// should be relayed to the client via a JSON-RPC notify message.
+        /// </summary>
+        /// <value>The default is <c>true</c>.</value>
+        public bool NotifyClientOfEvents { get; set; } = true;
+
+        /// <summary>
+        /// Gets an instance with default properties.
+        /// </summary>
+        /// <remarks>
+        /// Callers should *not* mutate properties on this instance since it is shared.
+        /// </remarks>
+        internal static JsonRpcTargetOptions Default { get; } = new JsonRpcTargetOptions();
+    }
+}

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -2,12 +2,18 @@ StreamJsonRpc.CommonMethodNameTransforms
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Delegate handler) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(string rpcMethodName, System.Reflection.MethodInfo handler, object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
-StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, System.Func<string, string> methodNameTransform) -> void
+StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, StreamJsonRpc.JsonRpcTargetOptions options) -> void
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
 StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.SynchronizationContext
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void
+StreamJsonRpc.JsonRpcTargetOptions
+StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions() -> void
+StreamJsonRpc.JsonRpcTargetOptions.MethodNameTransform.get -> System.Func<string, string>
+StreamJsonRpc.JsonRpcTargetOptions.MethodNameTransform.set -> void
+StreamJsonRpc.JsonRpcTargetOptions.NotifyClientOfEvents.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.NotifyClientOfEvents.set -> void
 StreamJsonRpc.WebSocketMessageHandler
 StreamJsonRpc.WebSocketMessageHandler.WebSocket.get -> System.Net.WebSockets.WebSocket
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, int bufferSize = 4096) -> void


### PR DESCRIPTION
If the target object passed to `JsonRpc` defines events, event handlers will be added to these events and when raised, will automatically propagate to the remote party (i.e. the client) as JSON-RPC "notify" messages.

**Policy:** This is on by default. But users can opt out. Is that the right direction? Might there be server objects with events used for something else already, such that forwarding these events to the client (with args) may present a bug or security risk? I suspect the risk here is low, and I'd like for the feature to be on by default if possible.

As part of this I changed the way `AddLocalRpcTarget` accepts options so that instead of one option per parameter, it takes a single options object so that in the future, options like the opt-out and method name transform can be added to the object without having to add method overloads each time.