### PR TITLE
Add JsonRpc.Attach<T> client proxy generating method

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -172,6 +172,14 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    [Trait("NegativeTest", "")]
+    public void GenerateProxyFromClassNotSuppported()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<EmptyClass>(this.clientStream));
+        this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
     public async Task CallMethod_CancellationToken_int()
     {
         await this.clientRpc.HeavyWorkAsync(CancellationToken.None);
@@ -272,6 +280,10 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.server.OnItHappened(EventArgs.Empty);
         await Assert.ThrowsAsync<TimeoutException>(() => tcs.Task.WithTimeout(ExpectedTimeout));
         Assert.False(tcs.Task.IsCompleted);
+    }
+
+    public class EmptyClass
+    {
     }
 
     public class CustomEventArgs : EventArgs

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -54,7 +54,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         Task<int> HeavyWorkAsync(int param1, CancellationToken cancellationToken);
 
         [JsonRpcMethod("AnotherName")]
-        Task<string> AManByAsync(string name);
+        Task<string> ARoseByAsync(string name);
     }
 
     public interface IServer2
@@ -242,7 +242,7 @@ public class JsonRpcProxyGenerationTests : TestBase
     [Fact]
     public async Task RPCMethodNameSubstitution()
     {
-        Assert.Equal("ANDREW", await this.clientRpc.AManByAsync("andrew"));
+        Assert.Equal("ANDREW", await this.clientRpc.ARoseByAsync("andrew"));
     }
 
     [Fact]
@@ -332,7 +332,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         public Task<int> MultiplyAsync(int a, int b) => Task.FromResult(a * b);
 
-        public Task<string> AManByAsync(string name) => Task.FromResult(name.ToUpperInvariant());
+        public Task<string> ARoseByAsync(string name) => Task.FromResult(name.ToUpperInvariant());
 
         internal void OnItHappened(EventArgs args) => this.ItHappened?.Invoke(this, args);
 

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -239,11 +239,13 @@ public class JsonRpcProxyGenerationTests : TestBase
         Assert.Throws<TypeLoadException>(() => JsonRpc.Attach<IServerInternal>(streams.Item1));
     }
 
+#if NET452 || NET461 || NETCOREAPP2_0
     [Fact]
     public async Task RPCMethodNameSubstitution()
     {
         Assert.Equal("ANDREW", await this.clientRpc.ARoseByAsync("andrew"));
     }
