### PR TITLE
Do not scan accessor methods on target objects

### DIFF
--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -106,6 +106,20 @@ public class TargetObjectEventsTests : TestBase
         Assert.Throws<NotSupportedException>(() => JsonRpc.Attach(streams.Item1, new ServerWithIncompatibleEvents()));
     }
 
+    [Fact]
+    public void EventsAreNotOfferedAsTargetMethods()
+    {
+        Func<string, string> methodNameTransform = clrMethodName =>
+        {
+            Assert.NotEqual($"add_{nameof(Server.ServerEvent)}", clrMethodName);
+            Assert.DoesNotContain($"get_{nameof(Server.ServerEventAccessor)}", clrMethodName);
+            return clrMethodName;
+        };
+
+        var serverRpc = new JsonRpc(this.serverStream, this.serverStream);
+        serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = methodNameTransform });
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -876,7 +876,8 @@ namespace StreamJsonRpc
 
             for (TypeInfo t = target.GetType().GetTypeInfo(); t != null && t != typeof(object).GetTypeInfo(); t = t.BaseType?.GetTypeInfo())
             {
-                foreach (MethodInfo method in t.DeclaredMethods)
+                // As we enumerate methods, skip accessor methods
+                foreach (MethodInfo method in t.DeclaredMethods.Where(m => !m.IsSpecialName))
                 {
                     var requestName = mapping.GetRpcMethodName(method);
 


### PR DESCRIPTION
Now that we allow JsonRpc users to transform every method name that is an RPC target, I noticed that accessor methods to events and properties (e.g. `add_SomeEvent` and `get_SomeProperty`) were also being selected as potential RPC target methods. This of course is not what the server target object is expecting, so this change filters those out.