### PR TITLE
Fault instead of cancel Tasks tracking outbound requests

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
@@ -54,7 +54,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     public async Task CloseStreamsOnSynchronousMethodException()
     {
         var exceptionMessage = "Exception from CloseStreamsOnSynchronousMethodException";
-        OperationCanceledException exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync(nameof(Server.MethodThatThrowsUnauthorizedAccessException), exceptionMessage));
+        ConnectionLostException exception = await Assert.ThrowsAnyAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync(nameof(Server.MethodThatThrowsUnauthorizedAccessException), exceptionMessage));
         Assert.NotNull(exception.StackTrace);
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
@@ -69,7 +69,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     public async Task CloseStreamOnAsyncYieldAndThrowException()
     {
         var exceptionMessage = "Exception from CloseStreamOnAsyncYieldAndThrowException";
-        Exception exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsAfterYield), exceptionMessage));
+        Exception exception = await Assert.ThrowsAnyAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsAfterYield), exceptionMessage));
         Assert.NotNull(exception.StackTrace);
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
@@ -81,10 +81,10 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     }
 
     [Fact]
-    public async Task CloseStreamOnAsyncThrowExceptionandYield()
+    public async Task CloseStreamOnAsyncThrowExceptionAndYield()
     {
         var exceptionMessage = "Exception from CloseStreamOnAsyncThrowExceptionAndYield";
-        Exception exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsBeforeYield), exceptionMessage));
+        Exception exception = await Assert.ThrowsAnyAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsBeforeYield), exceptionMessage));
         Assert.NotNull(exception.StackTrace);
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
@@ -99,7 +99,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     public async Task CloseStreamOnAsyncTMethodException()
     {
         var exceptionMessage = "Exception from CloseStreamOnAsyncTMethodException";
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatReturnsStringAndThrows), exceptionMessage));
+        await Assert.ThrowsAnyAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatReturnsStringAndThrows), exceptionMessage));
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
@@ -148,7 +148,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
             cts.Cancel();
             this.server.AllowServerMethodToReturn.Set();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+            await Assert.ThrowsAnyAsync<ConnectionLostException>(() => invokeTask);
             Assert.Equal(Server.ThrowAfterCancellationMessage, this.serverRpc.FaultException.Message);
             Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
         }

--- a/src/StreamJsonRpc/Exceptions/ConnectionLostException.cs
+++ b/src/StreamJsonRpc/Exceptions/ConnectionLostException.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// An exception used to fault a <see cref="Task"/> returned from a <see cref="JsonRpc"/> request
+    /// when the request could not be completed or the response cannot be received because the connection dropped.
+    /// </summary>
+#if SERIALIZABLE_EXCEPTIONS
+    [System.Serializable]
+#endif
+    public class ConnectionLostException : RemoteRpcException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionLostException"/> class.
+        /// </summary>
+        public ConnectionLostException()
+            : this(Resources.ConnectionDropped)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionLostException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ConnectionLostException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionLostException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public ConnectionLostException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if SERIALIZABLE_EXCEPTIONS
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionLostException"/> class.
+        /// </summary>
+        /// <param name="info">Serialization info.</param>
+        /// <param name="context">Streaming context.</param>
+        protected ConnectionLostException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1015,7 +1015,7 @@ namespace StreamJsonRpc
                     {
                         if (response == null)
                         {
-                            tcs.TrySetCanceled();
+                            tcs.TrySetException(new ConnectionLostException());
                         }
                         else if (response is JsonRpcError error)
                         {

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -200,6 +200,10 @@
           <target state="new">Text encoding is not supported because the formatter "{0}" does not implement "{1}".</target>
           <note from="MultilingualBuild" annotates="source" priority="2">{0} and {1} are CLR type names.</note>
         </trans-unit>
+        <trans-unit id="ConnectionDropped" translate="yes" xml:space="preserve">
+          <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
+          <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
+StreamJsonRpc.ConnectionLostException
+StreamJsonRpc.ConnectionLostException.ConnectionLostException() -> void
+StreamJsonRpc.ConnectionLostException.ConnectionLostException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+StreamJsonRpc.ConnectionLostException.ConnectionLostException(string message) -> void
+StreamJsonRpc.ConnectionLostException.ConnectionLostException(string message, System.Exception innerException) -> void
 StreamJsonRpc.HeaderDelimitedMessageHandler.Encoding.get -> System.Text.Encoding
 StreamJsonRpc.HeaderDelimitedMessageHandler.Encoding.set -> void
 StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -107,6 +107,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The JSON-RPC connection with the remote party was lost before the request could complete..
+        /// </summary>
+        internal static string ConnectionDropped {
+            get {
+                return ResourceManager.GetString("ConnectionDropped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Got a request to execute &apos;{0}&apos; but have no callback object. Dropping the request..
         /// </summary>
         internal static string DroppingRequestDueToNoTargetObject {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -265,4 +265,7 @@
     <value>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</value>
     <comment>{0} and {1} are CLR type names.</comment>
   </data>
+  <data name="ConnectionDropped" xml:space="preserve">
+    <value>The JSON-RPC connection with the remote party was lost before the request could complete.</value>
+  </data>
 </root>


### PR DESCRIPTION
Specifically, fault the tasks with a ConnectionLostException for this scenario.

This is technically a breaking change, but it's one that Roslyn has requested, and we're making lots of breaking changes in 2.0, so it's a reasonable time to do it. The new exception derives from an existing base class for an exception so it should be easy for folks to catch properly if they're looking for the base class.

Fixes #84