### PR TITLE
Reduce GC pressure

### DIFF
--- a/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
@@ -22,7 +22,7 @@ namespace StreamJsonRpc
 
         private JsonRpcMessage(string method, JToken parameters, object id = null, string jsonrpc = "2.0")
         {
-            this.Parameters = parameters;
+            this.Parameters = (JContainer)parameters; // must be an array, an object, or null.
             this.Method = method;
             this.Id = id != null ? JToken.FromObject(id) : null;
             this.JsonRpcVersion = jsonrpc;
@@ -41,7 +41,7 @@ namespace StreamJsonRpc
         public JsonRpcError Error { get; private set; }
 
         [JsonProperty("params")]
-        public JToken Parameters
+        public JContainer Parameters
         {
             get;
             set;
@@ -55,7 +55,7 @@ namespace StreamJsonRpc
 
         public bool IsNotification => this.Id == null;
 
-        public int ParameterCount => this.Parameters != null ? this.Parameters.Children().Count() : 0;
+        public int ParameterCount => this.Parameters?.Count ?? 0;
 
         [JsonProperty("result")]
         private JToken Result

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -4,6 +4,7 @@
 namespace StreamJsonRpc
 {
     using System;
+    using System.Buffers;
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
@@ -12,7 +13,6 @@ namespace StreamJsonRpc
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft;
     using Microsoft.VisualStudio.Threading;
 
     /// <summary>
@@ -208,48 +208,56 @@ namespace StreamJsonRpc
         {
             this.sendingBufferStream.SetLength(0);
 
-            // Understand the content we need to send in terms of bytes and length.
-            byte[] contentBytes = contentEncoding.GetBytes(content);
-            string contentBytesLength = contentBytes.Length.ToString(CultureInfo.InvariantCulture);
-
-            // Transmit the Content-Length header.
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-            this.sendingBufferStream.Write(ContentLengthHeaderName, 0, ContentLengthHeaderName.Length);
-            this.sendingBufferStream.Write(HeaderKeyValueDelimiter, 0, HeaderKeyValueDelimiter.Length);
-            int headerValueBytesLength = HeaderEncoding.GetBytes(contentBytesLength, 0, contentBytesLength.Length, this.sendingHeaderBuffer, 0);
-            this.sendingBufferStream.Write(this.sendingHeaderBuffer, 0, headerValueBytesLength);
-            this.sendingBufferStream.Write(CrlfBytes, 0, CrlfBytes.Length);
-
-            // Transmit the Content-Type header, but only when using a non-default encoding.
-            // We suppress it when it is the default both for smaller messages and to avoid
-            // having to load System.Net.Http on the receiving end in order to parse it.
-            if (DefaultContentEncoding.WebName != contentEncoding.WebName || this.SubType != DefaultSubType)
+            byte[] contentBytes = ArrayPool<byte>.Shared.Rent(contentEncoding.GetMaxByteCount(content.Length));
+            try
             {
-                this.sendingBufferStream.Write(ContentTypeHeaderName, 0, ContentTypeHeaderName.Length);
+                // Understand the content we need to send in terms of bytes and length.
+                int contentBytesLength = contentEncoding.GetBytes(content, 0, content.Length, contentBytes, 0);
+                string contentBytesLengthString = contentBytesLength.ToString(CultureInfo.InvariantCulture);
+
+                // Transmit the Content-Length header.
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+                this.sendingBufferStream.Write(ContentLengthHeaderName, 0, ContentLengthHeaderName.Length);
                 this.sendingBufferStream.Write(HeaderKeyValueDelimiter, 0, HeaderKeyValueDelimiter.Length);
-                var contentTypeHeaderValue = $"application/{this.SubType}; charset={contentEncoding.WebName}";
-                headerValueBytesLength = HeaderEncoding.GetBytes(contentTypeHeaderValue, 0, contentTypeHeaderValue.Length, this.sendingHeaderBuffer, 0);
+                int headerValueBytesLength = HeaderEncoding.GetBytes(contentBytesLengthString, 0, contentBytesLengthString.Length, this.sendingHeaderBuffer, 0);
                 this.sendingBufferStream.Write(this.sendingHeaderBuffer, 0, headerValueBytesLength);
                 this.sendingBufferStream.Write(CrlfBytes, 0, CrlfBytes.Length);
-            }
 
-            // Terminate the headers.
-            this.sendingBufferStream.Write(CrlfBytes, 0, CrlfBytes.Length);
+                // Transmit the Content-Type header, but only when using a non-default encoding.
+                // We suppress it when it is the default both for smaller messages and to avoid
+                // having to load System.Net.Http on the receiving end in order to parse it.
+                if (DefaultContentEncoding.WebName != contentEncoding.WebName || this.SubType != DefaultSubType)
+                {
+                    this.sendingBufferStream.Write(ContentTypeHeaderName, 0, ContentTypeHeaderName.Length);
+                    this.sendingBufferStream.Write(HeaderKeyValueDelimiter, 0, HeaderKeyValueDelimiter.Length);
+                    var contentTypeHeaderValue = $"application/{this.SubType}; charset={contentEncoding.WebName}";
+                    headerValueBytesLength = HeaderEncoding.GetBytes(contentTypeHeaderValue, 0, contentTypeHeaderValue.Length, this.sendingHeaderBuffer, 0);
+                    this.sendingBufferStream.Write(this.sendingHeaderBuffer, 0, headerValueBytesLength);
+                    this.sendingBufferStream.Write(CrlfBytes, 0, CrlfBytes.Length);
+                }
+
+                // Terminate the headers.
+                this.sendingBufferStream.Write(CrlfBytes, 0, CrlfBytes.Length);
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
 
-            // Either write both the header and the content, or don't write anything.
-            // If we write only the header when the cancellation comes, that would confuse the recieving side
-            // and corrupt the data data it reads.
-            cancellationToken.ThrowIfCancellationRequested();
+                // Either write both the header and the content, or don't write anything.
+                // If we write only the header when the cancellation comes, that would confuse the recieving side
+                // and corrupt the data data it reads.
+                cancellationToken.ThrowIfCancellationRequested();
 
-            // Transmit the headers.
-            // Ignore the cancellation token so we don't write the header without the content.
-            this.sendingBufferStream.Position = 0;
-            await this.sendingBufferStream.CopyToAsync(this.SendingStream, MaxHeaderElementSize).ConfigureAwait(false);
+                // Transmit the headers.
+                // Ignore the cancellation token so we don't write the header without the content.
+                this.sendingBufferStream.Position = 0;
+                await this.sendingBufferStream.CopyToAsync(this.SendingStream, MaxHeaderElementSize).ConfigureAwait(false);
 
-            // Transmit the content itself.
-            // Ignore the cancellation token so we don't write the header without the content.
-            await this.SendingStream.WriteAsync(contentBytes, 0, contentBytes.Length).ConfigureAwait(false);
+                // Transmit the content itself.
+                // Ignore the cancellation token so we don't write the header without the content.
+                await this.SendingStream.WriteAsync(contentBytes, 0, contentBytesLength).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(contentBytes);
+            }
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -36,15 +36,15 @@ namespace StreamJsonRpc
 
             this.request = request;
 
-            foreach (var method in candidateMethodTargets)
+            foreach (var candidateMethod in candidateMethodTargets)
             {
-                object[] args = this.TryGetParameters(request, method.Signature, jsonSerializer, request.Method);
+                object[] args = this.TryGetParameters(request, candidateMethod.Signature, jsonSerializer, request.Method);
                 if (this.method == null && args != null)
                 {
-                    this.target = method.Target;
-                    this.method = method.Signature.MethodInfo;
+                    this.target = candidateMethod.Target;
+                    this.method = candidateMethod.Signature.MethodInfo;
                     this.parameters = args;
-                    this.AcceptsCancellationToken = method.Signature.HasCancellationTokenParameter;
+                    this.AcceptsCancellationToken = candidateMethod.Signature.HasCancellationTokenParameter;
                     break;
                 }
             }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -45,6 +45,7 @@ namespace StreamJsonRpc
                     this.method = method.Signature.MethodInfo;
                     this.parameters = args;
                     this.AcceptsCancellationToken = method.Signature.HasCancellationTokenParameter;
+                    break;
                 }
             }
         }

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.20" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -4,6 +4,7 @@
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);WEBSOCKETS</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>


### PR DESCRIPTION
As a follow-up to #137, this adds the rest of my GC pressure fixes. I had an error in how I measured GC pressure that made it *look* like some of my enhancements were making things worse somehow, but it was only because they made things so much better that the CLR ran GC fewer times, which led to being blamed for more bytes allocated since the last GC. 

The real fix is to not run GC *at all* during the test, which @BertanAygun helped me learn how to do.