### PR TITLE
Fix handling of plain-Task returned objects from server methods

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -651,6 +651,12 @@ public class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task ServerReturnsCompletedTask()
+    {
+        await this.clientRpc.InvokeAsync(nameof(Server.ReturnPlainTask));
+    }
+
+    [Fact]
     public async Task CanInvokeServerMethodWithParameterPassedAsObject()
     {
         string result1 = await this.clientRpc.InvokeWithParameterObjectAsync<string>(nameof(Server.TestParameter), new { test = "test" });
@@ -1061,6 +1067,17 @@ public class JsonRpcTests : TestBase
             var tcs = new TaskCompletionSource<object>();
             tcs.SetCanceled();
             return tcs.Task;
+        }
+
+        public Task ReturnPlainTask()
+        {
+#if NET452
+            var task = new Task(() => { });
+            task.RunSynchronously(TaskScheduler.Default);
+            return task;
+#else
+            return Task.CompletedTask;
+#endif
         }
 
         public void MethodThatThrowsUnauthorizedAccessException()

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1080,7 +1080,7 @@ namespace StreamJsonRpc
                     return true;
                 }
 
-                taskTypeInfo = taskTypeInfo.BaseType.GetTypeInfo();
+                taskTypeInfo = taskTypeInfo.BaseType?.GetTypeInfo();
             }
 
             taskOfTTypeInfo = null;


### PR DESCRIPTION
Fixes #130 

The problem was we enter a loop when the server method returns a `Task` or `Task`-derived type. But the loop itself assumes that the loop (which walks up the type hierarchy) will always end up encountering a `Task<T>` type. Of course `Task` is the base type of `Task<T>` so if a `Task` is passed in, the loop will break (throwing an `ArgumentNullException`). The right behavior is to return null because the `Task` has no result value.