+#endif
 
     [Fact]
     public async Task GenericEventRaisedOnClient()

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcProxyGenerationTests : TestBase
+{
+    private readonly Server server;
+    private FullDuplexStream serverStream;
+    private JsonRpc serverRpc;
+
+    private FullDuplexStream clientStream;
+    private IServer clientRpc;
+
+    public JsonRpcProxyGenerationTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        this.serverStream = streams.Item1;
+        this.clientStream = streams.Item2;
+
+        this.clientRpc = JsonRpc.Attach<IServer>(this.clientStream);
+
+        this.server = new Server();
+        this.serverRpc = JsonRpc.Attach(this.serverStream, this.server);
+    }
+
+    public interface IServer
+    {
+        Task<string> SayHiAsync();
+
+        Task<string> SayHiAsync(string name);
+
+        Task<int> AddAsync(int a, int b);
+
+        Task IncrementAsync();
+    }
+
+    [Fact]
+    public void ProxyTypeIsReused()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        var clientRpc = JsonRpc.Attach<IServer>(streams.Item1);
+        Assert.IsType(this.clientRpc.GetType(), clientRpc);
+    }
+
+    [Fact]
+    public async Task CallMethod_String_String()
+    {
+        Assert.Equal("Hi, Andrew!", await this.clientRpc.SayHiAsync("Andrew"));
+    }
+
+    [Fact]
+    public async Task CallMethod_void_String()
+    {
+        Assert.Equal("Hi!", await this.clientRpc.SayHiAsync());
+    }
+
+    [Fact]
+    public async Task CallMethod_IntInt_Int()
+    {
+        Assert.Equal(3, await this.clientRpc.AddAsync(1, 2));
+    }
+
+    [Fact]
+    public async Task CallMethod_void_void()
+    {
+        await this.clientRpc.IncrementAsync();
+        Assert.Equal(1, this.server.Counter);
+    }
+
+    [Fact]
+    public void ImplementsIDisposable()
+    {
+        var disposableClient = (IDisposable)this.clientRpc;
+        disposableClient.Dispose();
+        Assert.True(this.clientStream.IsDisposed);
+    }
+
+    // TODO:
+    // * interfaces that contain non-Task returning methods
+    // * Task returning methods (not Task<T>)
+    // * RPC method names that vary from the CLR method names
+    // * no arguments
+    // * 1 argument
+    // * events
+    // * Dispose method on server interface
+
+    internal class Server : IServer
+    {
+        public int Counter { get; set; }
+
+        public Task<string> SayHiAsync() => Task.FromResult("Hi!");
+
+        public Task<string> SayHiAsync(string name) => Task.FromResult($"Hi, {name}!");
+
+        public Task<int> AddAsync(int a, int b) => Task.FromResult(a + b);
+
+        public Task IncrementAsync()
+        {
+            this.Counter++;
+            return TplExtensions.CompletedTask;
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -67,6 +67,21 @@ public class JsonRpcProxyGenerationTests : TestBase
         int Add(int a, int b);
     }
 
+    public interface IServerWithUnsupportedEventTypes
+    {
+        event Action MyActionEvent;
+    }
+
+    public interface IServerWithProperties
+    {
+        int Foo { get; set; }
+    }
+
+    public interface IServerWithGenericMethod
+    {
+        Task AddAsync<T>(T a, T b);
+    }
+
     internal interface IServerInternal
     {
         Task AddAsync(int a, int b);
@@ -124,10 +139,36 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    [Trait("NegativeTest", "")]
     public void NonTaskReturningMethod()
     {
         var streams = FullDuplexStream.CreateStreams();
-        Assert.Throws<ArgumentException>(() => JsonRpc.Attach<IServerWithNonTaskReturnTypes>(streams.Item1));
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithNonTaskReturnTypes>(streams.Item1));
+        this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void UnsupportedDelegateTypeOnEvent()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithUnsupportedEventTypes>(this.clientStream));
+        this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void PropertyOnInterface()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithProperties>(this.clientStream));
+        this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void GenericMethodOnInterface()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithGenericMethod>(this.clientStream));
+        this.Logger.WriteLine(exception.Message);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -55,6 +55,11 @@ public class JsonRpcProxyGenerationTests : TestBase
         int Add(int a, int b);
     }
 
+    internal interface IServerInternal
+    {
+        Task AddAsync(int a, int b);
+    }
+
     [Fact]
     public void ProxyTypeIsReused()
     {
@@ -128,10 +133,17 @@ public class JsonRpcProxyGenerationTests : TestBase
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.HeavyWorkAsync(456, new CancellationToken(canceled: true)));
     }
 
+    [Fact]
+    public void InternalInterface()
+    {
+        // When implementing internal interfaces work, fill out this test to actually invoke it.
+        var streams = FullDuplexStream.CreateStreams();
+        Assert.Throws<TypeLoadException>(() => JsonRpc.Attach<IServerInternal>(streams.Item1));
+    }
+
     // TODO:
     // * RPC method names that vary from the CLR method names
     // * events
-    // * Internal interface
 
     internal class Server : IServer
     {

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -48,6 +48,9 @@ public class JsonRpcProxyGenerationTests : TestBase
         Task HeavyWorkAsync(CancellationToken cancellationToken);
 
         Task<int> HeavyWorkAsync(int param1, CancellationToken cancellationToken);
+
+        [JsonRpcMethod("AnotherName")]
+        Task<string> AManByAsync(string name);
     }
 
     public interface IServer2
