### PR TITLE
JsonMessageFormatter GC pressure fixes

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -48,6 +48,16 @@ namespace StreamJsonRpc
         private static readonly IArrayPool<char> JsonCharArrayPool = new JsonArrayPool<char>(ArrayPool<char>.Shared);
 
         /// <summary>
+        /// An exactly default instance of the <see cref="JsonSerializer"/> to use where no special settings
+        /// are needed.
+        /// </summary>
+        /// <remarks>
+        /// This is useful when calling such APIs as <see cref="JToken.FromObject(object, JsonSerializer)"/>
+        /// because <see cref="JToken.FromObject(object)"/> allocates a new serializer with each invocation.
+        /// </remarks>
+        private static readonly JsonSerializer DefaultSerializer = JsonSerializer.CreateDefault();
+
+        /// <summary>
         /// The reusable <see cref="TextWriter"/> to use with newtonsoft.json's serializer.
         /// </summary>
         private readonly BufferTextWriter bufferTextWriter = new BufferTextWriter();
@@ -205,7 +215,7 @@ namespace StreamJsonRpc
             // Pre-tokenize the user data so we can use their custom converters for just their data and not for the base message.
             this.TokenizeUserData(message);
 
-            var json = JToken.FromObject(message);
+            var json = JToken.FromObject(message, DefaultSerializer);
 
             // Fix up dropped fields that are mandatory
             if (message is Protocol.JsonRpcResult && json["result"] == null)

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -48,6 +48,11 @@ namespace StreamJsonRpc
         private readonly BufferTextWriter bufferTextWriter = new BufferTextWriter();
 
         /// <summary>
+        /// The reusable <see cref="TextReader"/> to use with newtonsoft.json's deserializer.
+        /// </summary>
+        private readonly SequenceTextReader sequenceTextReader = new SequenceTextReader();
+
+        /// <summary>
         /// The version of the JSON-RPC protocol being emulated by this instance.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -280,7 +285,8 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(encoding, nameof(encoding));
 
-            var jsonReader = new JsonTextReader(new StreamReader(contentBuffer.AsStream(), encoding))
+            this.sequenceTextReader.Initialize(contentBuffer, encoding);
+            var jsonReader = new JsonTextReader(this.sequenceTextReader)
             {
                 CloseInput = true,
                 Culture = this.JsonSerializer.Culture,

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1343,7 +1343,7 @@ namespace StreamJsonRpc
             };
         }
 
-        private async Task<JsonRpcMessage> DispatchIncomingRequestAsync(JsonRpcRequest request)
+        private async ValueTask<JsonRpcMessage> DispatchIncomingRequestAsync(JsonRpcRequest request)
         {
             Requires.NotNull(request, nameof(request));
 

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.2.5-alpha" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.26" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.1.37" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.5-alpha" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />


### PR DESCRIPTION
This dramatically reduces GC pressure from `JsonMessageFormatter`.

1. Use shared array pool and recycle `Sequence<byte>` instance
1. Avoid allocating `Task<JsonRpcMessage>` for non-yielding server methods
1. Replace StreamWriter with BufferTextWriter
For each outgoing message, `JsonMessageFormatter` was creating a new `StreamWriter`, which allocated two large buffers. Since the `IBufferWriter<byte>` instance may vary across calls, we can't simply reuse a `StreamWriter` to avoid the allocations.
Instead we use a `TextWriter`-derived class which IS reusable across different target `IBufferWriter<byte>` instances. We allocate only one (char[]) buffer and encode directly to the memory returned from `IBufferWriter<byte>.GetMemory` so it's faster as well as much more GC friendly than the `StreamWriter`.
1. Use `SequenceTextReader` to reduce GC pressure  
In `JsonMessageFormatter`, creating a new `StreamReader` for every `ReadOnlySequence<byte>` is a very expensive process, as each new `StreamReader` allocates large `byte[]` and `char[]` arrays to use as buffers. The new `SequenceTextReader` only allocates one `char[]` array and that array is reused for every `ReadOnlySequence<byte>` to be read.
1.  Utilize `char[]` pooling for `JsonTextReader`
1. Avoid JsonSerializer allocation for each transmission
1.  Avoid linking `CancellationTokens` in `MessageHandlerBase`
It might be nice to forcefully cancel folks when the `MessageHandlerBase` is disposed of, but linking tokens requires memory allocations. Practically speaking, the only caller of these methods is `JsonRpc`, which itself will cancel the token it explicitly passed to these methods at about the time it disposes of the `MessageHandlerBase` anyway. So there's no reason to allocate in order to dispose in *both* ways at once.    

Fixes #276

This reduces GC pressure for small messages by 6X on .NET Framework and 10X on .NET Core. 
To give a clear idea of the "regression" from v1.5 to v2.0, and how this PR fixes it (and then goes further to be even better than 1.5), see the tables below. Particularly the last column regarding allocated memory.

v1.5

|             Method | Runtime |     Toolchain |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------- |-------- |-------------- |---------:|---------:|---------:|------:|--------:|------------:|------------:|------------:|--------------------:|
| InvokeAsync_NoArgs |     Clr |        net472 | 72.63 us | 1.365 us | 1.402 us |  1.00 |    0.00 |      4.6387 |           - |           - |            19.13 KB |
| InvokeAsync_NoArgs |    Core | netcoreapp2.2 | 98.32 us | 1.950 us | 4.784 us |  1.26 |    0.06 |      3.9063 |           - |           - |             3.88 KB |

v2.0:

|             Method | Runtime |     Toolchain |     Mean |    Error |    StdDev |   Median | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------- |-------- |-------------- |---------:|---------:|----------:|---------:|------:|--------:|------------:|------------:|------------:|--------------------:|
| InvokeAsync_NoArgs |     Clr |        net472 | 260.0 us | 41.86 us | 123.41 us | 308.0 us |  1.00 |    0.00 |     20.7520 |      0.1221 |           - |             85.4 KB |
| InvokeAsync_NoArgs |    Core | netcoreapp2.2 | 333.1 us | 11.43 us |  32.98 us | 328.0 us |  1.76 |    1.01 |     20.0195 |           - |           - |            32.49 KB |


fix276:

|             Method | Runtime |     Toolchain |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------- |-------- |-------------- |----------:|---------:|---------:|------:|--------:|------------:|------------:|------------:|--------------------:|
| InvokeAsync_NoArgs |     Clr |        net472 |  81.25 us | 1.551 us | 1.786 us |  1.00 |    0.00 |      3.1738 |           - |           - |            13.34 KB |
| InvokeAsync_NoArgs |    Core | netcoreapp2.2 | 120.44 us | 2.368 us | 5.149 us |  1.47 |    0.09 |      2.6855 |           - |           - |             3.39 KB |
