### PR TITLE
Do not return internal (empty) result from "async Task" methods

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -167,6 +167,13 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task NonGenericTaskServerMethod_ReturnsNullToClient()
+    {
+        object result = await this.clientRpc.InvokeAsync<object>(nameof(Server.ServerMethodThatReturnsTask));
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task CanInvokeMethodThatReturnsCustomTask()
     {
         int result = await this.clientRpc.InvokeAsync<int>(nameof(Server.ServerMethodThatReturnsCustomTask));

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -198,8 +198,8 @@ public abstract class JsonRpcTests : TestBase
     [Fact]
     public async Task CanInvokeMethodThatReturnsTaskOfInternalClass()
     {
-        // JSON RPC cannot invoke non-public members. A public member cannot have Task<NonPublicType> result.
-        // Though it can have result of just Task type, and return a Task<NonPublicType>, and dev hub supports that.
+        // JsonRpc does not invoke non-public members in the default configuration. A public member cannot have Task<NonPublicType> result.
+        // Though it can have result of just Task<object> type, which carries a NonPublicType instance.
         InternalClass result = await this.clientRpc.InvokeAsync<InternalClass>(nameof(Server.MethodThatReturnsTaskOfInternalClass));
         Assert.NotNull(result);
     }
@@ -1376,7 +1376,7 @@ public abstract class JsonRpcTests : TestBase
 
         public new string RedeclaredBaseMethod() => "child";
 
-        public Task ServerMethodThatReturnsCustomTask()
+        public Task<int> ServerMethodThatReturnsCustomTask()
         {
             var result = new CustomTask<int>(CustomTaskResult);
             result.Start();
@@ -1540,9 +1540,9 @@ public abstract class JsonRpcTests : TestBase
             throw new Exception();
         }
 
-        public Task MethodThatReturnsTaskOfInternalClass()
+        public Task<object> MethodThatReturnsTaskOfInternalClass()
         {
-            var result = new Task<InternalClass>(() => new InternalClass());
+            var result = new Task<object>(() => new InternalClass());
             result.Start();
             return result;
         }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -77,6 +77,8 @@ namespace StreamJsonRpc
             }
         }
 
+        internal Type ReturnType => this.signature?.MethodInfo.ReturnType;
+
         /// <inheritdoc/>
         public override string ToString()
         {


### PR DESCRIPTION
The C# compiler (or async method builder) emits code from an `async Task`-returning method that actually returns a `Task<VoidTaskResult>` instance. StreamJsonRpc was testing the returned value itself to see if it was a result-bearing `Task`, which this is, and was serializing the `VoidTaskResult` (an internal, empty struct) to the client. The client then saw a `{}` return value instead of `null`, as they would have seen from a plain `void` returning server method.

Besides the slight inaccuracy in the wire representation of the result, this caused an issue when using a serializer that doesn't know how to serialize the internal `VoidTaskResult` struct.

To fix this in a resilient way, I've opted for a slight behavioral breaking change in that if the server method is typed to return `Task` (and not a `Task<T>` or derived type), StreamJsonRpc will simply ignore any `Task<T>.Result` that might be present at runtime in the returned object. This is consistent with C# behavior if such a method were awaited on. You can see in a couple of small changes to existing tests that this behavioral breaking change had to be accomodated to keep tests passing.

Fixes #259 