### PR TITLE
Remove first (null) argument from notify events

### DIFF
--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -60,7 +60,7 @@ public class TargetObjectEventsTests : TestBase
     public async Task ServerEventRaisesCallback()
     {
         var tcs = new TaskCompletionSource<EventArgs>();
-        this.client.ServerEventRaised = (sender, args) => tcs.SetResult(args);
+        this.client.ServerEventRaised = args => tcs.SetResult(args);
         this.server.TriggerEvent(EventArgs.Empty);
         var actualArgs = await tcs.Task.WithCancellation(this.TimeoutToken);
         Assert.NotNull(actualArgs);
@@ -71,7 +71,7 @@ public class TargetObjectEventsTests : TestBase
     {
         var tcs = new TaskCompletionSource<CustomEventArgs>();
         var expectedArgs = new CustomEventArgs { Seeds = 5 };
-        this.client.GenericServerEventRaised = (sender, args) => tcs.SetResult(args);
+        this.client.GenericServerEventRaised = args => tcs.SetResult(args);
         this.server.TriggerGenericEvent(expectedArgs);
         var actualArgs = await tcs.Task.WithCancellation(this.TimeoutToken);
         Assert.Equal(expectedArgs.Seeds, actualArgs.Seeds);
@@ -119,13 +119,13 @@ public class TargetObjectEventsTests : TestBase
 
     private class Client
     {
-        internal Action<object, EventArgs> ServerEventRaised { get; set; }
+        internal Action<EventArgs> ServerEventRaised { get; set; }
 
-        internal Action<object, CustomEventArgs> GenericServerEventRaised { get; set; }
+        internal Action<CustomEventArgs> GenericServerEventRaised { get; set; }
 
-        public void ServerEvent(object sender, EventArgs args) => this.ServerEventRaised?.Invoke(sender, args);
+        public void ServerEvent(EventArgs args) => this.ServerEventRaised?.Invoke(args);
 
-        public void ServerEventWithCustomArgs(object sender, CustomEventArgs args) => this.GenericServerEventRaised?.Invoke(sender, args);
+        public void ServerEventWithCustomArgs(CustomEventArgs args) => this.GenericServerEventRaised?.Invoke(args);
     }
 
     private class Server

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1523,7 +1523,7 @@ namespace StreamJsonRpc
             private void OnEventRaised(object sender, EventArgs args)
             {
                 // We use null for the sender because we don't want to try to serialize the target object to the remote party.
-                this.jsonRpc.NotifyAsync(this.eventInfo.Name, new object[] { null, args });
+                this.jsonRpc.NotifyAsync(this.eventInfo.Name, new object[] { args });
             }
         }
     }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1522,7 +1522,6 @@ namespace StreamJsonRpc
 
             private void OnEventRaised(object sender, EventArgs args)
             {
-                // We use null for the sender because we don't want to try to serialize the target object to the remote party.
                 this.jsonRpc.NotifyAsync(this.eventInfo.Name, new object[] { args });
             }
         }


### PR DESCRIPTION
This is a follow-up to #105 based on my conversations with @jasongin on that PR. It removes the static "null" argument from the notify messages that propagate a raised event from the local target object to the remote party.