### PR TITLE
Fix dynamic proxy generation from interfaces which implement other interfaces

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -18,7 +18,7 @@ public class JsonRpcProxyGenerationTests : TestBase
     private JsonRpc serverRpc;
 
     private FullDuplexStream clientStream;
-    private IServer clientRpc;
+    private IServerDerived clientRpc;
 
     public JsonRpcProxyGenerationTests(ITestOutputHelper logger)
         : base(logger)
@@ -27,7 +27,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         this.serverStream = streams.Item1;
         this.clientStream = streams.Item2;
 
-        this.clientRpc = JsonRpc.Attach<IServer>(this.clientStream);
+        this.clientRpc = JsonRpc.Attach<IServerDerived>(this.clientStream);
 
         this.server = new Server();
         this.serverRpc = JsonRpc.Attach(this.serverStream, this.server);
@@ -48,7 +48,10 @@ public class JsonRpcProxyGenerationTests : TestBase
         Task IncrementAsync();
 
         Task Dispose();
+    }
 
+    public interface IServerDerived : IServer
+    {
         Task HeavyWorkAsync(CancellationToken cancellationToken);
 
         Task<int> HeavyWorkAsync(int param1, CancellationToken cancellationToken);
@@ -99,7 +102,7 @@ public class JsonRpcProxyGenerationTests : TestBase
     public void ProxyTypeIsReused()
     {
         var streams = FullDuplexStream.CreateStreams();
-        var clientRpc = JsonRpc.Attach<IServer>(streams.Item1);
+        var clientRpc = JsonRpc.Attach<IServerDerived>(streams.Item1);
         Assert.IsType(this.clientRpc.GetType(), clientRpc);
     }
 
@@ -378,7 +381,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         public int Seeds { get; set; }
     }
 
-    internal class Server : IServer, IServer2, IServer3
+    internal class Server : IServerDerived, IServer2, IServer3
     {
         public event EventHandler ItHappened;
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1534,7 +1534,8 @@ namespace StreamJsonRpc
             {
                 Requires.NotNull(typeInfo, nameof(typeInfo));
 #if NET45 || NET46 || NETSTANDARD2_0
-                this.interfaceMaps = typeInfo.ImplementedInterfaces.Select(i => typeInfo.GetInterfaceMap(i)).ToList();
+                this.interfaceMaps = typeInfo.IsInterface ? new List<InterfaceMapping>()
+                    : typeInfo.ImplementedInterfaces.Select(typeInfo.GetInterfaceMap).ToList();
 #else
                 this.interfaceMaps = new List<InterfaceMapping>();
 #endif

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -82,11 +82,11 @@ namespace StreamJsonRpc
                 var jsonRpcField = proxyTypeBuilder.DefineField("rpc", typeof(JsonRpc), fieldAttributes);
                 var optionsField = proxyTypeBuilder.DefineField("options", typeof(JsonRpcProxyOptions), fieldAttributes);
 
-                VerifySupported(!serviceInterface.DeclaredProperties.Any(), Resources.UnsupportedPropertiesOnClientProxyInterface, serviceInterface);
+                VerifySupported(!FindAllOnThisAndOtherInterfaces(serviceInterface, i => i.DeclaredProperties).Any(), Resources.UnsupportedPropertiesOnClientProxyInterface, serviceInterface);
 
                 // Implement events
                 var ctorActions = new List<Action<ILGenerator>>();
-                foreach (var evt in serviceInterface.DeclaredEvents)
+                foreach (var evt in FindAllOnThisAndOtherInterfaces(serviceInterface, i => i.DeclaredEvents))
                 {
                     VerifySupported(evt.EventHandlerType.Equals(typeof(EventHandler)) || (evt.EventHandlerType.GetTypeInfo().IsGenericType && evt.EventHandlerType.GetGenericTypeDefinition().Equals(typeof(EventHandler<>))), Resources.UnsupportedEventHandlerTypeOnClientProxyInterface, evt);
 
@@ -196,7 +196,7 @@ namespace StreamJsonRpc
                 var invokeWithCancellationAsyncOfTaskMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => !m.IsGenericMethod);
                 var invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod);
 
-                foreach (var method in serviceInterface.DeclaredMethods.Where(m => !m.IsSpecialName))
+                foreach (var method in FindAllOnThisAndOtherInterfaces(serviceInterface, i => i.DeclaredMethods).Where(m => !m.IsSpecialName))
                 {
                     VerifySupported(method.ReturnType == typeof(Task) || (method.ReturnType.GetTypeInfo().IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>)), Resources.UnsupportedMethodReturnTypeOnClientProxyInterface, method, method.ReturnType.FullName);
                     VerifySupported(!method.IsGenericMethod, Resources.UnsupportedGenericMethodsOnClientProxyInterface, method);
@@ -378,6 +378,15 @@ namespace StreamJsonRpc
 
                 throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, messageFormat, formattingArgs));
             }
+        }
+
+        private static IEnumerable<T> FindAllOnThisAndOtherInterfaces<T>(TypeInfo interfaceType, Func<TypeInfo, IEnumerable<T>> oneInterfaceQuery)
+        {
+            Requires.NotNull(interfaceType, nameof(interfaceType));
+            Requires.NotNull(oneInterfaceQuery, nameof(oneInterfaceQuery));
+
+            var result = oneInterfaceQuery(interfaceType);
+            return result.Concat(interfaceType.ImplementedInterfaces.SelectMany(i => oneInterfaceQuery(i.GetTypeInfo())));
         }
     }
 }


### PR DESCRIPTION
We weren't testing dynamic proxy generation with interfaces that derive from other interfaces. I stumbled across that while developing another feature and found it was broken. This fixes it, and adds a regression test.