### PR TITLE
Remove UTF-8 preamble from JSON-RPC messages

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Text;
-using System.Threading.Tasks;
+using Nerdbank.Streams;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
 using Xunit;
@@ -20,5 +21,28 @@ public class JsonMessageFormatterTests : TestBase
     {
         var formatter = new JsonMessageFormatter();
         Assert.Empty(formatter.Encoding.GetPreamble());
+    }
+
+    [Fact]
+    public void EncodingProperty_UsedToFormat()
+    {
+        JsonRpcRequest msg = new JsonRpcRequest { Method = "a" };
+        var builder = new Sequence<byte>();
+        var formatter = new JsonMessageFormatter();
+
+        formatter.Encoding = Encoding.ASCII;
+        formatter.Serialize(builder, msg);
+        long asciiLength = builder.AsReadOnlySequence.Length;
+        var readMsg = (JsonRpcRequest)formatter.Deserialize(builder.AsReadOnlySequence);
+        Assert.Equal(msg.Method, readMsg.Method);
+
+        builder.Reset();
+        formatter.Encoding = Encoding.UTF32;
+        formatter.Serialize(builder, msg);
+        long utf32Length = builder.AsReadOnlySequence.Length;
+        readMsg = (JsonRpcRequest)formatter.Deserialize(builder.AsReadOnlySequence);
+        Assert.Equal(msg.Method, readMsg.Method);
+
+        Assert.Equal(utf32Length - Encoding.UTF32.GetPreamble().Length, asciiLength * 4);
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -14,4 +14,11 @@ public class JsonMessageFormatterTests : TestBase
         : base(logger)
     {
     }
+
+    [Fact]
+    public void DefaultEncodingLacksPreamble()
+    {
+        var formatter = new JsonMessageFormatter();
+        Assert.Empty(formatter.Encoding.GetPreamble());
+    }
 }

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -31,6 +31,11 @@ namespace StreamJsonRpc
         internal const string ExceptionDataKey = "JToken";
 
         /// <summary>
+        /// UTF-8 encoding without a preamble.
+        /// </summary>
+        private static readonly Encoding DefaultEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
         /// Backing field for the <see cref="Encoding"/> property.
         /// </summary>
         private Encoding encoding;
@@ -40,7 +45,7 @@ namespace StreamJsonRpc
         /// that uses <see cref="Encoding.UTF8"/> for its text encoding.
         /// </summary>
         public JsonMessageFormatter()
-            : this(Encoding.UTF8)
+            : this(DefaultEncoding)
         {
         }
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -42,7 +42,7 @@ namespace StreamJsonRpc
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonMessageFormatter"/> class
-        /// that uses <see cref="Encoding.UTF8"/> for its text encoding.
+        /// that uses <see cref="Encoding.UTF8"/> (without the preamble) for its text encoding.
         /// </summary>
         public JsonMessageFormatter()
             : this(DefaultEncoding)


### PR DESCRIPTION
This fixes a regression from 1.x