### PR TITLE
Enable method rename behavior and tests on netcoreapp2.1

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -254,7 +254,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         Assert.Throws<TypeLoadException>(() => JsonRpc.Attach<IServerInternal>(streams.Item1));
     }
 
-#if NET461 || NETCOREAPP2_0
+#if !NETCOREAPP1_0
     [Fact]
     public async Task RPCMethodNameSubstitution()
     {
@@ -285,7 +285,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         Assert.Equal("Hi!", await clientRpcWithCamelCase.SayHiAsync()); // "sayHiAsync"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
-#if NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
+#if !NETCOREAPP1_0 // skip attribute-based renames where not supported
         Assert.Equal("ANDREW", await clientRpcWithCamelCase.ARoseByAsync("andrew")); // "anotherName"
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
 #endif
@@ -296,7 +296,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         // Retry with our second client proxy to send messages which the server should now accept.
         Assert.Equal("Hi!", await clientRpcWithPrefix.SayHiAsync()); // "ns.SayHiAsync"
-#if NET461 || NETCOREAPP2_0 // skip attribute-based renames where not supported
+#if !NETCOREAPP1_0 // skip attribute-based renames where not supported
         Assert.Equal("ANDREW", await clientRpcWithPrefix.ARoseByAsync("andrew")); // "ns.AnotherName"
 #endif
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1123,7 +1123,7 @@ public abstract class JsonRpcTests : TestBase
         await Task.WhenAll(invocation1, invocation2);
     }
 
-#if NET461 || NETCOREAPP2_0
+#if !NETCOREAPP1_0
     [Fact]
     public async Task ServerRespondsWithMethodRenamedByInterfaceAttribute()
     {

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -15,7 +15,7 @@
     <!-- VS2017 Test Explorer test navigation and callstack links don't work with portable PDBs yet. -->
     <DebugType>Full</DebugType>
 
-    <AspNetCoreHost Condition=" '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'net461' ">true</AspNetCoreHost>
+    <AspNetCoreHost Condition=" '$(TargetFramework)' != 'netcoreapp1.0' ">true</AspNetCoreHost>
     <DefineConstants Condition=" '$(AspNetCoreHost)' == 'true' ">$(DefineConstants);ASPNETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/WebSocketMessageHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0 || NET461
+﻿#if !NETCOREAPP1_0
 
 using System;
 using System.Collections.Generic;

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1812,7 +1812,7 @@ namespace StreamJsonRpc
             internal MethodNameMap(TypeInfo typeInfo)
             {
                 Requires.NotNull(typeInfo, nameof(typeInfo));
-#if NET46 || NETSTANDARD2_0
+#if !NETSTANDARD1_6
                 this.interfaceMaps = typeInfo.ImplementedInterfaces.Select(i => typeInfo.GetInterfaceMap(i)).ToList();
 #else
                 this.interfaceMaps = new List<InterfaceMapping>();


### PR DESCRIPTION
This worked on netcoreapp2.0 already, but when we started multi-targeting to netcoreapp2.1, the #if expressions were not updated, leading to a regression in functionality from 2.0 to 2.1.