@@ -182,8 +185,13 @@ public class JsonRpcProxyGenerationTests : TestBase
         Assert.Throws<TypeLoadException>(() => JsonRpc.Attach<IServerInternal>(streams.Item1));
     }
 
+    [Fact]
+    public async Task RPCMethodNameSubstitution()
+    {
+        Assert.Equal("ANDREW", await this.clientRpc.AManByAsync("andrew"));
+    }
+
     // TODO:
-    // * RPC method names that vary from the CLR method names
     // * events
 
     internal class Server : IServer, IServer2
@@ -222,5 +230,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         }
 
         public Task<int> MultiplyAsync(int a, int b) => Task.FromResult(a * b);
+
+        public Task<string> AManByAsync(string name) => Task.FromResult(name.ToUpperInvariant());
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -133,6 +133,15 @@ public class JsonRpcProxyGenerationTests : TestBase
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.HeavyWorkAsync(456, new CancellationToken(canceled: true)));
     }
 
+    /// <summary>
+    /// Verifies that object.ToString() does not get relayed to the service.
+    /// </summary>
+    [Fact]
+    public void CallBaseMethods()
+    {
+        Assert.Contains("proxy", this.clientRpc.ToString());
+    }
+
     [Fact]
     public void InternalInterface()
     {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -266,7 +266,9 @@ namespace StreamJsonRpc
         /// <param name="stream">A bidirectional stream to send and receive RPC messages on.</param>
         /// <param name="target">An optional target object to invoke when incoming RPC requests arrive.</param>
         /// <returns>The initialized and listening <see cref="JsonRpc"/> object.</returns>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public static JsonRpc Attach(Stream stream, object target = null)
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         {
             Requires.NotNull(stream, nameof(stream));
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -342,9 +342,9 @@ namespace StreamJsonRpc
             where T : class
         {
             var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: true);
-            var rpc = Attach(sendingStream, receivingStream);
+            var rpc = new JsonRpc(sendingStream, receivingStream);
             T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc);
-
+            rpc.StartListening();
             return proxy;
         }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -356,19 +356,16 @@ namespace StreamJsonRpc
         public T Attach<T>()
             where T : class
         {
-            return this.Attach<T>((Func<string, string>)null);
+            return this.Attach<T>((JsonRpcTargetOptions)null);
         }
 
         /// <summary>
         /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
         /// </summary>
         /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
-        /// <param name="methodNameTransform">
-        /// A function that takes the CLR method name and returns the RPC method name.
-        /// This method is useful for adding prefixes to all methods, or making them camelCased.
-        /// </param>
+        /// <param name="options">A set of customizations for how the target object is registered. If <c>null</c>, default options will be used.</param>
         /// <returns>An instance of the generated proxy.</returns>
-        public T Attach<T>(Func<string, string> methodNameTransform)
+        public T Attach<T>(JsonRpcTargetOptions options)
             where T : class
         {
             var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: false);

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -305,6 +305,35 @@ namespace StreamJsonRpc
         }
 
         /// <summary>
