### PR TITLE
Fix tests that randomly fail on Travis CI

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -39,7 +39,7 @@ public class JsonRpcClientInteropTests : InteropTestBase
             cts.Cancel();
 
             // Verify that no cancellation message is transmitted.
-            await Assert.ThrowsAsync<TaskCanceledException>(() => this.messageHandler.WrittenMessages.DequeueAsync(ExpectedTimeoutToken));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.messageHandler.WrittenMessages.DequeueAsync(ExpectedTimeoutToken));
         }
     }
 

--- a/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
@@ -71,7 +71,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     public async Task CloseStreamOnAsyncYieldAndThrowException()
     {
         var exceptionMessage = "Exception from CloseStreamOnAsyncYieldAndThrowException";
-        Exception exception = await Assert.ThrowsAnyAsync<TaskCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsAfterYield), exceptionMessage));
+        Exception exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsAfterYield), exceptionMessage));
         Assert.NotNull(exception.StackTrace);
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
@@ -101,7 +101,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     public async Task CloseStreamOnAsyncTMethodException()
     {
         var exceptionMessage = "Exception from CloseStreamOnAsyncTMethodException";
-        await Assert.ThrowsAsync<TaskCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatReturnsStringAndThrows), exceptionMessage));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatReturnsStringAndThrows), exceptionMessage));
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
@@ -150,7 +150,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
             cts.Cancel();
             this.server.AllowServerMethodToReturn.Set();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => invokeTask);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
             Assert.Equal(Server.ThrowAfterCancellationMessage, this.serverRpc.FaultException.Message);
             Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
         }

--- a/src/StreamJsonRpc.Tests/TestBase.cs
+++ b/src/StreamJsonRpc.Tests/TestBase.cs
@@ -84,7 +84,7 @@ public abstract class TestBase : IDisposable
             long leaked = (GC.GetTotalMemory(forceFullCollection: true) - initialMemory) / iterations;
 
             this.Logger?.WriteLine($"{leaked} bytes leaked per iteration.", leaked);
-            this.Logger?.WriteLine($"{allocated} bytes allocated per iteration ({maxBytesAllocated} allowed).");
+            this.Logger?.WriteLine($"{allocated} bytes allocated per iteration ({(maxBytesAllocated >= 0 ? (object)maxBytesAllocated : "unlimited")} allowed).");
 
             if (leaked <= 0 && (allocated <= maxBytesAllocated || maxBytesAllocated < 0))
             {


### PR DESCRIPTION
Catching OperationCanceledException is better than catch TaskCanceledException because OCE is the base class. CoreCLR seems to have a tendency to sporatically throw the base type instead of the derived type. And we don't really care which one is thrown, so stabilize the tests around it.

I also improve the test logging of GCPressure tests.