### PR TITLE
Allow for message formatters to rename properties on param objects 

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,6 +105,14 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
     }
 
     [Fact]
+    public async Task InvokeWithParameterObject_WithRenamingAttributes()
+    {
+        var param = new ParamsObjectWithCustomNames { TheArgument = "hello" };
+        string result = await this.clientRpc.InvokeWithParameterObjectAsync<string>(nameof(Server.ServerMethod), param, this.TimeoutToken);
+        Assert.Equal(param.TheArgument + "!", result);
+    }
+
+    [Fact]
     public async Task CanInvokeServerMethodWithParameterPassedAsArray()
     {
         string result1 = await this.clientRpc.InvokeAsync<string>(nameof(Server.TestParameter), "test");
@@ -192,6 +201,13 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
 
         this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
         this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+    }
+
+    [DataContract]
+    public class ParamsObjectWithCustomNames
+    {
+        [DataMember(Name = "argument")]
+        public string TheArgument { get; set; }
     }
 
     private class StringBase64Converter : JsonConverter

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -5,6 +5,10 @@ namespace StreamJsonRpc
 {
     using System;
     using System.Buffers;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
     using MessagePack;
     using Nerdbank.Streams;
     using StreamJsonRpc.Protocol;
@@ -53,6 +57,13 @@ namespace StreamJsonRpc
         /// <inheritdoc/>
         public void Serialize(IBufferWriter<byte> contentBuffer, JsonRpcMessage message)
         {
+            if (message is JsonRpcRequest request && request.Arguments != null && request.ArgumentsArray == null && !(request.Arguments is IReadOnlyDictionary<string, object>))
+            {
+                // This request contains named arguments, but not using a standard dictionary. Convert it to a dictionary so that
+                // the parameters can be matched to the method we're invoking.
+                request.Arguments = GetParamsObjectDictionary(request.Arguments);
+            }
+
             if (this.compress)
             {
                 LZ4MessagePackSerializer.Typeless.Serialize(contentBuffer.AsStream(), message);
@@ -65,5 +76,48 @@ namespace StreamJsonRpc
 
         /// <inheritdoc/>
         public object GetJsonText(JsonRpcMessage message) => MessagePackSerializer.ToJson<object>(message);
+
+        /// <summary>
+        /// Extracts a dictionary of property names and values from the specified params object.
+        /// </summary>
+        /// <param name="paramsObject">The params object.</param>
+        /// <returns>A dictionary, or <c>null</c> if <paramref name="paramsObject"/> is null.</returns>
+        /// <remarks>
+        /// In its present implementation, this method disregards any renaming attributes that would give
+        /// the properties on the parameter object a different name. The <see cref="MessagePackSerializer"/>
+        /// doesn't expose a simple way of doing this, so we'd have to emulate it by supporting both
+        /// <see cref="DataMemberAttribute.Name"/> and <see cref="KeyAttribute.StringKey"/> handling.
+        /// </remarks>
+        private static Dictionary<string, object> GetParamsObjectDictionary(object paramsObject)
+        {
+            if (paramsObject == null)
+            {
+                return null;
+            }
+
+            if (paramsObject is IReadOnlyDictionary<object, object> dictionary)
+            {
+                // Anonymous types are serialized this way.
+                return dictionary.ToDictionary(kv => (string)kv.Key, kv => kv.Value);
+            }
+
+            var result = new Dictionary<string, object>(StringComparer.Ordinal);
+
+            const BindingFlags bindingFlags = BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.Instance;
+            foreach (var property in paramsObject.GetType().GetTypeInfo().GetProperties(bindingFlags))
+            {
+                if (property.GetMethod != null)
+                {
+                    result[property.Name] = property.GetValue(paramsObject);
+                }
+            }
+
+            foreach (var field in paramsObject.GetType().GetTypeInfo().GetFields(bindingFlags))
+            {
+                result[field.Name] = field.GetValue(paramsObject);
+            }
+
+            return result;
+        }
     }
 }

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -202,15 +202,15 @@ namespace StreamJsonRpc
         {
             if (jsonRpcMessage is Protocol.JsonRpcRequest request)
             {
-                if (request.NamedArguments != null)
-                {
-                    request.NamedArguments = request.NamedArguments.ToDictionary(
-                        kv => kv.Key,
-                        kv => (object)this.TokenizeUserData(kv.Value));
-                }
-                else if (request.ArgumentsArray != null)
+                if (request.ArgumentsArray != null)
                 {
                     request.ArgumentsArray = request.ArgumentsArray.Select(this.TokenizeUserData).ToArray();
+                }
+                else if (request.Arguments != null)
+                {
+                    // Tokenize the user data using the user-supplied serializer.
+                    var paramsObject = JObject.FromObject(request.Arguments, this.JsonSerializer);
+                    request.Arguments = paramsObject;
                 }
             }
             else if (jsonRpcMessage is Protocol.JsonRpcResult result)

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1020,7 +1020,7 @@ namespace StreamJsonRpc
                     argument = arguments[0];
                 }
 
-                request.Arguments = GetParamsObjectDictionary(argument);
+                request.Arguments = argument;
             }
             else
             {
@@ -1099,35 +1099,6 @@ namespace StreamJsonRpc
             {
                 throw new ConnectionLostException(Resources.ConnectionDropped, ex);
             }
-        }
-
-        /// <summary>
-        /// Extracts a dictionary of property names and values from the specified params object.
-        /// </summary>
-        /// <param name="paramsObject">The params object supplied to <see cref="InvokeWithParameterObjectAsync{TResult}(string, object, CancellationToken)"/>.</param>
-        /// <returns>A dictionary, or <c>null</c> if <paramref name="paramsObject"/> is null.</returns>
-        private static Dictionary<string, object> GetParamsObjectDictionary(object paramsObject)
-        {
-            if (paramsObject == null)
-            {
-                return null;
-            }
-
-            var result = new Dictionary<string, object>(StringComparer.Ordinal);
-            foreach (var property in paramsObject.GetType().GetTypeInfo().GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (property.GetMethod != null)
-                {
-                    result[property.Name] = property.GetValue(paramsObject);
-                }
-            }
-
-            foreach (var field in paramsObject.GetType().GetTypeInfo().GetFields(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.Instance))
-            {
-                result[field.Name] = field.GetValue(paramsObject);
-            }
-
-            return result;
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -19,11 +19,6 @@ namespace StreamJsonRpc.Protocol
     public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     {
         /// <summary>
-        /// Backing field for the <see cref="Arguments"/> property.
-        /// </summary>
-        private object arguments;
-
-        /// <summary>
         /// The result of an attempt to match request arguments with a candidate method's parameters.
         /// </summary>
         public enum ArgumentMatchResult
@@ -66,15 +61,7 @@ namespace StreamJsonRpc.Protocol
         /// If neither of these, <see cref="ArgumentCount"/> and <see cref="TryGetArgumentByNameOrIndex(string, int, Type, out object)"/> should be overridden.
         /// </value>
         [DataMember(Name = "params", Order = 2, IsRequired = false, EmitDefaultValue = false)]
-        public object Arguments
-        {
-            get => this.arguments;
-            set
-            {
-                Requires.Argument(value is IReadOnlyDictionary<string, object> || value is object[] || value == null, nameof(value), "Disallowed type.");
-                this.arguments = value;
-            }
-        }
+        public object Arguments { get; set; }
 
         /// <summary>
         /// Gets or sets an identifier established by the client if a response to the request is expected.


### PR DESCRIPTION
This fixes a regression from 1.x to 2.0, that originated when `JsonRpc` took upon itself the responsibility of dissecting a params object into its individual members. It did this without regard to the properties that Newtonsoft.Json would respect to change the names of the members, because at the `JsonRpc` level we don't know which formatter will be used.

The fix is simply to absolve `JsonRpc` of any responsibility to break up the params object, but rather just leave it as a params object in the `JsonRpcRequest`, leaving it to the formatter to represent. This alone made it work almost for free. Only minimal work in the `JsonMessageFormatter` was required for this to work.

The sample `MessagePackFormatter` included in the test project theoretically should support property renaming as well, but as the `MessagePack` library isn't factored as well as Newtonsoft.Json, it wasn't easy enough to expose it properly, so I avoid adding the new property renaming test except to apply to the `JsonMessageFormatter` class.

Fixes #191