### PR TITLE
Prepare for Pipelines

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="MSBuild.SDK.Extras" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="GitLink" Version="3.2.0-unstable0014" PrivateAssets="all" />

--- a/src/StreamJsonRpc.Tests/FullDuplexStream.cs
+++ b/src/StreamJsonRpc.Tests/FullDuplexStream.cs
@@ -41,7 +41,7 @@
         private TaskCompletionSource<object> enqueuedSource = new TaskCompletionSource<object>(EnqueuedSourceOptions);
 
         /// <summary>
-        /// Gets or sets a value indicating whether the stream is disposed
+        /// Gets or sets a value indicating whether the stream is disposed.
         /// </summary>
         public bool IsDisposed { get; set; }
 

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1226,6 +1226,11 @@ public class JsonRpcTests : TestBase
             this.clientStream.Dispose();
         }
 
+        if (this.serverRpc.Completion.IsFaulted)
+        {
+            this.Logger.WriteLine("Server faulted with: " + this.serverRpc.Completion.Exception);
+        }
+
         base.Dispose(disposing);
     }
 

--- a/src/StreamJsonRpc.Tests/MessageHeaderTests.cs
+++ b/src/StreamJsonRpc.Tests/MessageHeaderTests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -40,30 +38,38 @@ public class MessageHeaderTests : TestBase
 
         await clientRpc.NotifyAsync("someMethod");
         clientRpc.Dispose();
-        var sr = new StreamReader(this.serverStream, Encoding.ASCII, false);
+        MemoryStream seekableServerStream = await this.GetSeekableServerStream();
+        var sr = new StreamReader(seekableServerStream, Encoding.ASCII, false);
         var headers = new Dictionary<string, string>();
         string header;
         var headerRegEx = new Regex("(.+?): (.+)");
+        int bytesRead = 0;
         while ((header = sr.ReadLine())?.Length > 0)
         {
+            bytesRead += header.Length + 2; // CRLF
             this.Logger.WriteLine(header);
             var match = headerRegEx.Match(header);
             Assert.True(match.Success);
             headers[match.Groups[1].Value] = match.Groups[2].Value;
         }
 
+        bytesRead += 2; // final CRLF
+
         Assert.True(headers.ContainsKey("Content-Length"));
         Assert.True(int.TryParse(headers["Content-Length"], out int length));
         Assert.NotEqual(0, length);
         byte[] messageBuffer = new byte[length];
-        int bytesRead = 0;
+        seekableServerStream.Position = bytesRead; // reset position to counteract buffer built up in StreamReader
+        bytesRead = 0;
         while (bytesRead < length)
         {
-            bytesRead += await this.serverStream.ReadAsync(messageBuffer, bytesRead, length - bytesRead, this.TimeoutToken);
+            int bytesJustRead = await seekableServerStream.ReadAsync(messageBuffer, bytesRead, length - bytesRead, this.TimeoutToken);
+            Assert.NotEqual(0, bytesJustRead); // end of stream reached unexpectedly.
+            bytesRead += bytesJustRead;
         }
 
         // Assert that the stream terminates after the alleged length of the only message sent.
-        Assert.Equal(-1, this.serverStream.ReadByte());
+        Assert.Equal(-1, seekableServerStream.ReadByte());
 
         // Decode the message for logging purposes.
         // Actually deserializing the message is beyond the scope of this test.
@@ -108,14 +114,18 @@ public class MessageHeaderTests : TestBase
         await rpcClient.NotifyAsync("Foo");
         rpcClient.Dispose();
 
-        var reader = new StreamReader(this.serverStream, Encoding.ASCII);
+        MemoryStream seekableServerStream = await this.GetSeekableServerStream();
+        int bytesRead = 0;
+        var reader = new StreamReader(seekableServerStream, Encoding.ASCII);
         var headerLines = new List<string>();
         string line;
         while ((line = reader.ReadLine()) != string.Empty)
         {
             headerLines.Add(line);
+            bytesRead += line.Length + 2; // + CRLF
         }
 
+        bytesRead += 2; // final CRLF
         this.Logger.WriteLine(string.Join(Environment.NewLine, headerLines));
 
         // utf-8 headers may not be present because they are the default, per the protocol spec.
