### PR TITLE
Add more static JsonRpc.Attach<T> overloads

### DIFF
--- a/src/StreamJsonRpc/IJsonRpcMessageFormatter.cs
+++ b/src/StreamJsonRpc/IJsonRpcMessageFormatter.cs
@@ -21,9 +21,9 @@ namespace StreamJsonRpc
         /// <summary>
         /// Serializes a <see cref="JsonRpcMessage"/>.
         /// </summary>
-        /// <param name="contentBuffer">The receiver of the serialized bytes.</param>
+        /// <param name="bufferWriter">The receiver of the serialized bytes.</param>
         /// <param name="message">The message to serialize.</param>
-        void Serialize(IBufferWriter<byte> contentBuffer, JsonRpcMessage message);
+        void Serialize(IBufferWriter<byte> bufferWriter, JsonRpcMessage message);
 
         /// <summary>
         /// Gets a JSON representation for a given message for tracing purposes.

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -507,6 +507,43 @@ namespace StreamJsonRpc
         /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
         /// </summary>
         /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
+        /// <param name="handler">The message handler to use.</param>
+        /// <returns>
+        /// An instance of the generated proxy.
+        /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+        /// and should be disposed of to close the connection.
+        /// </returns>
+        public static T Attach<T>(IJsonRpcMessageHandler handler)
+            where T : class
+        {
+            return Attach<T>(handler, options: null);
+        }
+
+        /// <summary>
+        /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
+        /// </summary>
+        /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
+        /// <param name="handler">The message handler to use.</param>
+        /// <param name="options">A set of customizations for how the client proxy is wired up. If <c>null</c>, default options will be used.</param>
+        /// <returns>
+        /// An instance of the generated proxy.
+        /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+        /// and should be disposed of to close the connection.
+        /// </returns>
+        public static T Attach<T>(IJsonRpcMessageHandler handler, JsonRpcProxyOptions options)
+            where T : class
+        {
+            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: true);
+            var rpc = new JsonRpc(handler);
+            T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc, options ?? JsonRpcProxyOptions.Default);
+            rpc.StartListening();
+            return proxy;
+        }
+
+        /// <summary>
+        /// Creates a JSON-RPC client proxy that conforms to the specified server interface.
+        /// </summary>
+        /// <typeparam name="T">The interface that describes the functions available on the remote end.</typeparam>
         /// <returns>An instance of the generated proxy.</returns>
         public T Attach<T>()
             where T : class

--- a/src/StreamJsonRpc/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Shipped.txt
@@ -104,7 +104,7 @@ StreamJsonRpc.HeaderDelimitedMessageHandler.HeaderDelimitedMessageHandler(System
 StreamJsonRpc.IJsonRpcMessageFormatter
 StreamJsonRpc.IJsonRpcMessageFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
 StreamJsonRpc.IJsonRpcMessageFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
-StreamJsonRpc.IJsonRpcMessageFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
+StreamJsonRpc.IJsonRpcMessageFormatter.Serialize(System.Buffers.IBufferWriter<byte> bufferWriter, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.IJsonRpcMessageHandler
 StreamJsonRpc.IJsonRpcMessageHandler.CanRead.get -> bool
 StreamJsonRpc.IJsonRpcMessageHandler.CanWrite.get -> bool

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
+static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T


### PR DESCRIPTION
These new overloads make it possible to create a dynamic client proxy that doesn't use the default HTTP+UTF8 handler/formatter.