### PR TITLE
More handlers!

### DIFF
--- a/src/StreamJsonRpc.Tests/LengthHeaderMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/LengthHeaderMessageHandlerTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class LengthHeaderMessageHandlerTests : TestBase
+{
+    private HalfDuplexStream halfDuplexStream = new HalfDuplexStream();
+    private LengthHeaderMessageHandler handler;
+
+    public LengthHeaderMessageHandlerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.handler = new LengthHeaderMessageHandler(this.halfDuplexStream, this.halfDuplexStream, new JsonMessageFormatter());
+    }
+
+    [Fact]
+    public void Ctor_NullPipe()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LengthHeaderMessageHandler(null, new JsonMessageFormatter()));
+    }
+
+    [Fact]
+    public void Ctor_NullFormatter()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LengthHeaderMessageHandler(new MemoryStream().UsePipe(), null));
+    }
+
+    [Fact]
+    public void Ctor_NullWriter()
+    {
+        this.handler = new LengthHeaderMessageHandler(null, new MemoryStream().UsePipeReader(), new JsonMessageFormatter());
+        Assert.True(this.handler.CanRead);
+        Assert.False(this.handler.CanWrite);
+    }
+
+    [Fact]
+    public void Ctor_NullReader()
+    {
+        this.handler = new LengthHeaderMessageHandler(new MemoryStream().UsePipeWriter(), null, new JsonMessageFormatter());
+        Assert.False(this.handler.CanRead);
+        Assert.True(this.handler.CanWrite);
+    }
+
+    [Fact]
+    public void Ctor_NullWriteStream()
+    {
+        this.handler = new LengthHeaderMessageHandler(null, new MemoryStream(), new JsonMessageFormatter());
+        Assert.True(this.handler.CanRead);
+        Assert.False(this.handler.CanWrite);
+    }
+
+    [Fact]
+    public void Ctor_NullReadStream()
+    {
+        this.handler = new LengthHeaderMessageHandler(new MemoryStream(), null, new JsonMessageFormatter());
+        Assert.False(this.handler.CanRead);
+        Assert.True(this.handler.CanWrite);
+    }
+
+    [Fact]
+    public async Task EndOfStream()
+    {
+        this.halfDuplexStream.CompleteWriting();
+        Assert.Null(await this.handler.ReadAsync(this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task WriteAndRead()
+    {
+        JsonRpcRequest original = new JsonRpcRequest { Method = "test" };
+        await this.handler.WriteAsync(original, this.TimeoutToken);
+        var commuted = (JsonRpcRequest)await this.handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(original.Method, commuted.Method);
+    }
+}

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -70,7 +70,7 @@ namespace StreamJsonRpc
         /// <param name="writer">The writer to use for transmitting messages.</param>
         /// <param name="reader">The reader to use for receiving messages.</param>
         /// <param name="formatter">The formatter to use to serialize <see cref="JsonRpcMessage"/> instances.</param>
-        public HeaderDelimitedMessageHandler(PipeWriter writer, PipeReader reader, IJsonRpcMessageTextFormatter formatter)
+        public HeaderDelimitedMessageHandler(PipeWriter writer, PipeReader reader, IJsonRpcMessageFormatter formatter)
             : base(writer, reader)
         {
             Requires.NotNull(formatter, nameof(formatter));
@@ -82,7 +82,7 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="pipe">The duplex pipe to use for exchanging messages.</param>
         /// <param name="formatter">The formatter to use to serialize <see cref="JsonRpcMessage"/> instances.</param>
-        public HeaderDelimitedMessageHandler(IDuplexPipe pipe, IJsonRpcMessageTextFormatter formatter)
+        public HeaderDelimitedMessageHandler(IDuplexPipe pipe, IJsonRpcMessageFormatter formatter)
             : this(pipe.Output, pipe.Input, formatter)
         {
         }
@@ -92,7 +92,7 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="duplexStream">The stream to use for exchanging messages.</param>
         /// <param name="formatter">The formatter to use to serialize <see cref="JsonRpcMessage"/> instances.</param>
-        public HeaderDelimitedMessageHandler(Stream duplexStream, IJsonRpcMessageTextFormatter formatter)
+        public HeaderDelimitedMessageHandler(Stream duplexStream, IJsonRpcMessageFormatter formatter)
             : this(duplexStream, duplexStream, formatter)
         {
         }
@@ -122,7 +122,7 @@ namespace StreamJsonRpc
         /// <param name="sendingStream">The stream to use for transmitting messages.</param>
         /// <param name="receivingStream">The stream to use for receiving messages.</param>
         /// <param name="formatter">The formatter to use to serialize <see cref="JsonRpcMessage"/> instances.</param>
-        public HeaderDelimitedMessageHandler(Stream sendingStream, Stream receivingStream, IJsonRpcMessageTextFormatter formatter)
+        public HeaderDelimitedMessageHandler(Stream sendingStream, Stream receivingStream, IJsonRpcMessageFormatter formatter)
             : base(sendingStream, receivingStream)
         {
             Requires.NotNull(formatter, nameof(formatter));
@@ -156,16 +156,23 @@ namespace StreamJsonRpc
         /// <summary>
         /// Gets or sets the encoding to use for transmitted messages.
         /// </summary>
+        /// <exception cref="NotSupportedException">Thrown if the <see cref="Formatter"/> in use does not implement <see cref="IJsonRpcMessageTextFormatter"/>.</exception>
         public Encoding Encoding
         {
-            get => this.Formatter.Encoding;
-            set => this.Formatter.Encoding = value;
+            get => this.TextFormatter.Encoding;
+            set => this.TextFormatter.Encoding = value;
         }
 
         /// <summary>
         /// Gets the formatter to use to serialize <see cref="JsonRpcMessage"/> instances.
         /// </summary>
-        public IJsonRpcMessageTextFormatter Formatter { get; }
+        public IJsonRpcMessageFormatter Formatter { get; }
+
+        /// <summary>
+        /// Gets the formatter to use to serialize <see cref="JsonRpcMessage"/> instances as text.
+        /// Throws if the formatter is not a text-based formatter.
+        /// </summary>
+        private IJsonRpcMessageTextFormatter TextFormatter => this.Formatter as IJsonRpcMessageTextFormatter ?? throw this.ThrowNoTextEncoder();
 
         /// <inheritdoc />
         protected override async ValueTask<JsonRpcMessage> ReadCoreAsync(CancellationToken cancellationToken)
@@ -184,7 +191,6 @@ namespace StreamJsonRpc
             }
 
             int contentLength = headers.Value.ContentLength.Value;
-            Encoding contentEncoding = headers.Value.ContentEncoding ?? DefaultContentEncoding;
 
             ReadOnlySequence<byte> contentBuffer = default;
             while (contentBuffer.Length < contentLength)
@@ -200,7 +206,20 @@ namespace StreamJsonRpc
             contentBuffer = contentBuffer.Slice(0, contentLength);
             try
             {
-                return this.Formatter.Deserialize(contentBuffer, contentEncoding);
+                if (this.Formatter is IJsonRpcMessageTextFormatter textFormatter)
+                {
+                    Encoding contentEncoding = headers.Value.ContentEncoding ?? DefaultContentEncoding;
+                    return textFormatter.Deserialize(contentBuffer, contentEncoding);
+                }
+                else
+                {
+                    if (headers.Value.ContentEncoding != null)
+                    {
+                        this.ThrowNoTextEncoder();
+                    }
+
+                    return this.Formatter.Deserialize(contentBuffer);
+                }
             }
             finally
             {
@@ -502,6 +521,11 @@ namespace StreamJsonRpc
             }
 
             return (contentLengthHeaderValue, contentEncoding);
+        }
+
+        private Exception ThrowNoTextEncoder()
+        {
+            throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Resources.TextEncoderNotApplicable, this.Formatter.GetType().FullName, typeof(IJsonRpcMessageTextFormatter).FullName));
         }
     }
 }

