### PR TITLE
Add support for TEventArgs without type constraints

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -39,6 +39,8 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         event EventHandler<CustomEventArgs> TreeGrown;
 
+        event EventHandler<CustomNonDerivingEventArgs> AppleGrown;
+
         Task<string> SayHiAsync();
 
         Task<string> SayHiAsync(string name);
@@ -364,6 +366,25 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    public async Task GenericEventWithoutEventArgsBaseTypeRaisedOnClient()
+    {
+        var tcs = new TaskCompletionSource<CustomNonDerivingEventArgs>();
+        EventHandler<CustomNonDerivingEventArgs> handler = (sender, args) => tcs.SetResult(args);
+        this.clientRpc.AppleGrown += handler;
+        var expectedArgs = new CustomNonDerivingEventArgs { Color = "Red" };
+        this.server.OnAppleGrown(expectedArgs);
+        var actualArgs = await tcs.Task.WithCancellation(this.TimeoutToken);
+        Assert.Equal(expectedArgs.Color, actualArgs.Color);
+
+        // Now unregister and confirm we don't get notified.
+        this.clientRpc.AppleGrown -= handler;
+        tcs = new TaskCompletionSource<CustomNonDerivingEventArgs>();
+        this.server.OnAppleGrown(expectedArgs);
+        await Assert.ThrowsAsync<TimeoutException>(() => tcs.Task.WithTimeout(ExpectedTimeout));
+        Assert.False(tcs.Task.IsCompleted);
+    }
+
+    [Fact]
     public async Task NonGenericEventRaisedOnClient()
     {
         var tcs = new TaskCompletionSource<EventArgs>();
@@ -497,11 +518,23 @@ public class JsonRpcProxyGenerationTests : TestBase
         public int Seeds { get; set; }
     }
 
+    /// <summary>
+    /// This class serves as a type argument to <see cref="EventHandler{TEventArgs}"/>
+    /// but intentionally does *not* derive from <see cref="EventArgs"/>
+    /// since that is no longer a requirement as of .NET 4.5.
+    /// </summary>
+    public class CustomNonDerivingEventArgs
+    {
+        public string Color { get; set; }
+    }
+
     internal class Server : IServerDerived, IServer2, IServer3
     {
         public event EventHandler ItHappened;
 
         public event EventHandler<CustomEventArgs> TreeGrown;
+
+        public event EventHandler<CustomNonDerivingEventArgs> AppleGrown;
 
         public AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
 
@@ -562,5 +595,7 @@ public class JsonRpcProxyGenerationTests : TestBase
         internal void OnItHappened(EventArgs args) => this.ItHappened?.Invoke(this, args);
 
         internal void OnTreeGrown(CustomEventArgs args) => this.TreeGrown?.Invoke(this, args);
+
+        internal void OnAppleGrown(CustomNonDerivingEventArgs args) => this.AppleGrown?.Invoke(this, args);
     }
 }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1713,7 +1713,7 @@ namespace StreamJsonRpc
                 this.eventInfo.RemoveEventHandler(this.server, this.registeredHandler);
             }
 
-            private void OnEventRaised(object sender, EventArgs args)
+            private void OnEventRaised(object sender, object args)
             {
                 this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args });
             }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1672,6 +1672,7 @@ namespace StreamJsonRpc
         private class EventReceiver : IDisposable
         {
             private static readonly MethodInfo OnEventRaisedMethodInfo = typeof(EventReceiver).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(OnEventRaised));
+            private static readonly MethodInfo OnEventRaisedGenericMethodInfo = typeof(EventReceiver).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(OnEventRaisedGeneric));
             private readonly JsonRpc jsonRpc;
             private readonly object server;
             private readonly EventInfo eventInfo;
@@ -1698,7 +1699,16 @@ namespace StreamJsonRpc
                     // It will work for EventHandler and EventHandler<T>, at least.
                     // If we want to support more, we'll likely have to use lightweight code-gen to generate a method
                     // with the right signature.
-                    this.registeredHandler = OnEventRaisedMethodInfo.CreateDelegate(eventInfo.EventHandlerType, this);
+                    if (eventInfo.EventHandlerType.Equals(typeof(EventHandler)))
+                    {
+                        this.registeredHandler = OnEventRaisedMethodInfo.CreateDelegate(eventInfo.EventHandlerType, this);
+                    }
+                    else
+                    {
+                        Type eventArgsType = eventInfo.EventHandlerType.GenericTypeArguments.FirstOrDefault() ?? typeof(object);
+                        var closedGenericMethod = OnEventRaisedGenericMethodInfo.MakeGenericMethod(eventArgsType);
+                        this.registeredHandler = closedGenericMethod.CreateDelegate(eventInfo.EventHandlerType, this);
+                    }
                 }
                 catch (ArgumentException ex)
                 {
@@ -1713,7 +1723,12 @@ namespace StreamJsonRpc
                 this.eventInfo.RemoveEventHandler(this.server, this.registeredHandler);
             }
 
-            private void OnEventRaised(object sender, object args)
+            private void OnEventRaisedGeneric<T>(object sender, T args)
+            {
+                this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args });
+            }
+
+            private void OnEventRaised(object sender, EventArgs args)
             {
                 this.jsonRpc.NotifyAsync(this.rpcEventName, new object[] { args });
             }


### PR DESCRIPTION
Add support for proxy generated clients with event handlers that take args that do *not* derive from `EventArgs`.

**History lesson**: From .NET 2.0 to 4.0, the `EventHandler<T>` delegate type had a type constraint of `T : EventArgs`, meaning that the second parameter that the event handler takes must derive from `EventArgs. In .NET 4.5, this type constraint was *dropped*. Apparently they consider this a non-breaking change. But when dealing with code gen and reflection, all bets are off. :)

Not realizing this, my event wiring code assumed that deriving from `EventArgs` was a guarantee. As a result, when a user defines an event typed as `EventHandler<T>` where `T` does *not* derive from `EventArgs`, we would fail. 

This PR fixes it. Supporting `T : class` was as easy as changing `EventArgs` to `object` in my event handler. But to support `T : struct` required that I bring in a generic method.

Fixes #284 