### PR TITLE
Enable JSON-RPC servers to completely control their error response

### DIFF
--- a/src/StreamJsonRpc.Tests/CommonErrorDataTests.cs
+++ b/src/StreamJsonRpc.Tests/CommonErrorDataTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class CommonErrorDataTests : TestBase
+{
+    public CommonErrorDataTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void Ctor_CopyFrom_Null()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CommonErrorData(null));
+    }
+
+    [Fact]
+    public void Ctor_CopyFrom_NeverThrown()
+    {
+        var template = new CustomException(5, "msg");
+        var errorData = new CommonErrorData(template);
+        Assert.Equal("msg", template.Message);
+        Assert.Equal(template.HResult, errorData.HResult);
+        Assert.Null(errorData.Inner);
+        Assert.Equal(typeof(CustomException).FullName, errorData.TypeName);
+        Assert.Null(errorData.StackTrace);
+    }
+
+    [Fact]
+    public void Ctor_CopyFrom_ThrownStackTrace()
+    {
+        try
+        {
+            throw new CustomException(5, "msg");
+        }
+        catch (Exception template)
+        {
+            var errorData = new CommonErrorData(template);
+            Assert.Equal("msg", template.Message);
+            Assert.Equal(template.HResult, errorData.HResult);
+            Assert.Null(errorData.Inner);
+            Assert.Equal(typeof(CustomException).FullName, errorData.TypeName);
+            Assert.NotNull(errorData.StackTrace);
+            this.Logger.WriteLine(errorData.StackTrace);
+        }
+    }
+
+    [Fact]
+    public void Ctor_CopyFrom_InnerExceptions()
+    {
+        var template = new InvalidOperationException("outer", new InvalidCastException("inner"));
+        var errorData = new CommonErrorData(template);
+
+        Assert.Equal(template.GetType().FullName, errorData.TypeName);
+        Assert.Equal(template.Message, errorData.Message);
+        Assert.Equal(template.InnerException.GetType().FullName, errorData.Inner?.TypeName);
+        Assert.Equal(template.InnerException.Message, errorData.Inner?.Message);
+    }
+
+    private class CustomException : Exception
+    {
+        internal CustomException(int hresult, string message)
+            : base(message)
+        {
+            this.HResult = hresult;
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/LocalRpcExceptionTests.cs
+++ b/src/StreamJsonRpc.Tests/LocalRpcExceptionTests.cs
@@ -1,0 +1,26 @@
+﻿using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class LocalRpcExceptionTests : TestBase
+{
+    public LocalRpcExceptionTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void ErrorCode()
+    {
+        var ex = new LocalRpcException() { ErrorCode = 1 };
+        Assert.Equal(1, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ErrorData_AnonymousType()
+    {
+        var ex = new LocalRpcException() { ErrorData = new { myError = 5 } };
+        dynamic error = ex.ErrorData;
+        Assert.Equal(5, (int)error.myError);
+    }
+}

--- a/src/StreamJsonRpc/Exceptions/LocalRpcException.cs
+++ b/src/StreamJsonRpc/Exceptions/LocalRpcException.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Text;
+    using Microsoft;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An exception that may be thrown within a locally invoked server method, and carries with it data that influences the JSON-RPC error message's error object.
+    /// </summary>
+    public class LocalRpcException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalRpcException"/> class.
+        /// </summary>
+        public LocalRpcException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalRpcException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public LocalRpcException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalRpcException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="inner">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public LocalRpcException(string message, Exception inner)
+                : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the value for the error.data property.
+        /// </summary>
+        public object ErrorData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value for the error.code property.
+        /// </summary>
+        /// <remarks>
+        /// The default value is set to a special general error code: <see cref="JsonRpcErrorCode.InvocationError"/>.
+        /// This may be set to a more meaningful error code for the application that allows the client to programatically respond to the error condition.
+        /// Application-defined values should avoid the [-32768, -32000] range, which is reserved for the JSON-RPC protocol itself.
+        /// </remarks>
+        public int ErrorCode { get; set; } = (int)JsonRpcErrorCode.InvocationError;
+    }
+}

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -5,12 +5,13 @@ namespace StreamJsonRpc
 {
     using System;
     using Newtonsoft.Json.Linq;
+    using StreamJsonRpc.Protocol;
 
     /// <summary>
     /// Remote RPC exception that indicates that the server target method threw an exception.
     /// </summary>
     /// <remarks>
-    /// The details of the target method exception can be found on <see cref="RemoteStackTrace"/> and <see cref="RemoteErrorCode"/>.
+    /// The details of the target method exception can be found on the <see cref="ErrorCode"/> and <see cref="ErrorData"/> properties.
     /// </remarks>
 #if SERIALIZABLE_EXCEPTIONS
     [System.Serializable]
@@ -21,25 +22,12 @@ namespace StreamJsonRpc
         /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <param name="remoteStack">The remote stack.</param>
-        /// <param name="remoteCode">The remote code.</param>
-        public RemoteInvocationException(string message, string remoteStack, string remoteCode)
-            : this(message, remoteStack, remoteCode, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
-        /// </summary>
-        /// <param name="message">The message.</param>
-        /// <param name="remoteStack">The remote stack.</param>
-        /// <param name="remoteCode">The remote code.</param>
+        /// <param name="errorCode">The value of the error.code field in the response.</param>
         /// <param name="errorData">The value of the error.data field in the response.</param>
-        public RemoteInvocationException(string message, string remoteStack, string remoteCode, object errorData)
+        public RemoteInvocationException(string message, int errorCode, object errorData)
             : base(message)
         {
-            this.RemoteStackTrace = remoteStack;
-            this.RemoteErrorCode = remoteCode;
+            this.ErrorCode = errorCode;
             this.ErrorData = errorData;
         }
 
@@ -58,18 +46,22 @@ namespace StreamJsonRpc
 #endif
 
         /// <summary>
-        /// Gets the value of the <c>error.data.stack</c> field in the response, if that value is a string.
+        /// Gets the value of the <c>error.code</c> field in the response.
         /// </summary>
-        public string RemoteStackTrace { get; }
-
-        /// <summary>
-        /// Gets the value of the <c>error.data.code</c> field in the response, if that value is a string or integer.
-        /// </summary>
-        public string RemoteErrorCode { get; }
+        /// <value>
+        /// The value may be any integer.
+        /// The value may be <see cref="JsonRpcErrorCode.InvocationError"/>, which is a general value used for exceptions thrown on the server when the server does not give an app-specific error code.
+        /// </value>
+        public int ErrorCode { get; }
 
         /// <summary>
         /// Gets the <c>error.data</c> value in the error response, if one was provided.
         /// </summary>
+        /// <remarks>
+        /// Depending on the <see cref="IJsonRpcMessageFormatter"/> used, the value of this property, if any,
+        /// may be a <see cref="JToken"/> or a deserialized object.
+        /// Deserializing this or casting this object to <see cref="CommonErrorData"/> <em>may</em> succeed, and be a means to extract useful error information.
+        /// </remarks>
         public object ErrorData { get; }
     }
 }

--- a/src/StreamJsonRpc/Protocol/CommonErrorData.cs
+++ b/src/StreamJsonRpc/Protocol/CommonErrorData.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Protocol
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text;
+    using Microsoft;
+
+    /// <summary>
+    /// A class that describes useful data that may be found in the JSON-RPC error message's error.data property.
+    /// </summary>
+    [DataContract]
+    public class CommonErrorData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommonErrorData"/> class.
+        /// </summary>
+        public CommonErrorData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommonErrorData"/> class.
+        /// </summary>
+        /// <param name="copyFrom">The exception to copy error details from.</param>
+        public CommonErrorData(Exception copyFrom)
+        {
+            Requires.NotNull(copyFrom, nameof(copyFrom));
+
+            this.Message = copyFrom.Message;
+            this.StackTrace = copyFrom.StackTrace;
+            this.HResult = copyFrom.HResult;
+            this.TypeName = copyFrom.GetType().FullName;
+            this.Inner = copyFrom.InnerException != null ? new CommonErrorData(copyFrom.InnerException) : null;
+        }
+
+        /// <summary>
+        /// Gets or sets the type of error (e.g. the full type name of the exception thrown).
+        /// </summary>
+        [DataMember(Order = 0, Name = "type")]
+        public string TypeName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message associated with this error.
+        /// </summary>
+        [DataMember(Order = 1, Name = "message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stack trace associated with the error.
+        /// </summary>
+        [DataMember(Order = 2, Name = "stack")]
+        public string StackTrace { get; set; }
+
+        /// <summary>
+        /// Gets or sets the application error code or HRESULT of the failure.
+        /// </summary>
+        [DataMember(Order = 3, Name = "code")]
+        public int HResult { get; set; }
+
+        /// <summary>
+        /// Gets or sets the inner error information, if any.
+        /// </summary>
+        [DataMember(Order = 4, Name = "inner")]
+        public CommonErrorData Inner { get; set; }
+    }
+}

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -54,20 +54,11 @@ namespace StreamJsonRpc.Protocol
         public class ErrorDetail
         {
             /// <summary>
-            /// The name of the error object's "data.stack" field within the data object.
-            /// </summary>
-            private const string DataStackFieldName = "stack";
-
-            /// <summary>
-            /// The name of the error object's "data.code" field within the data object.
-            /// </summary>
-            private const string DataCodeFieldName = "code";
-
-            /// <summary>
             /// Gets or sets a number that indicates the error type that occurred.
             /// </summary>
             /// <value>
-            /// The error codes from and including -32768 to -32000 are reserved for pre-defined errors.
+            /// The error codes from and including -32768 to -32000 are reserved for errors defined by the spec or this library.
+            /// Codes outside that range are available for app-specific error codes.
             /// </value>
             [DataMember(Name = "code", Order = 0, IsRequired = true)]
             public JsonRpcErrorCode Code { get; set; }
@@ -86,36 +77,6 @@ namespace StreamJsonRpc.Protocol
             /// </summary>
             [DataMember(Name = "data", Order = 2, IsRequired = false)]
             public object Data { get; set; }
-
-            /// <summary>
-            /// Gets the callstack of an exception thrown by the server.
-            /// </summary>
-            [IgnoreDataMember]
-            public virtual string ErrorStack
-            {
-                get
-                {
-                    return
-                        this.Data is JObject dataObject && dataObject[DataStackFieldName]?.Type == JTokenType.String ? dataObject.Value<string>(DataStackFieldName) :
-                        this.Data is Dictionary<object, object> data && data.TryGetValue(DataStackFieldName, out var stack) && stack is string stackString ? stackString :
-                        null;
-                }
-            }
-
-            /// <summary>
-            /// Gets the server error code.
-            /// </summary>
-            [IgnoreDataMember]
-            public virtual string ErrorCode
-            {
-                get
-                {
-                    return
-                        this.Data is JObject dataObject && (dataObject[DataCodeFieldName]?.Type == JTokenType.String || dataObject?[DataCodeFieldName]?.Type == JTokenType.Integer) ? dataObject.Value<string>(DataCodeFieldName) :
-                        this.Data is Dictionary<object, object> data && data.TryGetValue(DataCodeFieldName, out var code) && (code is string || code is int) ? code.ToString() :
-                        null;
-                }
-            }
         }
     }
 }