--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -191,19 +191,8 @@ namespace StreamJsonRpc
             }
 
             int contentLength = headers.Value.ContentLength.Value;
-
-            ReadOnlySequence<byte> contentBuffer = default;
-            while (contentBuffer.Length < contentLength)
-            {
-                var readResult = await this.Reader.ReadAsync(cancellationToken);
-                contentBuffer = readResult.Buffer;
-                if (contentBuffer.Length < contentLength)
-                {
-                    this.Reader.AdvanceTo(contentBuffer.Start, contentBuffer.End);
-                }
-            }
-
-            contentBuffer = contentBuffer.Slice(0, contentLength);
+            var readResult = await this.ReadAtLeastAsync(contentLength, allowEmpty: false, cancellationToken);
+            ReadOnlySequence<byte> contentBuffer = readResult.Buffer.Slice(0, contentLength);
             try
             {
                 if (this.Formatter is IJsonRpcMessageTextFormatter textFormatter)

--- a/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
+++ b/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Pipelines;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+    using Nerdbank.Streams;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// A minimal header for each message that is simply declares content length.
+    /// </summary>
+    /// <remarks>
+    /// The length is expressed as a big endian, 4 byte integer.
+    /// </remarks>
+    public class LengthHeaderMessageHandler : PipeMessageHandler
+    {
+        /// <summary>
+        /// The formatter to use for messaeg serialization.
+        /// </summary>
+        private readonly IJsonRpcMessageFormatter formatter;
+
+        /// <summary>
+        /// A wrapper to use for the <see cref="PipeMessageHandler.Writer"/> when we need to count bytes written.
+        /// </summary>
+        private CountingWriterWrapper<byte> writerWrapper;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LengthHeaderMessageHandler"/> class.
+        /// </summary>
+        /// <param name="pipe">The reader and writer to use for receiving/transmitting messages.</param>
+        /// <param name="formatter">The formatter to use for messaeg serialization.</param>
+        public LengthHeaderMessageHandler(IDuplexPipe pipe, IJsonRpcMessageFormatter formatter)
+            : base(pipe)
+        {
+            Requires.NotNull(formatter, nameof(formatter));
+            this.formatter = formatter;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LengthHeaderMessageHandler"/> class.
+        /// </summary>
+        /// <param name="writer">The writer to use for transmitting messages.</param>
+        /// <param name="reader">The reader to use for receiving messages.</param>
+        /// <param name="formatter">The formatter to use for messaeg serialization.</param>
+        public LengthHeaderMessageHandler(PipeWriter writer, PipeReader reader, IJsonRpcMessageFormatter formatter)
+            : base(writer, reader)
+        {
+            Requires.NotNull(formatter, nameof(formatter));
+            this.formatter = formatter;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LengthHeaderMessageHandler"/> class.
+        /// </summary>
+        /// <param name="sendingStream">The stream to use for transmitting messages.</param>
+        /// <param name="receivingStream">The stream to use for receiving messages.</param>
+        /// <param name="formatter">The formatter to use to serialize <see cref="JsonRpcMessage"/> instances.</param>
+        public LengthHeaderMessageHandler(Stream sendingStream, Stream receivingStream, IJsonRpcMessageFormatter formatter)
+            : base(sendingStream, receivingStream)
+        {
+            Requires.NotNull(formatter, nameof(formatter));
+            this.formatter = formatter;
+        }
+
+        /// <inheritdoc/>
+        protected override async ValueTask<JsonRpcMessage> ReadCoreAsync(CancellationToken cancellationToken)
+        {
+            var readResult = await this.ReadAtLeastAsync(4, allowEmpty: true, cancellationToken).ConfigureAwait(false);
+            if (readResult.Buffer.Length == 0)
+            {
+                return null;
+            }
+
+            ReadOnlySequence<byte> lengthBuffer = readResult.Buffer.Slice(0, 4);
+            int length = Utilities.ReadInt32BE(lengthBuffer);
+            this.Reader.AdvanceTo(lengthBuffer.End);
+
+            readResult = await this.ReadAtLeastAsync(length, allowEmpty: false, cancellationToken).ConfigureAwait(false);
+            ReadOnlySequence<byte> content = readResult.Buffer.Slice(0, length);
+            JsonRpcMessage message = this.formatter.Deserialize(content);
+            this.Reader.AdvanceTo(content.End);
+            return message;
+        }
+
+        /// <inheritdoc/>
+        protected override void Write(JsonRpcMessage content, CancellationToken cancellationToken)
+        {
+            if (this.writerWrapper == null)
+            {
+                this.writerWrapper = new CountingWriterWrapper<byte>(this.Writer);
+            }
+
+            // Reserve a 4 byte header for the content length.
+            Span<byte> lengthBuffer = this.Writer.GetSpan(sizeof(int));
+            this.Writer.Advance(4);
+
+            // Write out the actual message content, counting all written bytes.
+            this.writerWrapper.Reset();
+            this.formatter.Serialize(this.writerWrapper, content);
+
+            // Now go back and fill in the header with the actual content length.
+            Utilities.Write(lengthBuffer, this.writerWrapper.ElementCount);
+        }
+
+        /// <summary>
+        /// An <see cref="IBufferWriter{T}"/> that allows its owner to track how many elements are actually written.
+        /// </summary>
+        /// <typeparam name="T">The type of element written.</typeparam>
+        private class CountingWriterWrapper<T> : IBufferWriter<T>
+        {
+            /// <summary>
+            /// The writer to forward all write calls to.
+            /// </summary>
+            private readonly IBufferWriter<T> inner;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CountingWriterWrapper{T}"/> class.
+            /// </summary>
+            /// <param name="inner">The writer to forward all write calls to.</param>
+            internal CountingWriterWrapper(IBufferWriter<T> inner)
+            {
+                this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            }
+
+            /// <summary>
+            /// Gets the number of elements written since the last call to <see cref="Reset"/>.
+            /// </summary>
+            internal int ElementCount { get; private set; }
+
+            /// <inheritdoc />
+            public void Advance(int count)
+            {
+                this.ElementCount += count;
+                this.inner.Advance(count);
+            }
+
+            /// <inheritdoc />
+            public Memory<T> GetMemory(int sizeHint = 0) => this.inner.GetMemory(sizeHint);
+
+            /// <inheritdoc />
+            public Span<T> GetSpan(int sizeHint = 0) => this.inner.GetSpan(sizeHint);
+
+            /// <summary>
+            /// Restarts the <see cref="ElementCount"/> value to 0.
+            /// </summary>
+            internal void Reset() => this.ElementCount = 0;
+        }
+    }
+}

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">{0} není rozhraní.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" ist keine Schnittstelle.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" no es una interfaz.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" n'est pas une interface.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" non è un'interfaccia.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" はインターフェイスではありません。</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}"은(는) 인터페이스가 아닙니다.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">Element „{0}” nie jest interfejsem.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" não é uma interface.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" не является интерфейсом.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" bir arabirim değil.</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">“{0}”不是接口。</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -195,6 +195,11 @@
           <source>"{0}" is not an interface.</source>
           <target state="translated">"{0}" 不是介面。</target>
         </trans-unit>
+        <trans-unit id="TextEncoderNotApplicable" translate="yes" xml:space="preserve">
+          <source>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</source>
+          <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -37,6 +37,10 @@ StreamJsonRpc.JsonRpc.JsonRpc(StreamJsonRpc.IJsonRpcMessageHandler messageHandle
 StreamJsonRpc.JsonRpcDisconnectedEventArgs.JsonRpcDisconnectedEventArgs(string description, StreamJsonRpc.DisconnectedReason reason, Newtonsoft.Json.Linq.JToken lastMessage) -> void
 StreamJsonRpc.JsonRpcDisconnectedEventArgs.JsonRpcDisconnectedEventArgs(string description, StreamJsonRpc.DisconnectedReason reason, Newtonsoft.Json.Linq.JToken lastMessage, System.Exception exception) -> void
 StreamJsonRpc.JsonRpcDisconnectedEventArgs.LastMessage.get -> Newtonsoft.Json.Linq.JToken
+StreamJsonRpc.LengthHeaderMessageHandler
+StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
+StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
+StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Stream sendingStream, System.IO.Stream receivingStream, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.MessageHandlerBase
 StreamJsonRpc.MessageHandlerBase.DisposalToken.get -> System.Threading.CancellationToken
 StreamJsonRpc.MessageHandlerBase.Dispose() -> void
@@ -126,6 +130,8 @@ abstract StreamJsonRpc.MessageHandlerBase.WriteCoreAsync(StreamJsonRpc.Protocol.
 abstract StreamJsonRpc.PipeMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.HeaderDelimitedMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
 override StreamJsonRpc.HeaderDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
+override StreamJsonRpc.LengthHeaderMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
+override StreamJsonRpc.LengthHeaderMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.CanFlushConcurrentlyWithOtherWrites.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanWrite.get -> bool

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -47,6 +47,7 @@ StreamJsonRpc.PipeMessageHandler
 StreamJsonRpc.PipeMessageHandler.PipeMessageHandler(System.IO.Pipelines.IDuplexPipe pipe) -> void
 StreamJsonRpc.PipeMessageHandler.PipeMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader) -> void
 StreamJsonRpc.PipeMessageHandler.PipeMessageHandler(System.IO.Stream writer, System.IO.Stream reader) -> void
+StreamJsonRpc.PipeMessageHandler.ReadAtLeastAsync(int requiredBytes, bool allowEmpty, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult>
 StreamJsonRpc.PipeMessageHandler.Reader.get -> System.IO.Pipelines.PipeReader
 StreamJsonRpc.PipeMessageHandler.Writer.get -> System.IO.Pipelines.PipeWriter
 StreamJsonRpc.Protocol.JsonRpcError

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
 StreamJsonRpc.HeaderDelimitedMessageHandler.Encoding.get -> System.Text.Encoding
 StreamJsonRpc.HeaderDelimitedMessageHandler.Encoding.set -> void
-StreamJsonRpc.HeaderDelimitedMessageHandler.Formatter.get -> StreamJsonRpc.IJsonRpcMessageTextFormatter
-StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
-StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.HeaderDelimitedMessageHandler.Formatter.get -> StreamJsonRpc.IJsonRpcMessageFormatter
+StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
+StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Stream duplexStream) -> void
-StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Stream duplexStream, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
-StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Stream sendingStream, System.IO.Stream receivingStream, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Stream duplexStream, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
+StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Stream sendingStream, System.IO.Stream receivingStream, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.IJsonRpcMessageFormatter
 StreamJsonRpc.IJsonRpcMessageFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
 StreamJsonRpc.IJsonRpcMessageFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -368,6 +368,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Text encoding is not supported because the formatter &quot;{0}&quot; does not implement &quot;{1}&quot;..
+        /// </summary>
+        internal static string TextEncoderNotApplicable {
+            get {
+                return ResourceManager.GetString("TextEncoderNotApplicable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find method &apos;{0}/{1}&apos; on {2} for the following reasons: {3}.
         /// </summary>
         internal static string UnableToFindMethod {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -261,4 +261,8 @@
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>
   </data>
+  <data name="TextEncoderNotApplicable" xml:space="preserve">
+    <value>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</value>
+    <comment>{0} and {1} are CLR type names.</comment>
+  </data>
 </root>

--- a/src/StreamJsonRpc/Utilities.cs
+++ b/src/StreamJsonRpc/Utilities.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Buffers;
+    using Microsoft;
+
+    internal static class Utilities
+    {
+        /// <summary>
+        /// Reads an <see cref="int"/> value from a buffer using big endian.
+        /// </summary>
+        /// <param name="sequence">The sequence of bytes to read from. Must be at least 4 byte slong.</param>
+        /// <returns>The read value.</returns>
+        internal static int ReadInt32BE(ReadOnlySequence<byte> sequence)
+        {
+            sequence = sequence.Slice(0, 4);
+            Span<byte> stackSpan = stackalloc byte[4];
+            sequence.Slice(0, 4).CopyTo(stackSpan);
+            return ReadIntBE(stackSpan);
+        }
+
+        /// <summary>
+        /// Reads an <see cref="int"/> value to a buffer using big endian.
+        /// </summary>
+        /// <param name="buffer">The buffer to read from. Must be at most 4 bytes long.</param>
+        /// <returns>The read value.</returns>
+        internal static int ReadIntBE(ReadOnlySpan<byte> buffer)
+        {
+            Requires.Argument(buffer.Length <= 4, nameof(buffer), "Int32 length exceeded.");
+
+            int local = 0;
+            for (int offset = 0; offset < buffer.Length; offset++)
+            {
+                local <<= 8;
+                local |= buffer[offset];
+            }
+
+            return local;
+        }
+
+        /// <summary>
+        /// Writes an <see cref="int"/> value to a buffer using big endian.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to. Must be at least 4 bytes long.</param>
+        /// <param name="value">The value to write.</param>
+        internal static void Write(Span<byte> buffer, int value)
+        {
+            buffer[0] = (byte)(value >> 24);
+            buffer[1] = (byte)(value >> 16);
+            buffer[2] = (byte)(value >> 8);
+            buffer[3] = (byte)value;
+        }
+    }
+}


### PR DESCRIPTION
### Add LengthHeaderMessageHandler

It's a super small footprint, super fast handler that simply adds a big endian integer header for the length of the next message.

### Enable use of HeaderDelimitedMessageHandler for non-text formatters 

This expands HeaderDelimitedMessageHandler's applicability from requiring IJsonRpcMessageTextFormatter to allowing IJsonRpcMessageFormatter.

### Extras

* Replace hangs in tests with timeouts
* Extracted ReadAtLeastAsync to PipeMessageHandler