### PR TITLE
Fix handling of Task<T>-derived types returned from async methods

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1046,7 +1046,7 @@ public class JsonRpcTests : TestBase
 
         public Task ServerMethodThatReturnsCustomTask()
         {
-            var result = new CustomTask();
+            var result = new CustomTask<int>(CustomTaskResult);
             result.Start();
             return result;
         }
@@ -1279,16 +1279,14 @@ public class JsonRpcTests : TestBase
     {
     }
 
-    private class CustomTask : Task<int>
+    /// <summary>
+    /// This emulates what .NET Core 2.1 does where async <see cref="Task{T}"/> methods actually return an instance of a private derived type.
+    /// </summary>
+    private class CustomTask<T> : Task<T>
     {
-        public CustomTask()
-            : base(() => 0)
+        public CustomTask(T result)
+            : base(() => result)
         {
-        }
-
-        public new int Result
-        {
-            get { return CustomTaskResult; }
         }
     }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -848,6 +848,33 @@ namespace StreamJsonRpc
             return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, exception.Message, JObject.FromObject(data, DefaultJsonSerializer));
         }
 
+        /// <summary>
+        /// Extracts the literal <see cref="Task{T}"/> type from the type hierarchy of a given type.
+        /// </summary>
+        /// <param name="taskTypeInfo">The original type of the value returned from an RPC-invoked method.</param>
+        /// <param name="taskOfTTypeInfo">Receives the <see cref="Task{T}"/> type that is a base type of <paramref name="taskTypeInfo"/>, if found.</param>
+        /// <returns><c>true</c> if <see cref="Task{T}"/> could be found in the type hierarchy; otherwise <c>false</c>.</returns>
+        private static bool TryGetTaskOfTType(TypeInfo taskTypeInfo, out TypeInfo taskOfTTypeInfo)
+        {
+            Requires.NotNull(taskTypeInfo, nameof(taskTypeInfo));
+
+            while (taskTypeInfo != null)
+            {
+                if (IsTaskOfT(taskTypeInfo))
+                {
+                    taskOfTTypeInfo = taskTypeInfo;
+                    return true;
+                }
+
+                taskTypeInfo = taskTypeInfo.BaseType.GetTypeInfo();
+            }
+
+            taskOfTTypeInfo = null;
+            return false;
+
+            bool IsTaskOfT(TypeInfo typeInfo) => typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Task<>);
+        }
+
         private async Task<JsonRpcMessage> DispatchIncomingRequestAsync(JsonRpcMessage request)
         {
             Requires.NotNull(request, nameof(request));
@@ -943,12 +970,13 @@ namespace StreamJsonRpc
                 return JsonRpcMessage.CreateError(id, JsonRpcErrorCode.InvocationError, Resources.TaskWasCancelled);
             }
 
-            object taskResult = null;
-            Type taskType = t.GetType();
-
             // If t is a Task<SomeType>, it will have Result property.
             // If t is just a Task, there is no Result property on it.
-            if (!taskType.Equals(typeof(Task)))
+            // We can't really write direct code to deal with Task<T>, since we have no idea of T in this context, so we simply use reflection to
+            // read the result at runtime.
+            // Make sure we're prepared for Task<T>-derived types, by walking back up to the actual type in order to find the Result property.
+            object taskResult = null;
+            if (TryGetTaskOfTType(t.GetType().GetTypeInfo(), out TypeInfo taskOfTTypeInfo))
             {
 #pragma warning disable VSTHRD002 // misfiring analyzer https://github.com/Microsoft/vs-threading/issues/60
 #pragma warning disable VSTHRD102 // misfiring analyzer https://github.com/Microsoft/vs-threading/issues/60
@@ -956,10 +984,9 @@ namespace StreamJsonRpc
 #pragma warning restore VSTHRD002
 #pragma warning restore VSTHRD102
 
-                // We can't really write direct code to deal with Task<T>, since we have no idea of T in this context, so we simply use reflection to
-                // read the result at runtime.
-                PropertyInfo resultProperty = taskType.GetTypeInfo().GetDeclaredProperty(ResultPropertyName);
-                taskResult = resultProperty?.GetValue(t);
+                PropertyInfo resultProperty = taskOfTTypeInfo.GetDeclaredProperty(ResultPropertyName);
+                Assumes.NotNull(resultProperty);
+                taskResult = resultProperty.GetValue(t);
             }
 
             return JsonRpcMessage.CreateResult(id, taskResult, this.JsonSerializer);


### PR DESCRIPTION
.NET Core 2.1 changed how async `Task<T>` returning methods run, such that they now return a derived-type of `Task<T>`. StreamJsonRpc used reflection to read `Task<T>.Result` and it wasn't prepared for a `Task<T>`-derived type. As a result, StreamJsonRpc is broken on .NET Core 2.1, in that any async method invoked by StreamJsonRpc will return `null` to the client as the result of the method instead of the actual value.

With this fix, we properly walk up the type hierarchy till we find the `Task<T>` so we can reliably find the `Result` property and call it. 
In the future, if this were to fail, we now fail hard (throwing an `InternalErrorException` instead of quietly returning null) to make this more discoverable.

In the process, I added .NET Core 2.1 as a target so tests always run on it, but it led to [a failure on Travis CI](https://github.com/travis-ci/travis-ci/issues/9703) so I've held out that change for now. 
I did enhance an existing test to catch the problem regardless of the target framework though.

Fixes #116