### PR TITLE
Add support for JSON-RPC 1.0

### DIFF
--- a/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
@@ -53,10 +53,10 @@ public class HeaderDelimitedMessageHandlerTests : TestBase
     public async Task ReadCoreAsync_HandlesSpacingCorrectly()
     {
         string content =
-"Content-Length:  17   " + CRLF +
+"Content-Length:  33   " + CRLF +
 "Content-Type: application/vscode-jsonrpc;charset=utf-8" + CRLF +
 CRLF +
-"{\"method\":\"test\"}";
+"{\"jsonrpc\":\"2.0\",\"method\":\"test\"}";
         byte[] bytes = Encoding.UTF8.GetBytes(content);
         this.receivingStream.Write(bytes, 0, bytes.Length);
         this.receivingStream.Flush();
@@ -69,9 +69,9 @@ CRLF +
         this.receivingStream.SetLength(0);
 
         content =
-"Content-Length:17" + CRLF +
+"Content-Length:33" + CRLF +
 CRLF +
-"{\"method\":\"test\"}";
+"{\"jsonrpc\":\"2.0\",\"method\":\"test\"}";
         bytes = Encoding.UTF8.GetBytes(content);
         this.receivingStream.Write(bytes, 0, bytes.Length);
         this.receivingStream.Flush();
@@ -86,10 +86,10 @@ CRLF +
     {
         // Using 'utf8'
         string content =
-"Content-Length: 17" + CRLF +
+"Content-Length: 33" + CRLF +
 "Content-Type: application/vscode-jsonrpc;charset=utf8" + CRLF +
 CRLF +
-"{\"method\":\"test\"}";
+"{\"jsonrpc\":\"2.0\",\"method\":\"test\"}";
         byte[] bytes = Encoding.UTF8.GetBytes(content);
         this.receivingStream.Write(bytes, 0, bytes.Length);
         this.receivingStream.Flush();
@@ -103,10 +103,10 @@ CRLF +
 
         // Using 'utf-8'
         content =
-"Content-Length: 17" + CRLF +
+"Content-Length: 33" + CRLF +
 "Content-Type: application/vscode-jsonrpc;charset=utf-8" + CRLF +
 CRLF +
-"{\"method\":\"test\"}";
+"{\"jsonrpc\":\"2.0\",\"method\":\"test\"}";
         bytes = Encoding.UTF8.GetBytes(content);
         this.receivingStream.Write(bytes, 0, bytes.Length);
         this.receivingStream.Flush();

--- a/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -25,6 +25,37 @@ public class JsonMessageFormatterTests : TestBase
     }
 
     [Fact]
+    public void ProtocolVersion_Default()
+    {
+        var formatter = new JsonMessageFormatter();
+        Assert.Equal(new Version(2, 0), formatter.ProtocolVersion);
+    }
+
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(2, 0)]
+    public void ProtocolVersion_AcceptedVersions(int major, int minor)
+    {
+        Version expectedVersion = new Version(major, minor);
+        var formatter = new JsonMessageFormatter
+        {
+            ProtocolVersion = expectedVersion,
+        };
+        Assert.Equal(expectedVersion, formatter.ProtocolVersion);
+    }
+
+    [Fact]
+    public void ProtocolVersion_RejectsOtherVersions()
+    {
+        var formatter = new JsonMessageFormatter();
+        Assert.Throws<ArgumentNullException>(() => formatter.ProtocolVersion = null);
+        Assert.Throws<NotSupportedException>(() => formatter.ProtocolVersion = new Version(0, 0));
+        Assert.Throws<NotSupportedException>(() => formatter.ProtocolVersion = new Version(1, 1));
+        Assert.Throws<NotSupportedException>(() => formatter.ProtocolVersion = new Version(2, 1));
+        Assert.Throws<NotSupportedException>(() => formatter.ProtocolVersion = new Version(3, 0));
+    }
+
+    [Fact]
     public void EncodingProperty_UsedToFormat()
     {
         JsonRpcRequest msg = new JsonRpcRequest { Method = "a" };

--- a/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+/// <summary>
+/// Verifies the <see cref="JsonRpc"/> class's functionality as a JSON-RPC 1.0 *client* (i.e. the one sending requests, and receiving results)
+/// against various server messages.
+/// </summary>
+public class JsonRpcClient10InteropTests : InteropTestBase
+{
+    private readonly JsonRpc clientRpc;
+
+    public JsonRpcClient10InteropTests(ITestOutputHelper logger)
+        : base(logger, serverTest: false)
+    {
+        this.messageHandler.Formatter.ProtocolVersion = new Version(1, 0);
+        this.clientRpc = new JsonRpc(this.messageHandler);
+        this.clientRpc.StartListening();
+    }
+
+    [Fact]
+    public async Task ClientRecognizesResultWithNullError()
+    {
+        var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>("test", new object[] { "arg1" }, this.TimeoutToken);
+
+        // Receive the request at the server side and sanity check its contents.
+        JToken request = await this.ReceiveAsync();
+        Assert.Equal("test", request.Value<string>("method"));
+        Assert.Equal(1, ((JArray)request["params"]).Count);
+        Assert.Equal("arg1", request["params"][0].Value<string>());
+        Assert.NotNull(request["id"]);
+
+        const string expectedResult = "some result";
+        this.Send(new
+        {
+            id = request["id"],
+            result = expectedResult,
+            error = (object)null, // JSON-RPC 1.0 requires that the error property be specified as null in successful responses.
+        });
+        string actualResult = await invokeTask;
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+    public async Task ClientRecognizesErrorWithNullResult()
+    {
+        var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>("test");
+        dynamic request = await this.ReceiveAsync();
+        const string expectedErrorMessage = "some result";
+        this.Send(new
+        {
+            id = request.id,
+            result = (object)null, // JSON-RPC 1.0 requires that result be specified and null if there is an error.
+            error = new { message = expectedErrorMessage },
+        });
+        var error = await Assert.ThrowsAsync<RemoteInvocationException>(() => invokeTask);
+        Assert.Equal(expectedErrorMessage, error.Message);
+    }
+
+    /// <summary>
+    /// Verifies that since JSON-RPC 1.0 doesn't support parameter objects (only parameter arrays are allowed),
+    /// no request is sent from the client that violates that.
+    /// </summary>
+    [Fact]
+    public async Task ClientThrowsOnAttemptToSendParamsObject()
+    {
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 }, this.TimeoutToken)).WithCancellation(this.TimeoutToken);
+        this.Logger.WriteLine(ex.ToString());
+        await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 })).WithCancellation(this.TimeoutToken);
+
+        Assert.Equal(0, this.messageHandler.WrittenMessages.Count);
+    }
+
+    [Fact]
+    public async Task NotificationsAreSentWithNullId()
+    {
+        await this.clientRpc.NotifyAsync("method");
+        JToken request = await this.ReceiveAsync();
+        Assert.Equal(JTokenType.Null, request["id"]?.Type);
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -11,11 +11,15 @@ using StreamJsonRpc.Protocol;
 using Xunit;
 using Xunit.Abstractions;
 
-public class JsonRpcClientInteropTests : InteropTestBase
+/// <summary>
+/// Verifies the <see cref="JsonRpc"/> class's functionality as a JSON-RPC 2.0 *client* (i.e. the one sending requests, and receiving results)
+/// against various server messages.
+/// </summary>
+public class JsonRpcClient20InteropTests : InteropTestBase
 {
     private readonly JsonRpc clientRpc;
 
-    public JsonRpcClientInteropTests(ITestOutputHelper logger)
+    public JsonRpcClient20InteropTests(ITestOutputHelper logger)
         : base(logger, serverTest: false)
     {
         this.clientRpc = new JsonRpc(this.messageHandler);

--- a/src/StreamJsonRpc.Tests/MessageHeaderTests.cs
+++ b/src/StreamJsonRpc.Tests/MessageHeaderTests.cs
@@ -86,7 +86,7 @@ public class MessageHeaderTests : TestBase
         var rpcServer = JsonRpc.Attach(this.serverStream, server);
 
         Encoding contentEncoding = Encoding.GetEncoding(encodingName);
-        string jsonMessage = @"{""method"":""Foo"",""id"":1}";
+        string jsonMessage = @"{""jsonrpc"":""2.0"",""method"":""Foo"",""id"":1}";
         byte[] message = contentEncoding.GetBytes(jsonMessage);
 
         // Write the header, which is always in ASCII.

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.cs.xlf
@@ -208,6 +208,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.de.xlf
@@ -208,6 +208,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.es.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.fr.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.it.xlf
@@ -208,6 +208,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ja.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ko.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pl.xlf
@@ -208,6 +208,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.pt-BR.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.ru.xlf
@@ -208,6 +208,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.tr.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hans.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
+++ b/src/StreamJsonRpc/MultilingualResources/StreamJsonRpc.zh-Hant.xlf
@@ -209,6 +209,15 @@
           <source>A CancellationToken is only allowed as the last parameter.</source>
           <target state="new">A CancellationToken is only allowed as the last parameter.</target>
         </trans-unit>
+        <trans-unit id="UnsupportedJsonRpcProtocolVersion" translate="yes" xml:space="preserve">
+          <source>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</source>
+          <target state="new">Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</note>
+        </trans-unit>
+        <trans-unit id="ParameterObjectsNotSupportedInJsonRpc10" translate="yes" xml:space="preserve">
+          <source>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</source>
+          <target state="new">JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -37,6 +37,8 @@ StreamJsonRpc.JsonMessageFormatter.Deserialize(System.Buffers.ReadOnlySequence<b
 StreamJsonRpc.JsonMessageFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer, System.Text.Encoding encoding) -> StreamJsonRpc.Protocol.JsonRpcMessage
 StreamJsonRpc.JsonMessageFormatter.Encoding.get -> System.Text.Encoding
 StreamJsonRpc.JsonMessageFormatter.Encoding.set -> void
+StreamJsonRpc.JsonMessageFormatter.ProtocolVersion.get -> System.Version
+StreamJsonRpc.JsonMessageFormatter.ProtocolVersion.set -> void
 StreamJsonRpc.JsonMessageFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
 StreamJsonRpc.JsonMessageFormatter.JsonMessageFormatter() -> void
 StreamJsonRpc.JsonMessageFormatter.JsonMessageFormatter(System.Text.Encoding encoding) -> void

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -20,7 +20,7 @@ namespace StreamJsonRpc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -278,6 +278,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0..
+        /// </summary>
+        internal static string ParameterObjectsNotSupportedInJsonRpc10 {
+            get {
+                return ResourceManager.GetString("ParameterObjectsNotSupportedInJsonRpc10", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A positive integer is required..
         /// </summary>
         internal static string PositiveIntegerRequired {
@@ -454,6 +463,15 @@ namespace StreamJsonRpc {
         internal static string UnsupportedGenericMethodsOnClientProxyInterface {
             get {
                 return ResourceManager.GetString("UnsupportedGenericMethodsOnClientProxyInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}.
+        /// </summary>
+        internal static string UnsupportedJsonRpcProtocolVersion {
+            get {
+                return ResourceManager.GetString("UnsupportedJsonRpcProtocolVersion", resourceCulture);
             }
         }
         

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -274,4 +274,11 @@
   <data name="RequiredArgumentMissing" xml:space="preserve">
     <value>An argument was not supplied for a required parameter.</value>
   </data>
+  <data name="UnsupportedJsonRpcProtocolVersion" xml:space="preserve">
+    <value>Unsupported JSON-RPC protocol version {0}. The supported protocol versions are: {1}</value>
+    <comment>{0} is a version formatted as 1.2.3.4. {1} is a list of such versions, comma separated.</comment>
+  </data>
+  <data name="ParameterObjectsNotSupportedInJsonRpc10" xml:space="preserve">
+    <value>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</value>
+  </data>
 </root>


### PR DESCRIPTION
As part of this, I add a few validations when receiving JSON-RPC messages to verify they conform to the spec'd schema, at least in some ways. This extra validation helps to make sure folks are using the right protocol version setting in the `JsonMessageFormatter`. When turning this on, it caught a few tests that were not supplying the 2.0 protocol spec required `jsonrpc` property, so I fix those up too.

Fixes #220