### PR TITLE
Reduce GC pressure

### DIFF
--- a/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
@@ -143,18 +143,11 @@ namespace StreamJsonRpc
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));
 
             int index = 0;
-            var result = new List<object>(parameterInfos.Length);
+            var result = new object[parameterInfos.Length];
             foreach (var parameter in this.Parameters?.Children() ?? Enumerable.Empty<JToken>())
             {
-                Type type = typeof(object);
-                if (index < parameterInfos.Length)
-                {
-                    type = parameterInfos[index].ParameterType;
-                    index++;
-                }
-
-                object value = parameter.ToObject(type, jsonSerializer);
-                result.Add(value);
+                object value = parameter.ToObject(parameterInfos[index].ParameterType, jsonSerializer);
+                result[index++] = value;
             }
 
             for (; index < parameterInfos.Length; index++)
@@ -163,10 +156,10 @@ namespace StreamJsonRpc
                     parameterInfos[index].HasDefaultValue ? parameterInfos[index].DefaultValue :
                     parameterInfos[index].ParameterType == typeof(CancellationToken) ? (CancellationToken?)CancellationToken.None :
                     null;
-                result.Add(value);
+                result[index++] = value;
             }
 
-            return result.ToArray();
+            return result;
         }
 
         public string ToJson(Formatting formatting, JsonSerializerSettings settings)

--- a/src/StreamJsonRpc/Reflection/MethodSignature.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignature.cs
@@ -90,7 +90,7 @@ namespace StreamJsonRpc
             int bitCount = sizeof(uint) * 8;
             const int shift = 1;
 
-            foreach (ParameterInfo parameter in this.MethodInfo.GetParameters())
+            foreach (ParameterInfo parameter in this.Parameters)
             {
                 // Shifting result 1 bit per each parameter so that the hash is different for
                 // methods with the same parameter types at different location, e.g.

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -24,7 +24,7 @@ namespace StreamJsonRpc
         internal TargetMethod(
             JsonRpcMessage request,
             JsonSerializer jsonSerializer,
-            IEnumerable<MethodSignatureAndTarget> candidateMethodTargets)
+            List<MethodSignatureAndTarget> candidateMethodTargets)
         {
             Requires.NotNull(request, nameof(request));
             Requires.NotNull(jsonSerializer, nameof(jsonSerializer));

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -112,21 +112,22 @@ namespace StreamJsonRpc
                     return null;
                 }
 
-                var args = new List<object>(2);
-                args.Add(request.Parameters);
-
-                if (method.Parameters.Length > 1 && method.Parameters[1].ParameterType == typeof(CancellationToken))
-                {
-                    args.Add(CancellationToken.None);
-                }
-
                 if (method.Parameters.Length > 2)
                 {
                     // We don't support methods with more than two parameters.
                     return null;
                 }
 
-                return args.ToArray();
+                bool includeCancellationToken = method.Parameters.Length > 1 && method.Parameters[1].ParameterType == typeof(CancellationToken);
+
+                var args = new object[includeCancellationToken ? 2 : 1];
+                args[0] = request.Parameters;
+                if (includeCancellationToken)
+                {
+                    args[1] = CancellationToken.None;
+                }
+
+                return args;
             }
 
             // The number of parameters must fall within required and total parameters.


### PR DESCRIPTION
This is a bunch of micro-optimizations to remove allocations based on a study of PerfView memory allocation traces from work on https://github.com/AArnott/Nerdbank.Streams/issues/15.

This drops per-iteration allocations by about 50% (from 323 to 152 in my testing).