### PR TITLE
Always flush within the write semaphore

### DIFF
--- a/src/StreamJsonRpc/DelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/DelimitedMessageHandler.cs
@@ -158,9 +158,8 @@ namespace StreamJsonRpc
                     using (await this.sendingSemaphore.EnterAsync(cts.Token).ConfigureAwait(false))
                     {
                         await this.WriteCoreAsync(content, contentEncoding, cts.Token).ConfigureAwait(false);
+                        await this.FlushCoreAsync().ConfigureAwait(false);
                     }
-
-                    await this.FlushCoreAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {


### PR DESCRIPTION
It turns out that some streams are not safe to flush and write to concurrently. The STDIN stream of a child process happened to be the stream that we were writing to at a very high frequency when data corruption occurred. I saw cases both where buffers were transmitted twice, and in other cases buffers were just skipped.

Fixes #174 