### PR TITLE
Fix handling of nullable value types as RPC method parameters and return types

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -393,6 +393,26 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task NullableParameters()
+    {
+        int? result = await this.clientRpc.InvokeAsync<int?>(nameof(Server.MethodAcceptsNullableArgs), null, 3);
+        Assert.Equal(1, result);
+        result = await this.clientRpc.InvokeAsync<int?>(nameof(Server.MethodAcceptsNullableArgs), 3, null);
+        Assert.Equal(1, result);
+        result = await this.clientRpc.InvokeAsync<int?>(nameof(Server.MethodAcceptsNullableArgs), 3, 5);
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task NullableReturnType()
+    {
+        int? result = await this.clientRpc.InvokeAsync<int?>(nameof(Server.MethodReturnsNullableInt), 0);
+        Assert.Null(result);
+        result = await this.clientRpc.InvokeAsync<int?>(nameof(Server.MethodReturnsNullableInt), 5);
+        Assert.Equal(5, result);
+    }
+
+    [Fact]
     public async Task CanCallMethodWithoutOmittingAsyncSuffix()
     {
         int result = await this.clientRpc.InvokeAsync<int>("MethodThatEndsInAsync");
@@ -1338,6 +1358,10 @@ public abstract class JsonRpcTests : TestBase
         {
             return x + y;
         }
+
+        public int? MethodReturnsNullableInt(int a) => a > 0 ? (int?)a : null;
+
+        public int MethodAcceptsNullableArgs(int? a, int? b) => (a.HasValue ? 1 : 0) + (b.HasValue ? 1 : 0);
 
         public string ServerMethodInstance(string argument) => argument + "!";
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -462,7 +462,7 @@ namespace StreamJsonRpc
                 var result = (JToken)this.Result;
                 if (result.Type == JTokenType.Null)
                 {
-                    Verify.Operation(!typeof(T).GetTypeInfo().IsValueType, "null result is not assignable to a value type.");
+                    Verify.Operation(!typeof(T).GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(typeof(T)) != null, "null result is not assignable to a value type.");
                     return default;
                 }
 

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -144,7 +144,7 @@ namespace StreamJsonRpc.Protocol
                 {
                     if (argument == null)
                     {
-                        if (parameter.ParameterType.GetTypeInfo().IsValueType)
+                        if (parameter.ParameterType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(parameter.ParameterType) == null)
                         {
                             // We cannot pass a null value to a value type parameter.
                             return ArgumentMatchResult.ParameterArgumentTypeMismatch;


### PR DESCRIPTION
Both return types and value types were failing when we check that a value is assignable to the required CLR type because we weren't expressly checking that a value type is a nullable one, and we assumed all value types cannot be `null`.

Fixes #237