+        /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
+        /// </summary>
+        /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
+        /// <param name="stream">The bidirectional stream used to send and receive JSON-RPC messages.</param>
+        /// <returns>An instance of the generated proxy.</returns>
+        public static T Attach<T>(Stream stream)
+            where T : class
+        {
+            return Attach<T>(stream, stream);
+        }
+
+        /// <summary>
+        /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
+        /// </summary>
+        /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
+        /// <param name="sendingStream">The stream used to transmit messages. May be null.</param>
+        /// <param name="receivingStream">The stream used to receive messages. May be null.</param>
+        /// <returns>An instance of the generated proxy.</returns>
+        public static T Attach<T>(Stream sendingStream, Stream receivingStream)
+            where T : class
+        {
+            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo());
+            var rpc = Attach(sendingStream, receivingStream);
+            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc);
+
+            return proxy;
+        }
+
+        /// <summary>
         /// Adds the specified target as possible object to invoke when incoming messages are received.  The target object
         /// should not inherit from each other and are invoked in the order which they are added.
         /// </summary>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="cs" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Při volání metody serveru {0} došlo k závažné výjimce: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="de" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Eine schwerwiegende Ausnahme wurde von der Servermethode "{0}" ausgelöst: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="es" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Se lanzó una excepción fatal desde el método del servidor {0}: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="fr" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Une exception irrécupérable a été levée depuis la méthode de serveur {0} : {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="it" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Il metodo del server {0} ha generato un'eccezione irreversibile: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">致命的な例外がサーバー メソッド {0} からスローされました: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ko" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">서버 메서드에서 치명적인 예외가 throw되었습니다. {0}: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pl" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Metoda serwera {0}: {1} zgłosiła wyjątek krytyczny</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-BR" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Uma exceção fatal foi gerada pelo método do servidor {0}: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ru" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">Метод сервера {0} вызвал неустранимое исключение: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="tr" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">{0}: {1} sunucu metodundan önemli bir özel durum oluşturuldu.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-Hans" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -171,6 +171,23 @@
           <source>A fatal exception was thrown from the server method {0}: {1}</source>
           <target state="translated">服务器方法 {0} 引发了严重的异常: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -189,6 +189,10 @@
           <source>Properties are not supported for service interfaces.</source>
           <target state="new">Properties are not supported for service interfaces.</target>
         </trans-unit>
+        <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
+          <source>"{0}" is not an interface.</source>
+          <target state="new">"{0}" is not an interface.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -172,6 +172,23 @@
           <target state="translated">伺服器方法 {0} 擲出了嚴重例外狀況: {1}</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message</note>
         </trans-unit>
