### PR TITLE
Add option to suppress non-public method invocation on server objects

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -331,9 +331,10 @@ public class JsonRpcTests : TestBase
     }
 
     [Fact]
-    public async Task CannotCallPrivateMethod()
+    public async Task CanCallNonPublicMethods()
     {
-        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(Server.InternalMethod), 10));
+        await this.clientRpc.InvokeAsync(nameof(Server.InternalMethod));
+        await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
     }
 
     [Fact]
@@ -1543,6 +1544,7 @@ public class JsonRpcTests : TestBase
 
         internal void InternalMethod()
         {
+            this.ServerMethodReached.Set();
         }
 
         [JsonRpcMethod("InternalMethodWithAttribute")]

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -338,9 +338,10 @@ public class JsonRpcTests : TestBase
     }
 
     [Fact]
-    public async Task CannotCallPrivateMethodEvenWithAttribute()
+    public async Task CanCallNonPublicMethodsWithAttribute()
     {
-        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeAsync(nameof(Server.InternalMethodWithAttribute), 10));
+        await this.clientRpc.InvokeAsync(nameof(Server.InternalMethodWithAttribute));
+        await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
     }
 
     [Fact]
@@ -1550,6 +1551,7 @@ public class JsonRpcTests : TestBase
         [JsonRpcMethod("InternalMethodWithAttribute")]
         internal void InternalMethodWithAttribute()
         {
+            this.ServerMethodReached.Set();
         }
     }
 

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.combinatorial" Version="1.2.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.3" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.32" />

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -397,7 +397,7 @@ namespace StreamJsonRpc
             options = options ?? JsonRpcTargetOptions.Default;
             this.ThrowIfConfigurationLocked();
 
-            var mapping = GetRequestMethodToClrMethodMap(target);
+            var mapping = GetRequestMethodToClrMethodMap(target, options);
             lock (this.syncObject)
             {
                 foreach (var item in mapping)
@@ -934,10 +934,12 @@ namespace StreamJsonRpc
         /// Creates a dictionary which maps a request method name to its clr method name via <see cref="JsonRpcMethodAttribute" /> value.
         /// </summary>
         /// <param name="target">Object to reflect over and analyze its methods.</param>
+        /// <param name="options">The options that apply for this target object.</param>
         /// <returns>Dictionary which maps a request method name to its clr method name.</returns>
-        private static Dictionary<string, List<MethodSignatureAndTarget>> GetRequestMethodToClrMethodMap(object target)
+        private static Dictionary<string, List<MethodSignatureAndTarget>> GetRequestMethodToClrMethodMap(object target, JsonRpcTargetOptions options)
         {
             Requires.NotNull(target, nameof(target));
+            Requires.NotNull(options, nameof(options));
 
             var clrMethodToRequestMethodMap = new Dictionary<string, string>(StringComparer.Ordinal);
             var requestMethodToClrMethodNameMap = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -951,6 +953,11 @@ namespace StreamJsonRpc
                 // As we enumerate methods, skip accessor methods
                 foreach (MethodInfo method in t.DeclaredMethods.Where(m => !m.IsSpecialName))
                 {
+                    if (!options.AllowNonPublicInvocation && !method.IsPublic)
+                    {
+                        continue;
+                    }
+
                     var requestName = mapping.GetRpcMethodName(method);
 
                     if (!requestMethodToDelegateMap.TryGetValue(requestName, out var methodTargetList))

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -30,6 +30,13 @@ namespace StreamJsonRpc
         public bool NotifyClientOfEvents { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether non-public methods/events on target objects can be invoked
+        /// by remote clients.
+        /// </summary>
+        /// <value>The default value is <c>true</c> (for backward compatibility with previous 1.x versions).</value>
+        public bool AllowNonPublicInvocation { get; set; } = true;
+
+        /// <summary>
         /// Gets an instance with default properties.
         /// </summary>
         /// <remarks>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ StreamJsonRpc.JsonRpcProxyOptions.EventNameTransform.set -> void
 StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.get -> System.Func<string, string>
 StreamJsonRpc.JsonRpcProxyOptions.MethodNameTransform.set -> void
 StreamJsonRpc.JsonRpcTargetOptions
+StreamJsonRpc.JsonRpcTargetOptions.AllowNonPublicInvocation.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.AllowNonPublicInvocation.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions() -> void
 StreamJsonRpc.JsonRpcTargetOptions.EventNameTransform.get -> System.Func<string, string>
 StreamJsonRpc.JsonRpcTargetOptions.EventNameTransform.set -> void


### PR DESCRIPTION
Despite our intent and documentation that non-public methods should not be invokable using StreamJsonRpc, they are in fact invokable. Our unit test had a bug in it that was hiding this undesirable behavior.

Since fixing this to block non-public method invocation would be a breaking change at this point, rather than fix it immediately to block it, I add an option to block it so folks can opt into blocking non-public method calls. 
In a subsequent PR targeting our 2.0 release, I will change the default behavior to block non-public methods, forcing folks to opt *in* to allowing non-public method invocation, since that is what we told people we were doing already and from a security standpoint seems like the safer route.

Fixes #207 