### PR TITLE
Add MessagePack sample and tests

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -3,6 +3,8 @@
 See [full samples](https://github.com/AArnott/StreamJsonRpc.Sample) demonstrating two processes
 on the same machine utilizing this library for RPC, using either named pipes or web sockets.
 
+Learn more about how you can [customize the JSON-RPC protocol's wire format](protocol.md) that StreamJsonRpc uses for better interoperability or better performance.
+
 See also [Visual Studio specific concerns](vs.md).
 
 ## Establishing Connection
@@ -32,7 +34,7 @@ public void ConstructRpc(Stream clientStream, Stream serverStream)
 ## Invoking a notification
 To invoke a remote method named "foo" which takes one `string` parameter and does not return anything (i.e. send a notification remotely):
 ```csharp
-public async Task NotifyRemote(Stream stream) 
+public async Task NotifyRemote(Stream stream)
 {
     var target = new Server();
     var rpc = JsonRpc.Attach(stream, target);
@@ -43,7 +45,7 @@ The parameter will be passed remotely as an array of one object.
 
 To invoke a remote method named "bar" which takes one `string` parameter (but the parameter should be passed as an object instead of an array of one object):
 ```csharp
-public async Task NotifyRemote(Stream stream) 
+public async Task NotifyRemote(Stream stream)
 {
     var target = new Server();
     var rpc = JsonRpc.Attach(stream, target);
@@ -53,7 +55,7 @@ public async Task NotifyRemote(Stream stream)
 ## Invoking a request
 To invoke a remote method named "foo" which takes two `string` parameters and returns an int:
 ```csharp
-public async Task InvokeRemote(Stream stream) 
+public async Task InvokeRemote(Stream stream)
 {
     var target = new Server();
     var rpc = JsonRpc.Attach(stream, target);
@@ -64,7 +66,7 @@ The parameters will be passed remotely as an array of objects.
 
 To invoke a remote method named "baz" which takes one `string` parameter (but the parameter should be passed as an object instead of an array of one object) and returns a string:
 ```csharp
-public async Task InvokeRemote(Stream stream) 
+public async Task InvokeRemote(Stream stream)
 {
     var target = new Server();
     var rpc = JsonRpc.Attach(stream, target);
@@ -88,9 +90,9 @@ public class Server
     }
 }
 
-public class Connection 
+public class Connection
 {
-    public async Task InvokeRemote(Stream stream) 
+    public async Task InvokeRemote(Stream stream)
     {
         var target = new Server();
         var rpc = JsonRpc.Attach(stream, target);
@@ -110,9 +112,9 @@ public class Server : BaseClass
 ```
 With this attribute on the server method, the client can now invoke that method with a special name.
 ```csharp
-public class Connection 
+public class Connection
 {
-    public async Task InvokeRemote(Stream stream) 
+    public async Task InvokeRemote(Stream stream)
     {
         var rpc = JsonRpc.Attach(stream);
         var myResult = await rpc.InvokeWithParameterObjectAsync<string>("test/InvokeTestMethod");

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1,0 +1,40 @@
+# Protocol details and customizations
+
+By default, StreamJsonRpc follows the JSON-RPC protocol's use of textual JSON as the representation of its messages. This provides for maximum interoperability and conformance to the spec.
+
+For performance reasons, it may be appropriate to switch out the textual JSON representation for something that can be serialized faster and/or in a more compact format.
+
+StreamJsonRpc has extensibility points that put you control of multiple levels of the protocol. These extensibility points are described below, including the implementations that are included in the library for your use or replacement.
+
+## Message handlers
+
+The JSON-RPC spec does not describe how this should be done. Since common StreamJsonRpc scenarios include durable connections over which many messages pass, we need to define a way to read and write individual messages over the same connection.
+
+The `IJsonRpcMessageHandler` interface that StreamJsonRpc defines fills the responsibility for writing and reading multiple distinct messages on a single channel.
+Some of the constructors on the `JsonRpc` class accept an object that implements this interface, allowing you to define this part of the protocol yourself.
+
+A few `IJsonRpcMessageHandler` implementations are included with this library:
+
+1. `HeaderDelimitedMessageHandler` - This is the default handler. It is compatible with the [`vscode-jsonrpc`](https://www.npmjs.com/package/vscode-jsonrpc) NPM package. It utilizes HTTP-like headers to introduce each JSON-RPC message by describing its length and text encoding. This handler works with .NET `Stream` and the new pipelines API.
+1. `LengthHeaderMessageHandler` - This prepends a big endian 32-bit integer to each message to describe the length of the message. This handler works with .NET `Stream` and the new pipelines API. This handler is the fastest handler for those transports.
+1. `WebSocketMessageHandler` - This is designed specifically for `WebSocket`, which has implicit message boundaries as part of the web socket protocol. As such, no header is added. Each message is transmitted as a single web socket message.
+
+## Message formatters
+
+When the content of a JSON-RPC message is actually written by a handler, the actual serialization of the message itself is handed off to an implementation of `IJsonRpcMessageFormatter`. This interface has the very focused responsibility serializing and deserializing `JsonRpcMessage`-derived types, of which there are three: `JsonRpcRequest`, `JsonRpcResult` and `JsonRpcError`.
+
+### JsonMessageFormatter
+
+The `JsonMessageFormatter` class implements the `IJsonRpcMessageFormatter` interface by utilizing Newtonsoft.Json to serialize each JSON-RPC message as actual JSON.
+
+Objects you transmit as RPC method arguments or return values must be serializable by Newtonsoft.Json. You can leverage `JsonConverter` and add your custom converters via attributes or by contributing them to the `JsonMessageFormatter.JsonSerializer.Converters` collection.
+
+### MessagePack
+
+The [MessagePack](https://msgpack.org/) protocol is a fast, binary serialization format that resembles the structure of JSON. It can be used as a substitute for JSON when both parties agree on the protocol for significant wins in terms of performance and payload size.
+
+We recommend the [MessagePack for C#](https://www.nuget.org/packages/messagepack) implementation of MessagePack because of its incredibly high serialization speed and more compact message sizes.
+
+Utilizing `MessagePack` for exchanging JSON-RPC messages is incredibly easy. Check out our [MessagePack sample][Sample], which is implemented in terms of a small set of unit tests that demonstrate its usage. While the sample defines the `IJsonRpcMessageFormatter`-derived type that is implemented in terms of MessagePack, this class is not included in the StreamJsonRpc library, but you can use the sample as a starting point for using MessagePack with StreamJsonRpc in your application today.
+
+[Sample]: ../src/StreamJsonRpc.Tests/MessagePackFormatter.cs

--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcJsonHeadersTests : JsonRpcTests
+{
+    public JsonRpcJsonHeadersTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public async Task UnserializableTypeWorksWithConverter()
+    {
+        var clientMessageFormatter = (JsonMessageFormatter)this.clientMessageFormatter;
+        var serverMessageFormatter = (JsonMessageFormatter)this.serverMessageFormatter;
+
+        clientMessageFormatter.JsonSerializer.Converters.Add(new UnserializableTypeConverter());
+        serverMessageFormatter.JsonSerializer.Converters.Add(new UnserializableTypeConverter());
+        var result = await this.clientRpc.InvokeAsync<UnserializableType>(nameof(this.server.RepeatSpecialType), new UnserializableType { Value = "a" });
+        Assert.Equal("a!", result.Value);
+    }
+
+    [Fact]
+    public async Task CustomJsonConvertersAreNotAppliedToBaseMessage()
+    {
+        var clientMessageFormatter = (JsonMessageFormatter)this.clientMessageFormatter;
+        var serverMessageFormatter = (JsonMessageFormatter)this.serverMessageFormatter;
+
+        // This test works because it encodes any string value, such that if the json-rpc "method" property
+        // were serialized using the same serializer as parameters, the invocation would fail because the server-side
+        // doesn't find the method with the mangled name.
+
+        // Test with the converter only on the client side.
+        clientMessageFormatter.JsonSerializer.Converters.Add(new StringBase64Converter());
+        string result = await this.clientRpc.InvokeAsync<string>(nameof(this.server.ExpectEncodedA), "a");
+        Assert.Equal("a", result);
+
+        // Test with the converter on both sides.
+        serverMessageFormatter.JsonSerializer.Converters.Add(new StringBase64Converter());
+        result = await this.clientRpc.InvokeAsync<string>(nameof(this.server.RepeatString), "a");
+        Assert.Equal("a", result);
+
+        // Test with the converter only on the server side.
+        clientMessageFormatter.JsonSerializer.Converters.Clear();
+        result = await this.clientRpc.InvokeAsync<string>(nameof(this.server.AsyncMethod), "YQ==");
+        Assert.Equal("YSE=", result); // a!
+    }
+
+    [Fact]
+    public async Task CanInvokeServerMethodWithParameterPassedAsObject()
+    {
+        string result1 = await this.clientRpc.InvokeWithParameterObjectAsync<string>(nameof(Server.TestParameter), new { test = "test" });
+        Assert.Equal("object {" + Environment.NewLine + "  \"test\": \"test\"" + Environment.NewLine + "}", result1);
+    }
+
+    [Fact]
+    public async Task InvokeWithParameterObjectAsync_AndCancel()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithParameterObjectAsync<string>(nameof(Server.AsyncMethodWithJTokenAndCancellation), new { b = "a" }, cts.Token);
+            await Task.WhenAny(invokeTask, this.server.ServerMethodReached.WaitAsync(this.TimeoutToken));
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+        }
+    }
+
+    [Fact]
+    public async Task InvokeWithParameterObjectAsync_NoResult_AndCancel()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithParameterObjectAsync(nameof(Server.AsyncMethodWithJTokenAndCancellation), new { b = "a" }, cts.Token);
+            await Task.WhenAny(invokeTask, this.server.ServerMethodReached.WaitAsync(this.TimeoutToken));
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+        }
+    }
+
+    [Fact]
+    public async Task InvokeWithParameterObjectAsync_AndComplete()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithParameterObjectAsync<string>(nameof(Server.AsyncMethodWithJTokenAndCancellation), new { b = "a" }, cts.Token);
+            this.server.AllowServerMethodToReturn.Set();
+            string result = await invokeTask;
+            Assert.Equal(@"{""b"":""a""}!", result);
+        }
+    }
+
+    [Fact]
+    public async Task CanInvokeServerMethodWithParameterPassedAsArray()
+    {
+        string result1 = await this.clientRpc.InvokeAsync<string>(nameof(Server.TestParameter), "test");
+        Assert.Equal("object test", result1);
+    }
+
+    [Fact]
+    public async Task InvokeWithCancellationAsync_AndCancel()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithJTokenAndCancellation), new[] { "a" }, cts.Token);
+            await Task.WhenAny(invokeTask, this.server.ServerMethodReached.WaitAsync(this.TimeoutToken));
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+        }
+    }
+
+    [Fact]
+    public async Task InvokeWithCancellationAsync_AndComplete()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithJTokenAndCancellation), new[] { "a" }, cts.Token);
+            this.server.AllowServerMethodToReturn.Set();
+            string result = await invokeTask;
+            Assert.Equal(@"""a""!", result);
+        }
+    }
+
+    [Fact]
+    public async Task CanPassAndCallPrivateMethodsObjects()
+    {
+        var result = await this.clientRpc.InvokeAsync<Foo>(nameof(Server.MethodThatAcceptsFoo), new Foo { Bar = "bar", Bazz = 1000 });
+        Assert.NotNull(result);
+        Assert.Equal("bar!", result.Bar);
+        Assert.Equal(1001, result.Bazz);
+
+        result = await this.clientRpc.InvokeAsync<Foo>(nameof(Server.MethodThatAcceptsFoo), new { Bar = "bar", Bazz = 1000 });
+        Assert.NotNull(result);
+        Assert.Equal("bar!", result.Bar);
+        Assert.Equal(1001, result.Bazz);
+    }
+
+    [Fact]
+    public async Task Completion_FaultsOnFatalError()
+    {
+        Task completion = this.serverRpc.Completion;
+        byte[] invalidMessage = Encoding.UTF8.GetBytes("A\n\n");
+        await this.clientStream.WriteAsync(invalidMessage, 0, invalidMessage.Length).WithCancellation(this.TimeoutToken);
+        await this.clientStream.FlushAsync().WithCancellation(this.TimeoutToken);
+        await Assert.ThrowsAsync<BadRpcHeaderException>(() => completion).WithCancellation(this.TimeoutToken);
+        Assert.Same(completion, this.serverRpc.Completion);
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new JsonMessageFormatter();
+        this.clientMessageFormatter = new JsonMessageFormatter();
+
+        this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
+        this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+    }
+
+    private class StringBase64Converter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => objectType == typeof(string);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            string decoded = Encoding.UTF8.GetString(Convert.FromBase64String((string)reader.Value));
+            return decoded;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var stringValue = (string)value;
+            var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(stringValue));
+            writer.WriteValue(encoded);
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcMessagePackLengthTests : JsonRpcTests
+{
+    public JsonRpcMessagePackLengthTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public async Task CanPassAndCallPrivateMethodsObjects()
+    {
+        var result = await this.clientRpc.InvokeAsync<Foo>(nameof(Server.MethodThatAcceptsFoo), new Foo { Bar = "bar", Bazz = 1000 });
+        Assert.NotNull(result);
+        Assert.Equal("bar!", result.Bar);
+        Assert.Equal(1001, result.Bazz);
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new MessagePackFormatter();
+        this.clientMessageFormatter = new MessagePackFormatter();
+
+        this.serverMessageHandler = new LengthHeaderMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
+        this.clientMessageHandler = new LengthHeaderMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+    }
+}

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Buffers;
+    using MessagePack;
+    using Nerdbank.Streams;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// Serializes JSON-RPC messages using MessagePack (a fast, compact binary format).
+    /// </summary>
+    /// <remarks>
+    /// The MessagePack implementation used here comes from https://github.com/neuecc/MessagePack-CSharp.
+    /// The README on that project site describes use cases and its performance compared to alternative
+    /// .NET MessagePack implementations and this one appears to be the best by far.
+    /// </remarks>
+    public class MessagePackFormatter : IJsonRpcMessageFormatter
+    {
+        /// <summary>
+        /// A value indicating whether to use LZ4 compression.
+        /// </summary>
+        private readonly bool compress;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackFormatter"/> class
+        /// with LZ4 compression.
+        /// </summary>
+        public MessagePackFormatter()
+            : this(compress: true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackFormatter"/> class.
+        /// </summary>
+        /// <param name="compress">A value indicating whether to use LZ4 compression.</param>
+        public MessagePackFormatter(bool compress)
+        {
+            this.compress = compress;
+        }
+
+        /// <inheritdoc/>
+        public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer)
+        {
+            return this.compress
+                ? (JsonRpcMessage)LZ4MessagePackSerializer.Typeless.Deserialize(contentBuffer.AsStream())
+                : (JsonRpcMessage)MessagePackSerializer.Typeless.Deserialize(contentBuffer.AsStream());
+        }
+
+        /// <inheritdoc/>
+        public void Serialize(IBufferWriter<byte> contentBuffer, JsonRpcMessage message)
+        {
+            if (this.compress)
+            {
+                LZ4MessagePackSerializer.Typeless.Serialize(contentBuffer.AsStream(), message);
+            }
+            else
+            {
+                MessagePackSerializer.Typeless.Serialize(contentBuffer.AsStream(), message);
+            }
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class MessagePackFormatterTests : TestBase
+{
+    private readonly MessagePackFormatter formatter = new MessagePackFormatter();
+
+    public MessagePackFormatterTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void JsonRpcRequest_ArgsArray()
+    {
+        var original = new JsonRpcRequest
+        {
+            Id = 5,
+            Method = "test",
+            ArgumentsArray = new object[] { 5, "hi", new CustomType { Age = 8 } },
+        };
+
+        var actual = this.Roundtrip(original);
+        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(original.Method, actual.Method);
+        Assert.Equal(original.ArgumentsArray[0], actual.ArgumentsArray[0]);
+        Assert.Equal(original.ArgumentsArray[1], actual.ArgumentsArray[1]);
+        Assert.Equal(((CustomType)original.ArgumentsArray[2]).Age, ((CustomType)actual.ArgumentsArray[2]).Age);
+    }
+
+    [Fact]
+    public void JsonRpcResult()
+    {
+        var original = new JsonRpcResult
+        {
+            Id = 5,
+            Result = new CustomType { Age = 7 },
+        };
+
+        var actual = this.Roundtrip(original);
+        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(((CustomType)original.Result).Age, ((CustomType)actual.Result).Age);
+    }
+
+    [Fact]
+    public void JsonRpcError()
+    {
+        var original = new JsonRpcError
+        {
+            Id = 5,
+            Error = new JsonRpcError.ErrorDetail
+            {
+                Code = JsonRpcErrorCode.InvocationError,
+                Message = "Oops",
+                Data = new CustomType { Age = 15 },
+            },
+        };
+
+        var actual = this.Roundtrip(original);
+        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(original.Error.Code, actual.Error.Code);
+        Assert.Equal(original.Error.Message, actual.Error.Message);
+        Assert.Equal(((CustomType)original.Error.Data).Age, ((CustomType)actual.Error.Data).Age);
+    }
+
+    [Fact]
+    public async Task BasicJsonRpc()
+    {
+        var (clientStream, serverStream) = FullDuplexStream.CreatePair();
+        var formatter = new MessagePackFormatter(compress: false);
+
+        var clientHandler = new LengthHeaderMessageHandler(clientStream.UsePipe(), formatter);
+        var serverHandler = new LengthHeaderMessageHandler(serverStream.UsePipe(), formatter);
+
+        var clientRpc = new JsonRpc(clientHandler);
+        var serverRpc = new JsonRpc(serverHandler, new Server());
+
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        int result = await clientRpc.InvokeAsync<int>(nameof(Server.Add), 3, 5).WithCancellation(this.TimeoutToken);
+        Assert.Equal(8, result);
+    }
+
+    private T Roundtrip<T>(T value)
+        where T : JsonRpcMessage
+    {
+        var sequence = new Sequence<byte>();
+        this.formatter.Serialize(sequence, value);
+        var actual = (T)this.formatter.Deserialize(sequence);
+        return actual;
+    }
+
+    [DataContract]
+    public class CustomType
+    {
+        [DataMember]
+        public int Age { get; set; }
+    }
+
+    private class Server
+    {
+        public int Add(int a, int b) => a + b;
+    }
+}

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -48,6 +48,8 @@
     <PackageReference Include="xunit.skippablefact" Version="1.3.3" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.32" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="MessagePack" Version="1.7.3.4" />
+    <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AspNetCoreHost)' == 'true' ">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -3,6 +3,7 @@
 
 namespace StreamJsonRpc.Protocol
 {
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Runtime.Serialization;
     using Newtonsoft.Json.Linq;
@@ -75,12 +76,32 @@ namespace StreamJsonRpc.Protocol
             /// <summary>
             /// Gets the callstack of an exception thrown by the server.
             /// </summary>
-            public string ErrorStack => this.Data is JObject dataObject && dataObject[DataStackFieldName]?.Type == JTokenType.String ? dataObject.Value<string>(DataStackFieldName) : null;
+            [IgnoreDataMember]
+            public virtual string ErrorStack
+            {
+                get
+                {
+                    return
+                        this.Data is JObject dataObject && dataObject[DataStackFieldName]?.Type == JTokenType.String ? dataObject.Value<string>(DataStackFieldName) :
+                        this.Data is Dictionary<object, object> data && data.TryGetValue(DataStackFieldName, out var stack) && stack is string stackString ? stackString :
+                        null;
+                }
+            }
 
             /// <summary>
             /// Gets the server error code.
             /// </summary>
-            public string ErrorCode => this.Data is JObject dataObject && (dataObject[DataCodeFieldName]?.Type == JTokenType.String || dataObject?[DataCodeFieldName]?.Type == JTokenType.Integer) ? dataObject.Value<string>(DataCodeFieldName) : null;
+            [IgnoreDataMember]
+            public virtual string ErrorCode
+            {
+                get
+                {
+                    return
+                        this.Data is JObject dataObject && (dataObject[DataCodeFieldName]?.Type == JTokenType.String || dataObject?[DataCodeFieldName]?.Type == JTokenType.Integer) ? dataObject.Value<string>(DataCodeFieldName) :
+                        this.Data is Dictionary<object, object> data && data.TryGetValue(DataCodeFieldName, out var code) && (code is string || code is int) ? code.ToString() :
+                        null;
+                }
+            }
         }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -86,21 +86,25 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets a value indicating whether a response to this request is expected.
         /// </summary>
+        [IgnoreDataMember]
         public bool IsResponseExpected => this.Id != null;
 
         /// <summary>
         /// Gets a value indicating whether this is a notification, and no response is expected.
         /// </summary>
+        [IgnoreDataMember]
         public bool IsNotification => this.Id == null;
 
         /// <summary>
         /// Gets the number of arguments supplied in the request.
         /// </summary>
+        [IgnoreDataMember]
         public int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsArray?.Length ?? 0;
 
         /// <summary>
         /// Gets or sets the dictionary of named arguments, if applicable.
         /// </summary>
+        [IgnoreDataMember]
         public IReadOnlyDictionary<string, object> NamedArguments
         {
             get => this.Arguments as IReadOnlyDictionary<string, object>;
@@ -110,6 +114,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets an array of arguments, if applicable.
         /// </summary>
+        [IgnoreDataMember]
         public object[] ArgumentsArray
         {
             get => this.Arguments as object[];

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -63,9 +63,7 @@ StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Code.get -> StreamJsonRpc.Protoc
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Code.set -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Data.get -> object
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Data.set -> void
-StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorCode.get -> string
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorDetail() -> void
-StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorStack.get -> string
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Message.get -> string
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.Message.set -> void
 StreamJsonRpc.Protocol.JsonRpcError.Id.get -> object
@@ -152,6 +150,8 @@ override sealed StreamJsonRpc.PipeMessageHandler.WriteCoreAsync(StreamJsonRpc.Pr
 virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(long? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(long? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
 virtual StreamJsonRpc.MessageHandlerBase.Dispose(bool disposing) -> void
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorCode.get -> string
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorStack.get -> string
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetArgumentByNameOrIndex(string name, int position, System.Type typeHint, out object value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetTypedArguments(System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters, System.Span<object> typedArguments) -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 virtual StreamJsonRpc.Protocol.JsonRpcResult.GetResult<T>() -> T


### PR DESCRIPTION
To test this adequately I've split the JsonRpcTests class into two derived types to "replay" most tests against both MessagePack + Length handler as well as the original Json + Header handler stack.

At least for now, I'm leaving `MessagePackFormatter` in the test project rather than the library project. There are several optional paths folks can go down when using `MessagePack`, and any of them take about 1 line of code anyway. So rather than restrict folks to just one configuration, or writing code to support them all, the plan is to document the test project's version as a sample for folks to copy and/or inspire their own version.

Closes #124 