--- a/src/StreamJsonRpc/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Shipped.txt
@@ -27,10 +27,7 @@ StreamJsonRpc.JsonRpcDisconnectedEventArgs.JsonRpcDisconnectedEventArgs(string d
 StreamJsonRpc.JsonRpcDisconnectedEventArgs.JsonRpcDisconnectedEventArgs(string description, StreamJsonRpc.DisconnectedReason reason, System.Exception exception) -> void
 StreamJsonRpc.JsonRpcDisconnectedEventArgs.Reason.get -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.RemoteInvocationException
-StreamJsonRpc.RemoteInvocationException.RemoteErrorCode.get -> string
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, string remoteStack, string remoteCode) -> void
-StreamJsonRpc.RemoteInvocationException.RemoteStackTrace.get -> string
 StreamJsonRpc.RemoteMethodNotFoundException
 StreamJsonRpc.RemoteMethodNotFoundException.RemoteMethodNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.RemoteMethodNotFoundException.TargetMethod.get -> string

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -60,6 +60,14 @@ StreamJsonRpc.LengthHeaderMessageHandler
 StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.LengthHeaderMessageHandler.LengthHeaderMessageHandler(System.IO.Stream sendingStream, System.IO.Stream receivingStream, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
+StreamJsonRpc.LocalRpcException
+StreamJsonRpc.LocalRpcException.ErrorCode.get -> int
+StreamJsonRpc.LocalRpcException.ErrorCode.set -> void
+StreamJsonRpc.LocalRpcException.ErrorData.get -> object
+StreamJsonRpc.LocalRpcException.ErrorData.set -> void
+StreamJsonRpc.LocalRpcException.LocalRpcException() -> void
+StreamJsonRpc.LocalRpcException.LocalRpcException(string message) -> void
+StreamJsonRpc.LocalRpcException.LocalRpcException(string message, System.Exception inner) -> void
 StreamJsonRpc.MessageHandlerBase
 StreamJsonRpc.MessageHandlerBase.DisposalToken.get -> System.Threading.CancellationToken
 StreamJsonRpc.MessageHandlerBase.Dispose() -> void
@@ -74,6 +82,19 @@ StreamJsonRpc.PipeMessageHandler.PipeMessageHandler(System.IO.Stream writer, Sys
 StreamJsonRpc.PipeMessageHandler.ReadAtLeastAsync(int requiredBytes, bool allowEmpty, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult>
 StreamJsonRpc.PipeMessageHandler.Reader.get -> System.IO.Pipelines.PipeReader
 StreamJsonRpc.PipeMessageHandler.Writer.get -> System.IO.Pipelines.PipeWriter
+StreamJsonRpc.Protocol.CommonErrorData
+StreamJsonRpc.Protocol.CommonErrorData.CommonErrorData() -> void
+StreamJsonRpc.Protocol.CommonErrorData.CommonErrorData(System.Exception copyFrom) -> void
+StreamJsonRpc.Protocol.CommonErrorData.HResult.get -> int
+StreamJsonRpc.Protocol.CommonErrorData.HResult.set -> void
+StreamJsonRpc.Protocol.CommonErrorData.Inner.get -> StreamJsonRpc.Protocol.CommonErrorData
+StreamJsonRpc.Protocol.CommonErrorData.Inner.set -> void
+StreamJsonRpc.Protocol.CommonErrorData.Message.get -> string
+StreamJsonRpc.Protocol.CommonErrorData.Message.set -> void
+StreamJsonRpc.Protocol.CommonErrorData.StackTrace.get -> string
+StreamJsonRpc.Protocol.CommonErrorData.StackTrace.set -> void
+StreamJsonRpc.Protocol.CommonErrorData.TypeName.get -> string
+StreamJsonRpc.Protocol.CommonErrorData.TypeName.set -> void
 StreamJsonRpc.Protocol.JsonRpcError
 StreamJsonRpc.Protocol.JsonRpcError.DebuggerDisplay.get -> string
 StreamJsonRpc.Protocol.JsonRpcError.Error.get -> StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail
@@ -129,8 +150,9 @@ StreamJsonRpc.Protocol.JsonRpcResult.Id.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.JsonRpcResult() -> void
 StreamJsonRpc.Protocol.JsonRpcResult.Result.get -> object
 StreamJsonRpc.Protocol.JsonRpcResult.Result.set -> void
+StreamJsonRpc.RemoteInvocationException.ErrorCode.get -> int
 StreamJsonRpc.RemoteInvocationException.ErrorData.get -> object
-StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, string remoteStack, string remoteCode, object errorData) -> void
+StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData) -> void
 StreamJsonRpc.StreamMessageHandler
 StreamJsonRpc.StreamMessageHandler.ReceivingStream.get -> System.IO.Stream
 StreamJsonRpc.StreamMessageHandler.SendingStream.get -> System.IO.Stream
@@ -171,8 +193,6 @@ override sealed StreamJsonRpc.PipeMessageHandler.WriteCoreAsync(StreamJsonRpc.Pr
 virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(long? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 virtual StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(long? id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
 virtual StreamJsonRpc.MessageHandlerBase.Dispose(bool disposing) -> void
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorCode.get -> string
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.ErrorStack.get -> string
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetArgumentByNameOrIndex(string name, int position, System.Type typeHint, out object value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetTypedArguments(System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters, System.Span<object> typedArguments) -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 virtual StreamJsonRpc.Protocol.JsonRpcResult.GetResult<T>() -> T


### PR DESCRIPTION
Servers could already control the error.message property via the Message property on the exception they throw.
With this change, they can also control the error.code and error.data properties, by throwing a LocalRpcException which defines properties for these two other fields.

This also replaces the RemoteStackTrace and RemoteErrorCode properties which assumed a particular schema for the error.data object in favor of a new type that servers and clients can *optionally* use to convey this and more information.
The default behavior continues to include the information on the server we had before, plus the exception *type*.

Fixes #65