### PR TITLE
Add test that passes in a List<object> for arguments instead of object[]

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -563,6 +564,14 @@ public class JsonRpcTests : TestBase
                 // this is also an acceptable result.
             }
         }
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PassArgsAsNonArrayList()
+    {
+        var args = new List<object> { 1, 2 };
+        int result = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithDefaultParameter), args, this.TimeoutToken);
+        Assert.Equal(3, result);
     }
 
     [Fact]


### PR DESCRIPTION
Shows that #272 does not repro for v1.5