### PR TITLE
Be more liberal with the accepted type for a message id

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -22,7 +23,14 @@ public class JsonRpcClient20InteropTests : InteropTestBase
     public JsonRpcClient20InteropTests(ITestOutputHelper logger)
         : base(logger, serverTest: false)
     {
-        this.clientRpc = new JsonRpc(this.messageHandler);
+        this.clientRpc = new JsonRpc(this.messageHandler)
+        {
+            TraceSource =
+            {
+                Switch = { Level = SourceLevels.Verbose },
+                Listeners = { new XunitTraceListener(logger) },
+            },
+        };
         this.clientRpc.StartListening();
     }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1784,7 +1784,7 @@ namespace StreamJsonRpc
                     OutstandingCallData data = null;
                     lock (this.dispatcherMapLock)
                     {
-                        long id = (long)resultOrError.Id;
+                        long id = Convert.ToInt64(resultOrError.Id);
                         if (this.resultDispatcherMap.TryGetValue(id, out data))
                         {
                             this.resultDispatcherMap.Remove(id);


### PR DESCRIPTION
Some servers do not strictly follow the JSON-RPC spec and stringify the
id, even if the client sent it as a number.

Note: We've already filed a bug against the service that stringifies all ids but we're not expecting a fix from them soon.

PS: I know you are not accepting pull requests yet but wanted to get this on your radar.