### PR TITLE
Fix dynamic client proxies to honor method name transforms

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -277,9 +277,11 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.serverRpc.StartListening();
 
         Assert.Equal("Hi!", await clientRpcWithCamelCase.SayHiAsync()); // "sayHiAsync"
-        Assert.Equal("ANDREW", await clientRpcWithCamelCase.ARoseByAsync("andrew")); // "anotherName"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
+#if NET452 || NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
+        Assert.Equal("ANDREW", await clientRpcWithCamelCase.ARoseByAsync("andrew")); // "anotherName"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
+#endif
 
         // Prepare the server to *ALSO* accept method names with a prefix.
         this.serverRpc.AllowModificationWhileListening = true;
@@ -287,7 +289,9 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Retry with our second client proxy to send messages which the server should now accept.
         Assert.Equal("Hi!", await clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
+#if NET452 || NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
         Assert.Equal("ANDREW", await clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
+#endif
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -262,8 +262,8 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.serverStream = streams.Item1;
         this.clientStream = streams.Item2;
 
-        var camelCaseOptions = new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase };
-        var prefixOptions = new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.Prepend("ns.") };
+        var camelCaseOptions = new JsonRpcProxyOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase };
+        var prefixOptions = new JsonRpcProxyOptions { MethodNameTransform = CommonMethodNameTransforms.Prepend("ns.") };
 
         // Construct two client proxies with conflicting method transforms to prove that each instance returned retains its unique options.
         var clientRpc = new JsonRpc(this.clientStream, this.clientStream);
@@ -273,7 +273,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Construct the server to only respond to one set of method names for now to confirm that the client is sending the right one.
         this.serverRpc = new JsonRpc(this.serverStream, this.serverStream);
-        this.serverRpc.AddLocalRpcTarget(this.server, camelCaseOptions);
+        this.serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = camelCaseOptions.MethodNameTransform });
         this.serverRpc.StartListening();
 
         Assert.Equal("Hi!", await clientRpcWithCamelCase.SayHiAsync()); // "sayHiAsync"
@@ -283,7 +283,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Prepare the server to *ALSO* accept method names with a prefix.
         this.serverRpc.AllowModificationWhileListening = true;
-        this.serverRpc.AddLocalRpcTarget(this.server, prefixOptions);
+        this.serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = prefixOptions.MethodNameTransform });
 
         // Retry with our second client proxy to send messages which the server should now accept.
         Assert.Equal("Hi!", await clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -886,6 +886,28 @@ public class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<string>("ServerMethod", "hi"));
     }
 
+    /// <summary>
+    /// Verify that the method name transform runs with the attribute-determined method name as an input.
+    /// </summary>
+    [Fact]
+    public async Task AddLocalRpcTarget_MethodNameTransformAndRpcMethodAttribute()
+    {
+        // Now set up a server with a camel case transform and verify that it works (and that the original casing doesn't).
+        var streams = FullDuplexStream.CreateStreams();
+        var rpc = new JsonRpc(streams.Item1, streams.Item2);
+        rpc.AddLocalRpcTarget(new Server(), new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase });
+        rpc.StartListening();
+
+        Assert.Equal(3, await rpc.InvokeAsync<int>("classNameForMethod", 1, 2));
+
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("ClassNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("IFaceNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("AddWithNameSubstitution", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("iFaceNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("ifaceNameForMethod", 1, 2));
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeAsync<int>("addWithNameSubstitution", 1, 2));
+    }
+
     [Fact]
     public async Task AddLocalRpcMethod_ActionWith0Args()
     {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -347,7 +347,7 @@ namespace StreamJsonRpc
         {
             var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: true);
             var rpc = new JsonRpc(sendingStream, receivingStream);
-            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc);
+            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc, JsonRpcProxyOptions.Default);
             rpc.StartListening();
             return proxy;
         }
@@ -360,20 +360,20 @@ namespace StreamJsonRpc
         public T Attach<T>()
             where T : class
         {
-            return this.Attach<T>((JsonRpcTargetOptions)null);
+            return this.Attach<T>((JsonRpcProxyOptions)null);
         }
 
         /// <summary>
         /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
         /// </summary>
         /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
-        /// <param name="options">A set of customizations for how the target object is registered. If <c>null</c>, default options will be used.</param>
+        /// <param name="options">A set of customizations for how the client proxy is wired up. If <c>null</c>, default options will be used.</param>
         /// <returns>An instance of the generated proxy.</returns>
-        public T Attach<T>(JsonRpcTargetOptions options)
+        public T Attach<T>(JsonRpcProxyOptions options)
             where T : class
         {
             var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: false);
-            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), this);
+            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), this, options ?? JsonRpcProxyOptions.Default);
 
             return proxy;
         }

--- a/src/StreamJsonRpc/JsonRpcProxyOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcProxyOptions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using Microsoft;
+
+    /// <summary>
+    /// Options that may customize how a dynamically generated client proxy object calls into a <see cref="JsonRpc"/> instance.
+    /// </summary>
+    public class JsonRpcProxyOptions
+    {
+        /// <summary>
+        /// Backing field for the <see cref="MethodNameTransform"/> property.
+        /// </summary>
+        private Func<string, string> methodNameTransform = n => n;
+
+        /// <summary>
+        /// Gets or sets a function that takes the CLR method name and returns the RPC method name.
+        /// This method is useful for adding prefixes to all methods, or making them camelCased.
+        /// </summary>
+        /// <value>A function, defaulting to a straight pass-through. Never null.</value>
+        /// <exception cref="ArgumentNullException">Thrown if set to a null value.</exception>
+        public Func<string, string> MethodNameTransform
+        {
+            get => this.methodNameTransform;
+            set => this.methodNameTransform = Requires.NotNull(value, nameof(value));
+        }
+
+        /// <summary>
+        /// Gets an instance with default properties.
+        /// </summary>
+        /// <remarks>
+        /// Callers should *not* mutate properties on this instance since it is shared.
+        /// </remarks>
+        internal static JsonRpcProxyOptions Default { get; } = new JsonRpcProxyOptions();
+    }
+}

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -6,12 +6,16 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(object target, StreamJsonRpc.JsonRpcTarg
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.get -> bool
 StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
 StreamJsonRpc.JsonRpc.Attach<T>() -> T
-StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.JsonRpcTargetOptions options) -> T
+StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.JsonRpcProxyOptions options) -> T
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
 StreamJsonRpc.JsonRpc.JsonSerializerFormatting.get -> Newtonsoft.Json.Formatting
 StreamJsonRpc.JsonRpc.JsonSerializerFormatting.set -> void
 StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.SynchronizationContext
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void
+StreamJsonRpc.JsonRpcProxyOptions
+StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions() -> void
+StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.get -> System.Func<string, string>
+StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.set -> void
 StreamJsonRpc.JsonRpcTargetOptions
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions() -> void
 StreamJsonRpc.JsonRpcTargetOptions.MethodNameTransform.get -> System.Func<string, string>


### PR DESCRIPTION
Also create a new JsonRpcProxyOptions type and use that for dynamic client proxies. The JsonRpcTargetOptions type wasn't a good fit (it already has one extra property that is irrelevant to client proxies) and its name specifically refers to target objects, which the client proxy isn't one (conceptually anyway).

Fixes #119