### PR TITLE
Introduce v2.0 and remove some target frameworks

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -247,7 +247,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         Assert.Throws<TypeLoadException>(() => JsonRpc.Attach<IServerInternal>(streams.Item1));
     }
 
-#if NET452 || NET461 || NETCOREAPP2_0
+#if NET461 || NETCOREAPP2_0
     [Fact]
     public async Task RPCMethodNameSubstitution()
     {
@@ -278,7 +278,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         Assert.Equal("Hi!", await clientRpcWithCamelCase.SayHiAsync()); // "sayHiAsync"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
-#if NET452 || NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
+#if NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
         Assert.Equal("ANDREW", await clientRpcWithCamelCase.ARoseByAsync("andrew")); // "anotherName"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
 #endif
@@ -289,7 +289,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Retry with our second client proxy to send messages which the server should now accept.
         Assert.Equal("Hi!", await clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
-#if NET452 || NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
+#if NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
         Assert.Equal("ANDREW", await clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
 #endif
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -501,9 +501,7 @@ public class JsonRpcTests : TestBase
                 };
 
                 var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, cts.Token)).WithTimeout(UnexpectedTimeout);
-#if !NET452
                 Assert.Equal(cts.Token, ex.CancellationToken);
-#endif
                 this.clientStream.BeforeWrite = null;
             }
 
@@ -553,9 +551,7 @@ public class JsonRpcTests : TestBase
 
             // Ultimately, the server throws because it was canceled.
             var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask.WithTimeout(UnexpectedTimeout));
-#if !NET452
             Assert.Equal(cts.Token, ex.CancellationToken);
-#endif
         }
     }
 
@@ -1211,7 +1207,7 @@ public class JsonRpcTests : TestBase
         await Task.WhenAll(invocation1, invocation2);
     }
 
-#if NET452 || NET461 || NETCOREAPP2_0
+#if NET461 || NETCOREAPP2_0
     [Fact]
     public async Task ServerRespondsWithMethodRenamedByInterfaceAttribute()
     {
@@ -1348,16 +1344,7 @@ public class JsonRpcTests : TestBase
             return tcs.Task;
         }
 
-        public Task ReturnPlainTask()
-        {
-#if NET452
-            var task = new Task(() => { });
-            task.RunSynchronously(TaskScheduler.Default);
-            return task;
-#else
-            return Task.CompletedTask;
-#endif
-        }
+        public Task ReturnPlainTask() => Task.CompletedTask;
 
         public void MethodThatThrowsUnauthorizedAccessException()
         {

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net452;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StreamJsonRpc.Tests.ruleset</CodeAnalysisRuleSet>
     <RootNamespace />
@@ -38,7 +38,7 @@
     <ProjectReference Include="..\StreamJsonRpc\StreamJsonRpc.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes" Version="4.0.0" Condition=" '$(TargetFramework)' != 'net452' " />
+    <PackageReference Include="System.IO.Pipes" Version="4.0.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <!-- PackageReference Include="Nerdbank.FullDuplexStream" Version="1.0.9" /-->

--- a/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0 || NET452 || NET461
+﻿#if NETCOREAPP2_0 || NET461
 
 using System;
 using System.Collections.Generic;

--- a/src/StreamJsonRpc.sln
+++ b/src/StreamJsonRpc.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{68DDB820-140B-4178-B030-3E47C460376B}"
 	ProjectSection(SolutionItems) = preProject
 		..\.appveyor.yml = ..\.appveyor.yml
+		..\.travis.yml = ..\.travis.yml
 		..\.vsts-ci.yml = ..\.vsts-ci.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1466,34 +1466,14 @@ namespace StreamJsonRpc
         /// <param name="state">The ID associated with the request to be canceled.</param>
         private void CancelPendingOutboundRequest(object state)
         {
+            Requires.NotNull(state, nameof(state));
             Task.Run(async delegate
             {
-                try
+                if (!this.disposed)
                 {
-                    Requires.NotNull(state, nameof(state));
-                    object id = state;
-                    if (!this.disposed)
-                    {
-                        var cancellationMessage = JsonRpcMessage.CreateRequestWithNamedParameters(id: null, method: CancelRequestSpecialMethod, namedParameters: new { id = id }, parameterSerializer: DefaultJsonSerializer);
-                        await this.TransmitAsync(cancellationMessage, this.disposeCts.Token).ConfigureAwait(false);
-                    }
+                    var cancellationMessage = JsonRpcMessage.CreateRequestWithNamedParameters(id: null, method: CancelRequestSpecialMethod, namedParameters: new { id = state }, parameterSerializer: DefaultJsonSerializer);
+                    await this.TransmitAsync(cancellationMessage, this.disposeCts.Token).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
-                {
-                }
-                catch (ObjectDisposedException)
-                {
-                }
-#if NET45
-                catch (Exception ex)
-                {
-                    Debug.Fail(ex.Message, ex.ToString());
-                }
-#else
-                catch (Exception)
-                {
-                }
-#endif
             });
         }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -888,11 +888,7 @@ namespace StreamJsonRpc
                         {
                             if (response.Error?.Code == (int)JsonRpcErrorCode.RequestCanceled)
                             {
-#if TRYSETCANCELED_CT
                                 tcs.TrySetCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : CancellationToken.None);
-#else
-                                tcs.TrySetCanceled();
-#endif
                             }
                             else
                             {
@@ -1499,7 +1495,7 @@ namespace StreamJsonRpc
             internal MethodNameMap(TypeInfo typeInfo)
             {
                 Requires.NotNull(typeInfo, nameof(typeInfo));
-#if NET45 || NET46 || NETSTANDARD2_0
+#if NET46 || NETSTANDARD2_0
                 this.interfaceMaps = typeInfo.ImplementedInterfaces.Select(i => typeInfo.GetInterfaceMap(i)).ToList();
 #else
                 this.interfaceMaps = new List<InterfaceMapping>();

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.6;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);WEBSOCKETS</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);EXCLUDEFROMCODECOVERAGEATTRIBUTE</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' ">$(DefineConstants);TRYSETCANCELED_CT</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);WEBSOCKETS</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);SERIALIZABLE_EXCEPTIONS</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);EXCLUDEFROMCODECOVERAGEATTRIBUTE</DefineConstants>
 
     <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol and can use System.IO.Stream or WebSocket so you can use it with any transport.</Description>
     <PackageTags>visualstudio stream json rpc</PackageTags>
@@ -36,8 +35,6 @@
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;portable-net45+win8+wpa81;net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>StreamJsonRpc.ruleset</CodeAnalysisRuleSet>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,7 +37,10 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="1.2.0-beta2" PrivateAssets="all" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5-beta",
+  "version": "2.0-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches


### PR DESCRIPTION
* Drop target frameworks: netstandard1.1, netstandard1.3, Profile259, and net45. This speeds up our builds and simplifies our code `#if` checks. We were never testing these two builds of the library so arguably we shouldn't have been shipping it. I add netstandard1.6 as a target (which we test) and covers [all the platforms](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) we care about anyway.
* Use master to track the 2.0-alpha version

I've pushed a v1.5 branch to track future 1.x work.