### PR TITLE
Allow non-array lists of arguments

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -81,7 +81,7 @@ public abstract class JsonRpcTests : TestBase
             new JsonRpcRequest
             {
                 Method = nameof(Server.NotificationMethod),
-                ArgumentsArray = new[] { "hello" },
+                ArgumentsList = new[] { "hello" },
             },
             this.TimeoutToken);
 
@@ -99,7 +99,7 @@ public abstract class JsonRpcTests : TestBase
             {
                 Id = 1,
                 Method = nameof(Server.MethodThatAccceptsAndReturnsNull),
-                ArgumentsArray = new object[] { null },
+                ArgumentsList = new object[] { null },
             },
             this.TimeoutToken);
 

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -57,7 +57,7 @@ namespace StreamJsonRpc
         /// <inheritdoc/>
         public void Serialize(IBufferWriter<byte> contentBuffer, JsonRpcMessage message)
         {
-            if (message is JsonRpcRequest request && request.Arguments != null && request.ArgumentsArray == null && !(request.Arguments is IReadOnlyDictionary<string, object>))
+            if (message is JsonRpcRequest request && request.Arguments != null && request.ArgumentsList == null && !(request.Arguments is IReadOnlyDictionary<string, object>))
             {
                 // This request contains named arguments, but not using a standard dictionary. Convert it to a dictionary so that
                 // the parameters can be matched to the method we're invoking.

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -28,15 +28,15 @@ public class MessagePackFormatterTests : TestBase
         {
             Id = 5,
             Method = "test",
-            ArgumentsArray = new object[] { 5, "hi", new CustomType { Age = 8 } },
+            ArgumentsList = new object[] { 5, "hi", new CustomType { Age = 8 } },
         };
 
         var actual = this.Roundtrip(original);
         Assert.Equal(original.Id, actual.Id);
         Assert.Equal(original.Method, actual.Method);
-        Assert.Equal(original.ArgumentsArray[0], actual.ArgumentsArray[0]);
-        Assert.Equal(original.ArgumentsArray[1], actual.ArgumentsArray[1]);
-        Assert.Equal(((CustomType)original.ArgumentsArray[2]).Age, ((CustomType)actual.ArgumentsArray[2]).Age);
+        Assert.Equal(original.ArgumentsList[0], actual.ArgumentsList[0]);
+        Assert.Equal(original.ArgumentsList[1], actual.ArgumentsList[1]);
+        Assert.Equal(((CustomType)original.ArgumentsList[2]).Age, ((CustomType)actual.ArgumentsList[2]).Age);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
+++ b/src/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using StreamJsonRpc.Protocol;
+using Xunit;
+
+public class JsonRpcRequestTests
+{
+    private static readonly IReadOnlyList<object> ArgumentsAsList = new List<object> { 4, 6, 8 };
+    private static readonly IReadOnlyList<object> ArgumentsAsArray = new object[] { 4, 6, 8 };
+    private static readonly object ArgumentsAsObject = new Dictionary<string, object> { { "Foo", 4 }, { "bar", 6 } };
+
+    [Fact]
+    public void ArgumentsCount_WithNamedArguments()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsObject,
+        };
+        Assert.Equal(2, request.ArgumentCount);
+    }
+
+    [Fact]
+    public void ArgumentsCount_WithList()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsList,
+        };
+        Assert.Equal(3, request.ArgumentCount);
+    }
+
+    [Fact]
+    public void ArgumentsCount_WithArray()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsArray,
+        };
+        Assert.Equal(3, request.ArgumentCount);
+    }
+
+    [Fact]
+    public void ArgumentsList()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsList,
+        };
+        Assert.Same(request.Arguments, request.ArgumentsList);
+        Assert.Same(ArgumentsAsList, request.ArgumentsList);
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Fact]
+    public void ArgumentsArray_WithArray()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsArray,
+        };
+        Assert.Same(request.Arguments, request.ArgumentsArray);
+        Assert.Same(ArgumentsAsArray, request.ArgumentsArray);
+    }
+
+    [Fact]
+    public void ArgumentsArray_WithList()
+    {
+        var request = new JsonRpcRequest
+        {
+            Arguments = ArgumentsAsList,
+        };
+        Assert.Null(request.ArgumentsArray);
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+}

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -298,9 +298,9 @@ namespace StreamJsonRpc
         {
             if (jsonRpcMessage is Protocol.JsonRpcRequest request)
             {
-                if (request.ArgumentsArray != null)
+                if (request.ArgumentsList != null)
                 {
-                    request.ArgumentsArray = request.ArgumentsArray.Select(this.TokenizeUserData).ToArray();
+                    request.ArgumentsList = request.ArgumentsList.Select(this.TokenizeUserData).ToArray();
                 }
                 else if (request.Arguments != null)
                 {

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -86,7 +86,7 @@ namespace StreamJsonRpc.Protocol
         /// Gets the number of arguments supplied in the request.
         /// </summary>
         [IgnoreDataMember]
-        public int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsArray?.Length ?? 0;
+        public int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsList?.Count ?? 0;
 
         /// <summary>
         /// Gets or sets the dictionary of named arguments, if applicable.
@@ -102,9 +102,20 @@ namespace StreamJsonRpc.Protocol
         /// Gets or sets an array of arguments, if applicable.
         /// </summary>
         [IgnoreDataMember]
+        [Obsolete("Use " + nameof(ArgumentsList) + " instead.")]
         public object[] ArgumentsArray
         {
             get => this.Arguments as object[];
+            set => this.Arguments = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a read only list of arguments, if applicable.
+        /// </summary>
+        [IgnoreDataMember]
+        public IReadOnlyList<object> ArgumentsList
+        {
+            get => this.Arguments as IReadOnlyList<object>;
             set => this.Arguments = value;
         }
 
@@ -189,9 +200,9 @@ namespace StreamJsonRpc.Protocol
             {
                 return this.NamedArguments.TryGetValue(name, out value);
             }
-            else if (this.ArgumentsArray != null && position < this.ArgumentsArray.Length && position >= 0)
+            else if (this.ArgumentsList != null && position < this.ArgumentsList.Count && position >= 0)
             {
-                value = this.ArgumentsArray[position];
+                value = this.ArgumentsList[position];
                 return true;
             }
 

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentsList.get -> System.Collections.Generic.IReadOnlyList<object>
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentsList.set -> void


### PR DESCRIPTION
This corrects a regression in the 2.0 release where non-arrays could be passed in via the `IReadOnlyList<object>` parameter on `InvokeWithCancellationAsync`. We hadn't been testing with any non-array lists, and our API is actually inconsistent in support of these. So this fixes the regression by consistently using a new API to support it. But all existing JsonRpc consumers do not need to change. The new API is merely to support the formatters, which is an uncommon extensibility point.

Fixes #272