### PR TITLE
More confidently fault aborted requests

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
@@ -26,8 +26,8 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         this.clientRpc = new JsonRpcWithFatalExceptions(this.messageHandler);
         this.serverRpc = new JsonRpcWithFatalExceptions(new HeaderDelimitedMessageHandler(streams.Item2, streams.Item2), this.server);
 
-        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Error);
-        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Error);
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Information);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Information);
 
         this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
         this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
@@ -67,10 +67,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
-        // Assert that the JsonRpc and MessageHandler objects are disposed after exception
-        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.messageHandler).IsDisposed);
+        await this.AssertAllPartiesDisposedEventuallyAsync();
     }
 
     [Fact]
@@ -82,10 +79,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
-        // Assert that the JsonRpc and MessageHandler objects are disposed after exception
-        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.messageHandler).IsDisposed);
+        await this.AssertAllPartiesDisposedEventuallyAsync();
     }
 
     [Fact]
@@ -97,10 +91,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
-        // Assert that the JsonRpc and MessageHandler objects are disposed after exception
-        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.messageHandler).IsDisposed);
+        await this.AssertAllPartiesDisposedEventuallyAsync();
     }
 
     [Fact]
@@ -111,10 +102,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         Assert.Equal(exceptionMessage, this.serverRpc.FaultException.Message);
         Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
 
-        // Assert that the JsonRpc and MessageHandler objects are disposed after exception
-        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.messageHandler).IsDisposed);
+        await this.AssertAllPartiesDisposedEventuallyAsync();
     }
 
     [Fact]
@@ -161,10 +149,7 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
             Assert.Equal(1, this.serverRpc.IsFatalExceptionCount);
         }
 
-        // Assert that the JsonRpc and MessageHandler objects are disposed after exception
-        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverRpc).IsDisposed);
-        Assert.True(((IDisposableObservable)this.messageHandler).IsDisposed);
+        await this.AssertAllPartiesDisposedEventuallyAsync();
     }
 
     [Fact]
@@ -203,6 +188,41 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
         }
 
         base.Dispose(disposing);
+    }
+
+    private Task AssertAllPartiesDisposedEventuallyAsync()
+    {
+        return Task.WhenAll(
+            this.AssertIsDisposedEventuallyAsync(this.clientRpc),
+            this.AssertIsDisposedEventuallyAsync(this.serverRpc),
+            this.AssertIsDisposedEventuallyAsync(this.messageHandler as IDisposableObservable));
+    }
+
+    private async Task AssertIsDisposedEventuallyAsync(IDisposableObservable disposableObservable)
+    {
+        if (disposableObservable == null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (!this.TimeoutToken.IsCancellationRequested)
+            {
+                if (disposableObservable.IsDisposed)
+                {
+                    return;
+                }
+
+                await Task.Delay(1, this.TimeoutToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Swallow this. We're going to assert next for a better failure message.
+        }
+
+        Assert.True(disposableObservable.IsDisposed);
     }
 
     public class Server

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1486,11 +1486,12 @@ namespace StreamJsonRpc
             }
             finally
             {
-                // Dispose the stream and cancel pending requests in the finally block
+                // Dispose the stream and fault pending requests in the finally block
                 // So this is executed even if Disconnected event handler throws.
-                this.disposeCts.Cancel();
+                this.FaultPendingRequests(); // fault existing ones so they don't get inadvertently canceled
+                this.disposeCts.Cancel(); // slam the door shut on new requests
+                this.FaultPendingRequests(); // fault any that slipped through while we closed the door.
                 (this.MessageHandler as IDisposable)?.Dispose();
-                this.CancelPendingRequests();
 
                 // Ensure the Task we may have returned from Completion is completed.
                 if (eventArgs.Exception != null)
@@ -1701,7 +1702,7 @@ namespace StreamJsonRpc
             }
         }
 
-        private void CancelPendingRequests()
+        private void FaultPendingRequests()
         {
             OutstandingCallData[] pendingRequests;
             lock (this.dispatcherMapLock)


### PR DESCRIPTION
The problem was we started shutting things down before faulting requests, such that a race existed in which requests might be "canceled" before we got around to faulting them. So with this change, we fault them *first*, then shut other stuff down.

This should stabilize the JsonRpcWithFatalExceptionsTests tests that are sporatically failing ever since 25a8e35ee was checked in.