### PR TITLE
Ensures name transforms are used for events

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -365,6 +365,8 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.server.OnItHappened(EventArgs.Empty);
         await Assert.ThrowsAsync<TimeoutException>(() => tcs.Task.WithTimeout(ExpectedTimeout));
         Assert.False(tcs.Task.IsCompleted);
+
+        clientRpcWithPrefix.ItHappened -= handler;
     }
 
     public class EmptyClass

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -338,8 +338,8 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.serverStream = streams.Item1;
         this.clientStream = streams.Item2;
 
-        var camelCaseOptions = new JsonRpcProxyOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase };
-        var prefixOptions = new JsonRpcProxyOptions { MethodNameTransform = CommonMethodNameTransforms.Prepend("ns.") };
+        var camelCaseOptions = new JsonRpcProxyOptions { EventNameTransform = CommonMethodNameTransforms.CamelCase };
+        var prefixOptions = new JsonRpcProxyOptions { EventNameTransform = CommonMethodNameTransforms.Prepend("ns.") };
 
         // Construct two client proxies with conflicting method transforms to prove that each instance returned retains its unique options.
         var clientRpc = new JsonRpc(this.clientStream, this.clientStream);
@@ -349,7 +349,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Construct the server to only respond to one set of method names for now to confirm that the client is sending the right one.
         this.serverRpc = new JsonRpc(this.serverStream, this.serverStream);
-        this.serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = camelCaseOptions.MethodNameTransform });
+        this.serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { EventNameTransform = camelCaseOptions.EventNameTransform });
         this.serverRpc.StartListening();
 
         var tcs = new TaskCompletionSource<EventArgs>();

--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -120,6 +120,26 @@ public class TargetObjectEventsTests : TestBase
         serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = methodNameTransform });
     }
 
+    [Fact]
+    public void NameTransformIsUsedWhenRaisingEvent()
+    {
+        bool eventNameTransformSeen = false;
+        Func<string, string> methodNameTransform = name =>
+        {
+            if (name == nameof(Server.ServerEvent))
+            {
+                eventNameTransformSeen = true;
+            }
+
+            return name;
+        };
+
+        var serverRpc = new JsonRpc(this.serverStream, this.serverStream);
+        serverRpc.AddLocalRpcTarget(this.server, new JsonRpcTargetOptions { MethodNameTransform = methodNameTransform });
+        this.server.TriggerEvent(EventArgs.Empty);
+        Assert.True(eventNameTransformSeen);
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1600,7 +1600,7 @@ namespace StreamJsonRpc
                 this.server = server;
                 this.eventInfo = eventInfo;
 
-                this.rpcEventName = options.MethodNameTransform != null ? options.MethodNameTransform(eventInfo.Name) : eventInfo.Name;
+                this.rpcEventName = options.EventNameTransform != null ? options.EventNameTransform(eventInfo.Name) : eventInfo.Name;
 
                 try
                 {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -430,7 +430,7 @@ namespace StreamJsonRpc
                             this.eventReceivers = new List<EventReceiver>();
                         }
 
-                        this.eventReceivers.Add(new EventReceiver(this, target, evt));
+                        this.eventReceivers.Add(new EventReceiver(this, target, evt, options));
                     }
                 }
             }
@@ -1586,16 +1586,22 @@ namespace StreamJsonRpc
             private readonly object server;
             private readonly EventInfo eventInfo;
             private readonly Delegate registeredHandler;
+            private readonly string rpcEventName;
 
-            internal EventReceiver(JsonRpc jsonRpc, object server, EventInfo eventInfo)
+            internal EventReceiver(JsonRpc jsonRpc, object server, EventInfo eventInfo, JsonRpcTargetOptions options)
             {
                 Requires.NotNull(jsonRpc, nameof(jsonRpc));
                 Requires.NotNull(server, nameof(server));
                 Requires.NotNull(eventInfo, nameof(eventInfo));
 
+                options = options ?? JsonRpcTargetOptions.Default;
+
                 this.jsonRpc = jsonRpc;
                 this.server = server;
                 this.eventInfo = eventInfo;
+
+                this.rpcEventName = options.MethodNameTransform != null ? options.MethodNameTransform(eventInfo.Name) : eventInfo.Name;
+
                 try
                 {
                     // This might throw if our EventHandler-modeled method doesn't "fit" the event delegate signature.
@@ -1619,7 +1625,7 @@ namespace StreamJsonRpc
 
             private void OnEventRaised(object sender, EventArgs args)
             {
-                this.jsonRpc.NotifyAsync(this.eventInfo.Name, new object[] { args });
+                this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args });
             }
         }
     }

--- a/src/StreamJsonRpc/JsonRpcProxyOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcProxyOptions.cs
@@ -17,6 +17,11 @@ namespace StreamJsonRpc
         private Func<string, string> methodNameTransform = n => n;
 
         /// <summary>
+        /// Backing field for the <see cref="EventNameTransform"/> property.
+        /// </summary>
+        private Func<string, string> eventNameTransform = n => n;
+
+        /// <summary>
         /// Gets or sets a function that takes the CLR method name and returns the RPC method name.
         /// This method is useful for adding prefixes to all methods, or making them camelCased.
         /// </summary>
@@ -26,6 +31,18 @@ namespace StreamJsonRpc
         {
             get => this.methodNameTransform;
             set => this.methodNameTransform = Requires.NotNull(value, nameof(value));
+        }
+
+        /// <summary>
+        /// Gets or sets a function that takes the CLR event name and returns the RPC event name used in notifications.
+        /// This method is useful for adding prefixes to all events, or making them camelCased.
+        /// </summary>
+        /// <value>A function, defaulting to a straight pass-through. Never null.</value>
+        /// <exception cref="ArgumentNullException">Thrown if set to a null value.</exception>
+        public Func<string, string> EventNameTransform
+        {
+            get => this.eventNameTransform;
+            set => this.eventNameTransform = Requires.NotNull(value, nameof(value));
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -17,6 +17,12 @@ namespace StreamJsonRpc
         public Func<string, string> MethodNameTransform { get; set; }
 
         /// <summary>
+        /// Gets or sets a function that takes the CLR event name and returns the RPC event name used in notification messages.
+        /// This method is useful for adding prefixes to all events, or making them camelCased.
+        /// </summary>
+        public Func<string, string> EventNameTransform { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether events raised on the target object
         /// should be relayed to the client via a JSON-RPC notify message.
         /// </summary>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -11,10 +11,14 @@ StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.Synchroniza
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void
 StreamJsonRpc.JsonRpcProxyOptions
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions() -> void
+StreamJsonRpc.JsonRpcProxyOptions.EventNameTransform.get -> System.Func<string, string>
+StreamJsonRpc.JsonRpcProxyOptions.EventNameTransform.set -> void
 StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.get -> System.Func<string, string>
 StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.set -> void
 StreamJsonRpc.JsonRpcTargetOptions
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions() -> void
+StreamJsonRpc.JsonRpcTargetOptions.EventNameTransform.get -> System.Func<string, string>
+StreamJsonRpc.JsonRpcTargetOptions.EventNameTransform.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.MethodNameTransform.get -> System.Func<string, string>
 StreamJsonRpc.JsonRpcTargetOptions.MethodNameTransform.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.NotifyClientOfEvents.get -> bool


### PR DESCRIPTION
Adds usage of name transform functions to both proxy generation and also while raising notify messages. Adds unit tests for relevant cases. Fixes #135.