### PR TITLE
Remove unused JsonRpc.JsonSerializerFormatting property

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClientInteropTests.cs
@@ -100,7 +100,6 @@ public class JsonRpcClientInteropTests : InteropTestBase
     [Fact]
     public async Task SerializeWithNoWhitespace()
     {
-        this.clientRpc.JsonSerializerFormatting = Newtonsoft.Json.Formatting.None;
         Task notifyTask = this.clientRpc.NotifyAsync("test");
         JToken jtoken = await this.messageHandler.WrittenMessages.DequeueAsync(this.TimeoutToken);
         string json = jtoken.ToString(Formatting.None);

--- a/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/DataContracts/JsonRpcMessage.cs
@@ -120,19 +120,6 @@ namespace StreamJsonRpc
             return json.ToObject<JsonRpcMessage>(serializer);
         }
 
-        public static JsonRpcMessage FromJson(JsonReader reader, JsonSerializerSettings settings)
-        {
-            JsonSerializer serializer = JsonSerializer.Create(settings);
-
-            JsonRpcMessage result = serializer.Deserialize<JsonRpcMessage>(reader);
-            if (result == null)
-            {
-                throw new JsonException(Resources.JsonRpcCannotBeNull);
-            }
-
-            return result;
-        }
-
         public T GetResult<T>(JsonSerializer serializer)
         {
             return this.Result == null ? default(T) : this.Result.ToObject<T>(serializer);
@@ -161,11 +148,6 @@ namespace StreamJsonRpc
             }
 
             return result;
-        }
-
-        public string ToJson(Formatting formatting, JsonSerializerSettings settings)
-        {
-            return JsonConvert.SerializeObject(this, formatting, settings);
         }
     }
 }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -259,12 +259,6 @@ namespace StreamJsonRpc
         /// </summary>
         public JsonSerializer JsonSerializer { get; }
 
-        /// <summary>
-        /// Gets or sets the formatting to use when serializing JSON-RPC messages.
-        /// </summary>
-        /// <value>The default value is <see cref="Formatting.Indented"/>.</value>
-        public Formatting JsonSerializerFormatting { get; set; } = Formatting.Indented;
-
         private JsonSerializerSettings MessageJsonSerializerSettings { get; }
 
         private JsonSerializerSettings MessageJsonDeserializerSettings { get; }

--- a/src/StreamJsonRpc/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Shipped.txt
@@ -65,8 +65,6 @@ StreamJsonRpc.JsonRpc.AllowModificationWhileListening.set -> void
 StreamJsonRpc.JsonRpc.Attach<T>() -> T
 StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.JsonRpcProxyOptions options) -> T
 StreamJsonRpc.JsonRpc.Completion.get -> System.Threading.Tasks.Task
-StreamJsonRpc.JsonRpc.JsonSerializerFormatting.get -> Newtonsoft.Json.Formatting
-StreamJsonRpc.JsonRpc.JsonSerializerFormatting.set -> void
 StreamJsonRpc.JsonRpc.SynchronizationContext.get -> System.Threading.SynchronizationContext
 StreamJsonRpc.JsonRpc.SynchronizationContext.set -> void
 StreamJsonRpc.JsonRpcProxyOptions


### PR DESCRIPTION
It was used in the 1.x era, but no more.