### PR TITLE
Fix cancellation race that can result in connection termination

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1167,7 +1167,16 @@ namespace StreamJsonRpc
                 // It may have callbacks registered on cancellation.
                 // Cancel it asynchronously to ensure that these callbacks do not delay handling of other json rpc messages.
                 await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-                cts.Cancel();
+                try
+                {
+                    cts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // There is a race condition between when we retrieve the CTS and actually call Cancel,
+                    // vs. another thread that disposes the CTS at the conclusion of the method invocation.
+                    // It cannot be prevented, so just swallow it since the method executed successfully.
+                }
             }
         }
 


### PR DESCRIPTION
While working on #115, I happened across a fatal error in the traces that came from a race condition with disposal vs. cancelling a `CancellationTokenSource`. 

Connections that frequently cancel requests are at risk of dropping the entire connection as a result. This fixes the issue by swallowing the otherwise harmless exception.