+        <trans-unit id="UnsupportedEventHandlerTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</source>
+          <target state="new">Unsupported event handler type on "{0}". Only EventHandler and EventHandler<it id="1" pos="open">&lt;T&gt;</it> are supported.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a type and member name.</note>
+        </trans-unit>
+        <trans-unit id="UnsupportedGenericMethodsOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Generic methods are not supported.</source>
+          <target state="new">Generic methods are not supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedMethodReturnTypeOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</source>
+          <target state="new">Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</target>
+        </trans-unit>
+        <trans-unit id="UnsupportedPropertiesOnClientProxyInterface" translate="yes" xml:space="preserve">
+          <source>Properties are not supported for service interfaces.</source>
+          <target state="new">Properties are not supported for service interfaces.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using Microsoft;
+
+    internal static class ProxyGeneration
+    {
+        private static readonly Type[] EmptyTypes = new Type[0];
+        private static readonly AssemblyName ProxyAssemblyName = new AssemblyName(string.Format(CultureInfo.InvariantCulture, "StreamJsonRpc_Proxies_{0}", Guid.NewGuid()));
+        private static readonly AssemblyBuilder AssemblyBuilder;
+        private static readonly ModuleBuilder ProxyModuleBuilder;
+        private static readonly ConstructorInfo ObjectCtor = typeof(object).GetTypeInfo().DeclaredConstructors.Single();
+        private static readonly Dictionary<TypeInfo, TypeInfo> GeneratedProxiesByInterface = new Dictionary<TypeInfo, TypeInfo>();
+
+        static ProxyGeneration()
+        {
+            AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName($"rpcProxies_{Guid.NewGuid()}"), AssemblyBuilderAccess.RunAndCollect);
+            ProxyModuleBuilder = AssemblyBuilder.DefineDynamicModule("rpcProxies");
+        }
+
+        internal static TypeInfo Get(TypeInfo serviceInterface)
+        {
+            Requires.NotNull(serviceInterface, nameof(serviceInterface));
+            Requires.Argument(serviceInterface.IsInterface, nameof(serviceInterface), "Generic type argument must be an interface.");
+
+            TypeInfo generatedType;
+
+            lock (GeneratedProxiesByInterface)
+            {
+                if (GeneratedProxiesByInterface.TryGetValue(serviceInterface, out generatedType))
+                {
+                    return generatedType;
+                }
+            }
+
+            lock (ProxyModuleBuilder)
+            {
+                var interfaces = new Type[]
+                {
+                    typeof(IDisposable),
+                    serviceInterface.AsType(),
+                };
+
+                var proxyTypeBuilder = ProxyModuleBuilder.DefineType(
+                    string.Format(CultureInfo.InvariantCulture, "_proxy_{0}_{1}", serviceInterface.FullName, Guid.NewGuid()),
+                    TypeAttributes.Public,
+                    typeof(object),
+                    interfaces);
+
+                var jsonRpcField = proxyTypeBuilder.DefineField("rpc", typeof(JsonRpc), FieldAttributes.Private | FieldAttributes.InitOnly);
+
+                // .ctor(JsonRpc)
+                {
+                    var ctor = proxyTypeBuilder.DefineConstructor(MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName, CallingConventions.Standard, new Type[] { typeof(JsonRpc) });
+                    var il = ctor.GetILGenerator();
+
+                    // : base()
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Call, ObjectCtor);
+
+                    // this.rpc = rpc;
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Stfld, jsonRpcField);
+
+                    il.Emit(OpCodes.Ret);
+                }
+
+                // IDisposable.Dispose()
+                {
+                    var disposeMethod = proxyTypeBuilder.DefineMethod(nameof(IDisposable.Dispose), MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual);
+                    var il = disposeMethod.GetILGenerator();
+
+                    // this.rpc.Dispose();
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, jsonRpcField);
+                    MethodInfo jsonRpcDisposeMethod = typeof(JsonRpc).GetTypeInfo().GetDeclaredMethods(nameof(JsonRpc.Dispose)).Single(m => m.GetParameters().Length == 0);
+                    il.EmitCall(OpCodes.Callvirt, jsonRpcDisposeMethod, EmptyTypes);
+                    il.Emit(OpCodes.Ret);
+
+                    proxyTypeBuilder.DefineMethodOverride(disposeMethod, typeof(IDisposable).GetTypeInfo().GetDeclaredMethod(nameof(IDisposable.Dispose)));
+                }
+
+                var invokeAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeAsync) && m.GetParameters()[1].ParameterType == typeof(object[])).ToArray();
+                var invokeAsyncOfTaskMethodInfo = invokeAsyncMethodInfos.Single(m => !m.IsGenericMethod);
+                var invokeAsyncOfTaskOfTMethodInfo = invokeAsyncMethodInfos.Single(m => m.IsGenericMethod);
+
+                foreach (var method in serviceInterface.DeclaredMethods)
+                {
+                    ParameterInfo[] methodParameters = method.GetParameters();
+                    var methodBuilder = proxyTypeBuilder.DefineMethod(
+                        method.Name,
+                        MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,
+                        method.ReturnType,
+                        methodParameters.Select(p => p.ParameterType).ToArray());
+                    var il = methodBuilder.GetILGenerator();
+
+                    // this.rpc
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, jsonRpcField);
+
+                    // First argument to InvokeAsync is the method name.
+                    il.Emit(OpCodes.Ldstr, method.Name);
+
+                    // The second argument is an array of arguments for the RPC method.
+                    il.Emit(OpCodes.Ldc_I4, methodParameters.Length);
+                    il.Emit(OpCodes.Newarr, typeof(object));
+
+                    for (int i = 0; i < methodParameters.Length; i++)
+                    {
+                        il.Emit(OpCodes.Dup); // duplicate the array on the stack
+                        il.Emit(OpCodes.Ldc_I4, i); // push the index of the array to be initialized.
+                        il.Emit(OpCodes.Ldarg, i + 1); // push the associated argument
+                        if (methodParameters[i].ParameterType.GetTypeInfo().IsValueType)
+                        {
+                            il.Emit(OpCodes.Box, methodParameters[i].ParameterType); // box if the argument is a value type
+                        }
+
+                        il.Emit(OpCodes.Stelem_Ref); // set the array element.
+                    }
+
+                    // Construct the InvokeAsync<T> method with the T argument supplied if we have a return type.
+                    MethodInfo invokeAsyncMethod = method.ReturnType.GetTypeInfo().IsGenericType
+                        ? invokeAsyncOfTaskOfTMethodInfo.MakeGenericMethod(method.ReturnType.GetTypeInfo().GenericTypeArguments[0])
+                        : invokeAsyncOfTaskMethodInfo;
+                    il.EmitCall(OpCodes.Callvirt, invokeAsyncMethod, null);
+                    il.Emit(OpCodes.Ret);
+
+                    proxyTypeBuilder.DefineMethodOverride(methodBuilder, method);
+                }
+
+                generatedType = proxyTypeBuilder.CreateTypeInfo();
+            }
+
+            lock (GeneratedProxiesByInterface)
+            {
+                if (!GeneratedProxiesByInterface.TryGetValue(serviceInterface, out var raceGeneratedType))
+                {
+                    GeneratedProxiesByInterface.Add(serviceInterface, generatedType);
+                }
+                else
+                {
+                    // Ensure we only expose the same generated type externally.
+                    generatedType = raceGeneratedType;
+                }
+            }
+
+            return generatedType;
+        }
+    }
+}

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -9,6 +9,7 @@ namespace StreamJsonRpc
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
+    using System.Threading.Tasks;
     using Microsoft;
 
     internal static class ProxyGeneration
