### PR TITLE
Throw OCE from canceled requests even when remote disconnects before sending cancellation acknowledgment

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -575,6 +575,21 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task Invoke_ThrowsConnectionLostExceptionOverDisposedException()
+    {
+        using (var cts = new CancellationTokenSource())
+        {
+            var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, cts.Token);
+            await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
+            this.clientRpc.Dispose();
+            this.server.AllowServerMethodToReturn.Set();
+
+            // Connection was closed before error was sent from the server
+            await Assert.ThrowsAnyAsync<ConnectionLostException>(() => invokeTask);
+        }
+    }
+
+    [Fact]
     public async Task InvokeAsync_CanCallCancellableMethodWithNoArgs()
     {
         Assert.Equal(5, await this.clientRpc.InvokeAsync<int>(nameof(Server.AsyncMethodWithCancellationAndNoArgs)));

--- a/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcWithFatalExceptionsTests.cs
@@ -174,50 +174,6 @@ public class JsonRpcWithFatalExceptionsTests : TestBase
     }
 
     [Fact]
-    public async Task DisposedClientResultsInCancelled()
-    {
-        using (var cts = new CancellationTokenSource())
-        {
-            var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodFaultsAfterCancellation), new[] { "a" }, cts.Token);
-            await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
-            this.clientRpc.Dispose();
-            this.server.AllowServerMethodToReturn.Set();
-
-            // Connection was closed before error was sent from the server
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
-            Assert.Equal(0, this.serverRpc.IsFatalExceptionCount);
-        }
-
-        Assert.True(((IDisposableObservable)this.clientMessageHandler).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverMessageHandler).IsDisposed);
-        Assert.True(this.clientRpc.IsDisposed);
-        Assert.False(this.serverRpc.IsDisposed);
-    }
-
-    [Fact]
-    public async Task UnexpectedDisconnectResultsInConnectionLostException()
-    {
-        using (var cts = new CancellationTokenSource())
-        {
-            var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodFaultsAfterCancellation), new[] { "a" }, cts.Token);
-            await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
-
-            // Simulate an unexpected lost connection
-            ((IDisposable)this.serverMessageHandler).Dispose();
-            this.server.AllowServerMethodToReturn.Set();
-
-            // Connection was closed before error was sent from the server
-            await Assert.ThrowsAnyAsync<ConnectionLostException>(() => invokeTask);
-            Assert.Equal(0, this.serverRpc.IsFatalExceptionCount);
-        }
-
-        Assert.True(((IDisposableObservable)this.clientMessageHandler).IsDisposed);
-        Assert.True(((IDisposableObservable)this.serverMessageHandler).IsDisposed);
-        Assert.False(this.clientRpc.IsDisposed);
-        Assert.False(this.serverRpc.IsDisposed);
-    }
-
-    [Fact]
     public async Task AggregateExceptionIsNotRemovedFromAsyncMethod()
     {
         var remoteException = await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.InvokeAsync(nameof(Server.AsyncMethodThrowsAggregateExceptionWithTwoInner)));

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1079,7 +1079,7 @@ namespace StreamJsonRpc
                                 if (cancellationToken.IsCancellationRequested || this.IsDisposed)
                                 {
                                     // Consider lost connection to be result of task canceled or disposed and set state to canceled
-                                    tcs.TrySetCanceled();
+                                    tcs.TrySetCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : CancellationToken.None);
                                 }
                                 else
                                 {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1076,10 +1076,10 @@ namespace StreamJsonRpc
                                     this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.RequestAbandonedByRemote, "Aborting pending request \"{0}\" because the connection was lost.", id);
                                 }
 
-                                if (cancellationToken.IsCancellationRequested || this.IsDisposed)
+                                if (cancellationToken.IsCancellationRequested)
                                 {
-                                    // Consider lost connection to be result of task canceled or disposed and set state to canceled
-                                    tcs.TrySetCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : CancellationToken.None);
+                                    // Consider lost connection to be result of task canceled and set state to canceled.
+                                    tcs.TrySetCanceled(cancellationToken);
                                 }
                                 else
                                 {
@@ -1137,7 +1137,7 @@ namespace StreamJsonRpc
                     }
                 }
             }
-            catch (OperationCanceledException ex) when (this.DisconnectedToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested && !this.IsDisposed)
+            catch (OperationCanceledException ex) when (this.DisconnectedToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new ConnectionLostException(Resources.ConnectionDropped, ex);
             }


### PR DESCRIPTION
After canceling a request, frequently the client gets disposed. In 1.5 this would result in an expected cancelation state. In 2.0 this started throwing a ConnectionLostException if the dispose happened subsequently. Since the lost connection was a result of canceled request and not the cause of it, this adjusts the state of the task to match the expected state.

Tests were added to verify dispose does the expected behavior, as well as a lost connection still results in the ConnectionLostException.

* [x] Ask mode approval obtained from @Michael-Eng

Fixes: #265

@AArnott @tinaschrepfer 