@@ -124,9 +134,20 @@ public class MessageHeaderTests : TestBase
             Assert.Contains(headerLines, l => l.Contains($"charset={encodingName}"));
         }
 
-        reader = new StreamReader(this.serverStream, Encoding.GetEncoding(encodingName));
+        // Because the first StreamReader probably read farther (to fill its buffer) than the end of the headers,
+        // we need to reposition the stream at the start of the content to create a new StreamReader.
+        seekableServerStream.Position = bytesRead;
+        reader = new StreamReader(seekableServerStream, Encoding.GetEncoding(encodingName));
         string json = reader.ReadToEnd();
         Assert.Equal('{', json[0]);
+    }
+
+    private async Task<MemoryStream> GetSeekableServerStream()
+    {
+        var seekableServerStream = new MemoryStream();
+        await this.serverStream.CopyToAsync(seekableServerStream);
+        seekableServerStream.Position = 0;
+        return seekableServerStream;
     }
 
     private class Server

--- a/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
@@ -346,6 +346,7 @@ public class WebSocketMessageHandlerTests : TestBase
                         await rpc.Completion;
                     }
                 }
+
                 await next();
             });
         }

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -22,7 +22,7 @@ namespace StreamJsonRpc
     /// </summary>
     /// <remarks>
     /// This is based on the language server protocol spec:
-    /// https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#base-protocol
+    /// https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#base-protocol.
     /// </remarks>
     public class HeaderDelimitedMessageHandler : StreamMessageHandler
     {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1475,7 +1475,7 @@ namespace StreamJsonRpc
                     var cancellationMessage = JsonRpcMessage.CreateRequestWithNamedParameters(id: null, method: CancelRequestSpecialMethod, namedParameters: new { id = state }, parameterSerializer: DefaultJsonSerializer);
                     await this.TransmitAsync(cancellationMessage, this.disposeCts.Token).ConfigureAwait(false);
                 }
-            });
+            }).Forget();
         }
 
 #pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
@@ -1607,7 +1607,7 @@ namespace StreamJsonRpc
 
             private void OnEventRaised(object sender, EventArgs args)
             {
-                this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args });
+                this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args }).Forget();
             }
         }
     }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -561,7 +561,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="TResult">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="argument">Method argument, must be serializable to JSON.</param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
@@ -589,7 +589,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="TResult">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
@@ -620,7 +620,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.  The parameter is passed as an object.
         /// </summary>
-        /// <typeparam name="TResult">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="argument">Method argument, must be serializable to JSON.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
@@ -678,7 +678,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Invoke a method on the server and get back the result.
         /// </summary>
-        /// <typeparam name="TResult">Type of the method result</typeparam>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
         /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
         /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
@@ -801,7 +801,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Indicates whether the connection should be closed when the server throws an exception.
         /// </summary>
-        /// <param name="ex">The <see cref="Exception"/> thrown from server that is potentially fatal</param>
+        /// <param name="ex">The <see cref="Exception"/> thrown from server that is potentially fatal.</param>
         /// <returns>A <see cref="bool"/> indicating if the streams should be closed.</returns>
         /// <remarks>
         /// This method is invoked within the context of an exception filter or when a task fails to complete and simply returns false by default.
@@ -811,9 +811,9 @@ namespace StreamJsonRpc
         protected virtual bool IsFatalException(Exception ex) => false;
 
         /// <summary>
-        /// Invokes the specified RPC method
+        /// Invokes the specified RPC method.
         /// </summary>
-        /// <typeparam name="TResult">RPC method return type</typeparam>
+        /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>
@@ -826,9 +826,9 @@ namespace StreamJsonRpc
         }
 
         /// <summary>
-        /// Invokes the specified RPC method
+        /// Invokes the specified RPC method.
         /// </summary>
-        /// <typeparam name="TResult">RPC method return type</typeparam>
+        /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.20" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.20" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.122" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.122" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />


### PR DESCRIPTION
These changes are a bunch of style or test resiliency changes. I made them as part of an upcoming change to add System.IO.Pipelines support to the API. That work is done, but this is a preliminary PR to get some of the noisier style/test changes out of the way first. The test changes fix issues where the tests were verifying behavior that was never reliable, and in fact changes later with the pipeline work.