@@ -95,6 +96,8 @@ namespace StreamJsonRpc
 
                 foreach (var method in serviceInterface.DeclaredMethods)
                 {
+                    Requires.Argument(method.ReturnType == typeof(Task) || (method.ReturnType.GetTypeInfo().IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>)), nameof(serviceInterface), "Method \"{0}\" has unsupported return type \"{1}\". Only Task-returning methods are supported.", method.Name, method.ReturnType.FullName);
+
                     ParameterInfo[] methodParameters = method.GetParameters();
                     var methodBuilder = proxyTypeBuilder.DefineMethod(
                         method.Name,

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -45,6 +45,8 @@ namespace StreamJsonRpc
                 }
             }
 
+            var methodNameMap = new JsonRpc.MethodNameMap(serviceInterface);
+
             lock (ProxyModuleBuilder)
             {
                 var interfaces = new List<Type>
@@ -123,7 +125,7 @@ namespace StreamJsonRpc
                     il.Emit(OpCodes.Ldfld, jsonRpcField);
 
                     // First argument to InvokeAsync is the method name.
-                    il.Emit(OpCodes.Ldstr, method.Name);
+                    il.Emit(OpCodes.Ldstr, methodNameMap.GetRpcMethodName(method));
 
                     // The second argument is an array of arguments for the RPC method.
                     il.Emit(OpCodes.Ldc_I4, methodParameters.Count(p => p.ParameterType != typeof(CancellationToken)));

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -40,7 +40,7 @@ namespace StreamJsonRpc
         internal static TypeInfo Get(TypeInfo serviceInterface, bool disposable)
         {
             Requires.NotNull(serviceInterface, nameof(serviceInterface));
-            Requires.Argument(serviceInterface.IsInterface, nameof(serviceInterface), "Generic type argument must be an interface.");
+            VerifySupported(serviceInterface.IsInterface, Resources.ClientProxyTypeArgumentMustBeAnInterface, serviceInterface);
 
             TypeInfo generatedType;
 

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -5,6 +5,7 @@ namespace StreamJsonRpc
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
@@ -74,13 +75,13 @@ namespace StreamJsonRpc
 
                 var jsonRpcField = proxyTypeBuilder.DefineField("rpc", typeof(JsonRpc), FieldAttributes.Private | FieldAttributes.InitOnly);
 
-                VerifySupported(!serviceInterface.DeclaredProperties.Any(), "Properties are not supported for service interfaces.", serviceInterface);
+                VerifySupported(!serviceInterface.DeclaredProperties.Any(), Resources.UnsupportedPropertiesOnClientProxyInterface, serviceInterface);
 
                 // Implement events
                 var ctorActions = new List<Action<ILGenerator>>();
                 foreach (var evt in serviceInterface.DeclaredEvents)
                 {
-                    VerifySupported(evt.EventHandlerType.Equals(typeof(EventHandler)) || (evt.EventHandlerType.GetTypeInfo().IsGenericType && evt.EventHandlerType.GetGenericTypeDefinition().Equals(typeof(EventHandler<>))), "Unsupported event handler type on \"{0}\". Only EventHandler and EventHandler<T> are supported.", evt);
+                    VerifySupported(evt.EventHandlerType.Equals(typeof(EventHandler)) || (evt.EventHandlerType.GetTypeInfo().IsGenericType && evt.EventHandlerType.GetGenericTypeDefinition().Equals(typeof(EventHandler<>))), Resources.UnsupportedEventHandlerTypeOnClientProxyInterface, evt);
 
                     // public event EventHandler EventName;
                     var evtBuilder = proxyTypeBuilder.DefineEvent(evt.Name, evt.Attributes, evt.EventHandlerType);
@@ -173,8 +174,8 @@ namespace StreamJsonRpc
 
                 foreach (var method in serviceInterface.DeclaredMethods.Where(m => !m.IsSpecialName))
                 {
-                    VerifySupported(method.ReturnType == typeof(Task) || (method.ReturnType.GetTypeInfo().IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>)), "Method \"{0}\" has unsupported return type \"{1}\". Only Task-returning methods are supported.", method, method.ReturnType.FullName);
-                    VerifySupported(!method.IsGenericMethod, "Generic methods are not supported", method);
+                    VerifySupported(method.ReturnType == typeof(Task) || (method.ReturnType.GetTypeInfo().IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>)), Resources.UnsupportedMethodReturnTypeOnClientProxyInterface, method, method.ReturnType.FullName);
+                    VerifySupported(!method.IsGenericMethod, Resources.UnsupportedGenericMethodsOnClientProxyInterface, method);
 
                     ParameterInfo[] methodParameters = method.GetParameters();
                     var methodBuilder = proxyTypeBuilder.DefineMethod(

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -15,4 +15,6 @@ override StreamJsonRpc.WebSocketMessageHandler.ReadCoreAsync(System.Threading.Ca
 override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(string content, System.Text.Encoding contentEncoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 static StreamJsonRpc.CommonMethodNameTransforms.CamelCase.get -> System.Func<string, string>
 static StreamJsonRpc.CommonMethodNameTransforms.Prepend(string prefix) -> System.Func<string, string>
+static StreamJsonRpc.JsonRpc.Attach<T>(System.IO.Stream sendingStream, System.IO.Stream receivingStream) -> T
+static StreamJsonRpc.JsonRpc.Attach<T>(System.IO.Stream stream) -> T
 virtual StreamJsonRpc.DelimitedMessageHandler.FlushCoreAsync() -> System.Threading.Tasks.Task

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, System.Func<string, string> methodNameTransform) -> void
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
+StreamJsonRpc.JsonRpc.Attach<T>() -> T
+StreamJsonRpc.JsonRpc.Attach<T>(System.Func<string, string> methodNameTransform) -> T
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
 StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.SynchronizationContext
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -6,7 +6,7 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, StreamJsonRpc.JsonRpcTarg
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
 StreamJsonRpc.JsonRpc.Attach<T>() -> T
-StreamJsonRpc.JsonRpc.Attach<T>(System.Func<string, string> methodNameTransform) -> T
+StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.JsonRpcTargetOptions options) -> T
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
 StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.SynchronizationContext
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -393,5 +393,41 @@ namespace StreamJsonRpc {
                 return ResourceManager.GetString("UnrecognizedIncomingJsonRpc", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported event handler type on &quot;{0}&quot;. Only EventHandler and EventHandler&lt;T&gt; are supported..
+        /// </summary>
+        internal static string UnsupportedEventHandlerTypeOnClientProxyInterface {
+            get {
+                return ResourceManager.GetString("UnsupportedEventHandlerTypeOnClientProxyInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Generic methods are not supported..
+        /// </summary>
+        internal static string UnsupportedGenericMethodsOnClientProxyInterface {
+            get {
+                return ResourceManager.GetString("UnsupportedGenericMethodsOnClientProxyInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &quot;{0}&quot; has unsupported return type &quot;{1}&quot;. Only Task-returning methods are supported..
+        /// </summary>
+        internal static string UnsupportedMethodReturnTypeOnClientProxyInterface {
+            get {
+                return ResourceManager.GetString("UnsupportedMethodReturnTypeOnClientProxyInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties are not supported for service interfaces..
+        /// </summary>
+        internal static string UnsupportedPropertiesOnClientProxyInterface {
+            get {
+                return ResourceManager.GetString("UnsupportedPropertiesOnClientProxyInterface", resourceCulture);
+            }
+        }
     }
 }

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -71,6 +71,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &quot;{0}&quot; is not an interface..
+        /// </summary>
+        internal static string ClientProxyTypeArgumentMustBeAnInterface {
+            get {
+                return ResourceManager.GetString("ClientProxyTypeArgumentMustBeAnInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to .NET methods &apos;{0}&apos; and &apos;{1}&apos; cannot both map to the same request method name: &apos;{2}&apos;..
         /// </summary>
         internal static string ConflictingMethodAttributeValue {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -246,4 +246,17 @@
   <data name="MustNotBeListening" xml:space="preserve">
     <value>This cannot be done after listening has started.</value>
   </data>
+  <data name="UnsupportedEventHandlerTypeOnClientProxyInterface" xml:space="preserve">
+    <value>Unsupported event handler type on "{0}". Only EventHandler and EventHandler&lt;T&gt; are supported.</value>
+    <comment>{0} is a type and member name.</comment>
+  </data>
+  <data name="UnsupportedGenericMethodsOnClientProxyInterface" xml:space="preserve">
+    <value>Generic methods are not supported.</value>
+  </data>
+  <data name="UnsupportedMethodReturnTypeOnClientProxyInterface" xml:space="preserve">
+    <value>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</value>
+  </data>
+  <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
+    <value>Properties are not supported for service interfaces.</value>
+  </data>
 </root>

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -246,6 +246,9 @@
   <data name="MustNotBeListening" xml:space="preserve">
     <value>This cannot be done after listening has started.</value>
   </data>
+  <data name="ClientProxyTypeArgumentMustBeAnInterface" xml:space="preserve">
+    <value>"{0}" is not an interface.</value>
+  </data>
   <data name="UnsupportedEventHandlerTypeOnClientProxyInterface" xml:space="preserve">
     <value>Unsupported event handler type on "{0}". Only EventHandler and EventHandler&lt;T&gt; are supported.</value>
     <comment>{0} is a type and member name.</comment>

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
When a JSON-RPC server offers a .NET interface that describes their API, StreamJsonRpc's `JsonRpc` class can now automatically generate a client proxy that implements that interface to give the client a strongly-typed way to send these RPC messages. This in effect replaces such code as:

```cs
var rpc = JsonRpc.Attach(stream);
Result result = await rpc.InvokeAsync<Result>("MyMethodAsync", 1, 2, "three");
```

with: 

```cs
IServer rpc = JsonRpc.Attach<IServer>(stream);
Result result = await server.MyMethodAsync(1,2, "three");
```

These client proxies also implement `IDisposable` if returned from the *static* `Attach<T>` method, since that is the only value that callers have that might be disposed to close the connection. There is also an instance method version of `Attach<T>`  so that more control and potentially multiple client proxies can be attached to the same stream.

These client proxies also support events defined on the `IServer` interface, such that if the server raises callbacks to the client, it will automatically raise any event handlers for that event on the client side. This is to support #105 in the client proxy.

The only supported members on the server interface are:
1. methods that return `Task` or `Task<T>`
1. events that are typed as `EventHandler` or `EventHandler<T>`