### PR TITLE
Apply JsonSerializer settings to JToken parser

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -278,7 +278,16 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(encoding, nameof(encoding));
 
-            var jsonReader = new JsonTextReader(new StreamReader(contentBuffer.AsStream(), encoding));
+            var jsonReader = new JsonTextReader(new StreamReader(contentBuffer.AsStream(), encoding))
+            {
+                CloseInput = true,
+                Culture = this.JsonSerializer.Culture,
+                DateFormatString = this.JsonSerializer.DateFormatString,
+                DateParseHandling = this.JsonSerializer.DateParseHandling,
+                DateTimeZoneHandling = this.JsonSerializer.DateTimeZoneHandling,
+                FloatParseHandling = this.JsonSerializer.FloatParseHandling,
+                MaxDepth = this.JsonSerializer.MaxDepth,
+            };
             JToken json = JToken.ReadFrom(jsonReader);
             return json;
         }


### PR DESCRIPTION
StreamJsonRpc uses a two-step deserialization whereby we first read JTokens, then we later deserialize those JTokens with the user-provided `JsonSerializer`. It turns out that simply parsing the text into JTokens is a stage where some of the settings on the user-supplied `JsonSerializer` would have applied had it all been done in one step.

As this parsing step doesn't take a settings or a `JsonSerializer` object, the only thing we can do is manually copy the relevant settings from the user-supplied `JsonSerializer` object onto their matching properties on the `JsonTextReader`. 

Fixes #227 