### PR TITLE
 Fix proxy gen detection of CancellationToken in unsupported position

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -57,6 +57,11 @@ public class JsonRpcProxyGenerationTests : TestBase
         Task<string> ARoseByAsync(string name);
     }
 
+    public interface IServerWithBadCancellationParam
+    {
+        Task<int> HeavyWorkAsync(CancellationToken cancellationToken, int param1);
+    }
+
     public interface IServer3
     {
         Task<string> SayHiAsync();
@@ -222,6 +227,12 @@ public class JsonRpcProxyGenerationTests : TestBase
         cts.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         Assert.Equal(456, await this.server.MethodResult.Task); // assert that the argument we passed actually reached the method
+    }
+
+    [Fact]
+    public void CancellationTokenInBadPositionIsRejected()
+    {
+        Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithBadCancellationParam>(new MemoryStream()));
     }
 
     /// <summary>

--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -192,14 +192,36 @@ public class JsonRpcProxyGenerationTests : TestBase
     {
         await this.clientRpc.HeavyWorkAsync(CancellationToken.None);
         Assert.Equal(1, this.server.Counter);
+        this.server.MethodEntered.Reset();
+
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.HeavyWorkAsync(new CancellationToken(canceled: true)));
+        Assert.False(this.server.MethodEntered.IsSet);
+
+        var cts = new CancellationTokenSource();
+        this.server.ResumeMethod.Reset();
+        Task task = this.clientRpc.HeavyWorkAsync(cts.Token);
+        await this.server.MethodEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
     }
 
     [Fact]
     public async Task CallMethod_intCancellationToken_int()
     {
         Assert.Equal(123, await this.clientRpc.HeavyWorkAsync(123, CancellationToken.None));
+        this.server.MethodEntered.Reset();
+        this.server.MethodResult = new TaskCompletionSource<int>();
+
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.HeavyWorkAsync(456, new CancellationToken(canceled: true)));
+        Assert.False(this.server.MethodEntered.IsSet);
+
+        var cts = new CancellationTokenSource();
+        this.server.ResumeMethod.Reset();
+        Task task = this.clientRpc.HeavyWorkAsync(456, cts.Token);
+        await this.server.MethodEntered.WaitAsync().WithCancellation(this.TimeoutToken);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        Assert.Equal(456, await this.server.MethodResult.Task); // assert that the argument we passed actually reached the method
     }
 
     /// <summary>
@@ -384,6 +406,12 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         public event EventHandler<CustomEventArgs> TreeGrown;
 
+        public AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
+
+        public AsyncManualResetEvent ResumeMethod { get; } = new AsyncManualResetEvent(initialState: true);
+
+        public TaskCompletionSource<int> MethodResult { get; set; } = new TaskCompletionSource<int>();
+
         public int Counter { get; set; }
 
         public Task<string> SayHiAsync() => Task.FromResult("Hi!");
@@ -404,17 +432,21 @@ public class JsonRpcProxyGenerationTests : TestBase
             return TplExtensions.CompletedTask;
         }
 
-        public Task HeavyWorkAsync(CancellationToken cancellationToken)
+        public async Task HeavyWorkAsync(CancellationToken cancellationToken)
         {
+            this.MethodEntered.Set();
+            await this.ResumeMethod.WaitAsync().WithCancellation(cancellationToken);
             this.Counter++;
             cancellationToken.ThrowIfCancellationRequested();
-            return TplExtensions.CompletedTask;
         }
 
-        public Task<int> HeavyWorkAsync(int param1, CancellationToken cancellationToken)
+        public async Task<int> HeavyWorkAsync(int param1, CancellationToken cancellationToken)
         {
+            this.MethodEntered.Set();
+            this.MethodResult.SetResult(param1);
+            await this.ResumeMethod.WaitAsync().WithCancellation(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(param1);
+            return param1;
         }
 
         public Task<int> MultiplyAsync(int a, int b) => Task.FromResult(a * b);

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="cs" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">{0} není rozhraní.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="de" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" ist keine Schnittstelle.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="es" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" no es una interfaz.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="fr" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" n'est pas une interface.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="it" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" non è un'interfaccia.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" はインターフェイスではありません。</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ko" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}"은(는) 인터페이스가 아닙니다.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pl" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">Element „{0}” nie jest interfejsem.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-br" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" não é uma interface.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ru" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" не является интерфейсом.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="tr" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" bir arabirim değil.</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-hans" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">“{0}”不是接口。</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="zh-hant" original="STREAMJSONRPC/RESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -192,6 +192,10 @@
         <trans-unit id="ClientProxyTypeArgumentMustBeAnInterface" translate="yes" xml:space="preserve">
           <source>"{0}" is not an interface.</source>
 		  <target state="translated">"{0}" 不是介面。</target>
+        </trans-unit>
+        <trans-unit id="CancellationTokenMustBeLastParameter" translate="yes" xml:space="preserve">
+          <source>A CancellationToken is only allowed as the last parameter.</source>
+          <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
       </group>
     </body>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -232,6 +232,7 @@ namespace StreamJsonRpc
                     {
                         if (methodParameters[i].ParameterType == typeof(CancellationToken))
                         {
+                            VerifySupported(i == methodParameters.Length - 1, Resources.CancellationTokenMustBeLastParameter, method);
                             cancellationTokenParameter = methodParameters[i];
                             continue;
                         }

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -71,6 +71,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A CancellationToken is only allowed as the last parameter..
+        /// </summary>
+        internal static string CancellationTokenMustBeLastParameter {
+            get {
+                return ResourceManager.GetString("CancellationTokenMustBeLastParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; is not an interface..
         /// </summary>
         internal static string ClientProxyTypeArgumentMustBeAnInterface {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -246,6 +246,9 @@
   <data name="MustNotBeListening" xml:space="preserve">
     <value>This cannot be done after listening has started.</value>
   </data>
+  <data name="CancellationTokenMustBeLastParameter" xml:space="preserve">
+    <value>A CancellationToken is only allowed as the last parameter.</value>
+  </data>
   <data name="ClientProxyTypeArgumentMustBeAnInterface" xml:space="preserve">
     <value>"{0}" is not an interface.</value>
   </data>


### PR DESCRIPTION
Enhances CancellationToken tests of the dynamic proxy generation, and fixes proxy gen to notice and report an error when the CancellationToken is not the last parameter. 
Before this change, the generated proxy would throw an `IndexOutOfRangeException` at runtime if the `CancellationToken` appeared as anything other than the last parameter of a method on the interface.