### PR TITLE
Improve error message when required arguments are missing

### DIFF
--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -204,6 +204,10 @@
           <source>The JSON-RPC connection with the remote party was lost before the request could complete.</source>
           <target state="new">The JSON-RPC connection with the remote party was lost before the request could complete.</target>
         </trans-unit>
+        <trans-unit id="RequiredArgumentMissing" translate="yes" xml:space="preserve">
+          <source>An argument was not supplied for a required parameter.</source>
+          <target state="new">An argument was not supplied for a required parameter.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -149,6 +149,7 @@ namespace StreamJsonRpc
                     this.AddErrorMessage(string.Format(CultureInfo.CurrentCulture, Resources.MethodParametersNotCompatible, method));
                     return false;
                 case JsonRpcRequest.ArgumentMatchResult.MissingArgument:
+                    this.AddErrorMessage(Resources.RequiredArgumentMissing);
                     return false;
                 default:
                     return false;

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -296,6 +296,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An argument was not supplied for a required parameter..
+        /// </summary>
+        internal static string RequiredArgumentMissing {
+            get {
+                return ResourceManager.GetString("RequiredArgumentMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Response is not error..
         /// </summary>
         internal static string ResponseIsNotError {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -268,4 +268,7 @@
   <data name="ConnectionDropped" xml:space="preserve">
     <value>The JSON-RPC connection with the remote party was lost before the request could complete.</value>
   </data>
+  <data name="RequiredArgumentMissing" xml:space="preserve">
+    <value>An argument was not supplied for a required parameter.</value>
+  </data>
 </root>


### PR DESCRIPTION
Before this change, when an argument is not supplied for a required parameter, the error the user would get was essentially "it didn't work for these reasons: " but no reason was given. The new string added in this PR adds the rest of this message so that a reason is actually given.