### PR TITLE
Stop writing to and flushing streams concurrently

### DIFF
--- a/src/StreamJsonRpc.Tests/DirectMessageHandler.cs
+++ b/src/StreamJsonRpc.Tests/DirectMessageHandler.cs
@@ -31,8 +31,6 @@ public class DirectMessageHandler : MessageHandlerBase
 
     internal AsyncQueue<JToken> WrittenMessages { get; } = new AsyncQueue<JToken>();
 
-    protected override bool CanFlushConcurrentlyWithOtherWrites => true;
-
     protected override async ValueTask<JsonRpcMessage> ReadCoreAsync(CancellationToken cancellationToken)
     {
         return this.Formatter.Deserialize(await this.MessagesToRead.DequeueAsync(cancellationToken));

--- a/src/StreamJsonRpc/PipeMessageHandler.cs
+++ b/src/StreamJsonRpc/PipeMessageHandler.cs
@@ -93,9 +93,6 @@ namespace StreamJsonRpc
         /// </summary>
         protected PipeWriter Writer { get; }
 
-        /// <inheritdoc/>
-        protected override bool CanFlushConcurrentlyWithOtherWrites => false;
-
 #pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
         /// <inheritdoc/>
         protected sealed override ValueTask WriteCoreAsync(JsonRpcMessage content, CancellationToken cancellationToken)

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -164,7 +164,6 @@ StreamJsonRpc.StreamMessageHandler.SendingStream.get -> System.IO.Stream
 StreamJsonRpc.StreamMessageHandler.StreamMessageHandler(System.IO.Stream sendingStream, System.IO.Stream receivingStream, StreamJsonRpc.IJsonRpcMessageFormatter formatter) -> void
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket) -> void
 StreamJsonRpc.WebSocketMessageHandler.WebSocketMessageHandler(System.Net.WebSockets.WebSocket webSocket, StreamJsonRpc.IJsonRpcMessageFormatter formatter, int sizeHint = 4096) -> void
-abstract StreamJsonRpc.MessageHandlerBase.CanFlushConcurrentlyWithOtherWrites.get -> bool
 abstract StreamJsonRpc.MessageHandlerBase.CanRead.get -> bool
 abstract StreamJsonRpc.MessageHandlerBase.CanWrite.get -> bool
 abstract StreamJsonRpc.MessageHandlerBase.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
@@ -175,7 +174,6 @@ override StreamJsonRpc.HeaderDelimitedMessageHandler.ReadCoreAsync(System.Thread
 override StreamJsonRpc.HeaderDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.LengthHeaderMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
 override StreamJsonRpc.LengthHeaderMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
-override StreamJsonRpc.PipeMessageHandler.CanFlushConcurrentlyWithOtherWrites.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanWrite.get -> bool
 override StreamJsonRpc.PipeMessageHandler.Dispose(bool disposing) -> void
@@ -183,12 +181,10 @@ override StreamJsonRpc.PipeMessageHandler.FlushAsync(System.Threading.Cancellati
 override StreamJsonRpc.Protocol.JsonRpcError.ToString() -> string
 override StreamJsonRpc.Protocol.JsonRpcRequest.ToString() -> string
 override StreamJsonRpc.Protocol.JsonRpcResult.ToString() -> string
-override StreamJsonRpc.StreamMessageHandler.CanFlushConcurrentlyWithOtherWrites.get -> bool
 override StreamJsonRpc.StreamMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.StreamMessageHandler.CanWrite.get -> bool
 override StreamJsonRpc.StreamMessageHandler.Dispose(bool disposing) -> void
 override StreamJsonRpc.StreamMessageHandler.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-override StreamJsonRpc.WebSocketMessageHandler.CanFlushConcurrentlyWithOtherWrites.get -> bool
 override StreamJsonRpc.WebSocketMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.WebSocketMessageHandler.CanWrite.get -> bool
 override StreamJsonRpc.WebSocketMessageHandler.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/StreamJsonRpc/StreamMessageHandler.cs
+++ b/src/StreamJsonRpc/StreamMessageHandler.cs
@@ -51,9 +51,6 @@ namespace StreamJsonRpc
         /// </summary>
         public override bool CanWrite => this.SendingStream != null;
 
-        /// <inheritdoc/>
-        protected override bool CanFlushConcurrentlyWithOtherWrites => true;
-
         /// <summary>
         /// Gets the stream used to transmit messages. May be null.
         /// </summary>

--- a/src/StreamJsonRpc/WebSocketMessageHandler.cs
+++ b/src/StreamJsonRpc/WebSocketMessageHandler.cs
@@ -72,9 +72,6 @@ namespace StreamJsonRpc
         public WebSocket WebSocket { get; }
 
         /// <inheritdoc />
-        protected override bool CanFlushConcurrentlyWithOtherWrites => true;
-
-        /// <inheritdoc />
         protected override async ValueTask<JsonRpcMessage> ReadCoreAsync(CancellationToken cancellationToken)
         {
             using (var contentSequenceBuilder = new Sequence<byte>())


### PR DESCRIPTION
This is a fresh fix for #174 that is compatible with our 2.0 branch.

Basically I'm removing the option (which our Stream handler had opted into) for flush and write to happen concurrently.