### PR TITLE
Fix build break in PRs from forks

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,6 +19,11 @@ jobs:
 - job: Windows
   pool: Hosted VS2017
   steps:
+  - script: |
+      dotnet tool install --tool-path . nbgv
+      .\nbgv cloud -p src
+    displayName: Set build number
+    condition: ne(variables['system.pullrequest.isfork'], true)
   - task: PowerShell@2
     displayName: Set VSTS variables
     inputs:

--- a/src/version.json
+++ b/src/version.json
@@ -4,10 +4,5 @@
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches
-  ],
-  "cloudBuild": {
-    "buildNumber": {
-      "enabled": true
-    }
-  }
+  ]
 }


### PR DESCRIPTION
This works around the build break that occurs on Azure Pipelines when a PR from a forked repo tries to set the build number.