### PR TITLE
Provide all the same abilities in dynamic client proxies that JsonRpc itself has

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -289,7 +289,7 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
-    public void InstanceProxiesDoNotImplementIDisposable()
+    public void InstanceProxiesImplementIJsonRpcClientProxy()
     {
         var streams = FullDuplexStream.CreateStreams();
         var server = new Server();
@@ -297,7 +297,7 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         var clientRpc = new JsonRpc(streams.Item1, streams.Item1);
         var client1 = clientRpc.Attach<IServer>();
-        Assert.IsNotType(typeof(IDisposable), client1);
+        Assert.Same(clientRpc, ((IJsonRpcClientProxy)client1).JsonRpc);
     }
 
     [Fact]

--- a/src/StreamJsonRpc/IJsonRpcClientProxy.cs
+++ b/src/StreamJsonRpc/IJsonRpcClientProxy.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+
+    /// <summary>
+    /// Implemented by dynamically generated proxies returned from <see cref="JsonRpc.Attach{T}(IJsonRpcMessageHandler, JsonRpcProxyOptions)"/> and its overloads
+    /// to provide access to additional JSON-RPC functionality.
+    /// </summary>
+    public interface IJsonRpcClientProxy : IDisposable
+    {
+        /// <summary>
+        /// Gets the <see cref="StreamJsonRpc.JsonRpc"/> instance behind this proxy.
+        /// </summary>
+        JsonRpc JsonRpc { get; }
+    }
+}

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -507,7 +507,7 @@ namespace StreamJsonRpc
         public static T Attach<T>(Stream sendingStream, Stream receivingStream)
             where T : class
         {
-            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: true);
+            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo());
             var rpc = new JsonRpc(sendingStream, receivingStream);
             T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc, JsonRpcProxyOptions.Default);
             rpc.StartListening();
@@ -544,7 +544,7 @@ namespace StreamJsonRpc
         public static T Attach<T>(IJsonRpcMessageHandler handler, JsonRpcProxyOptions options)
             where T : class
         {
-            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: true);
+            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo());
             var rpc = new JsonRpc(handler);
             T proxy = (T)Activator.CreateInstance(proxyType.AsType(), rpc, options ?? JsonRpcProxyOptions.Default);
             rpc.StartListening();
@@ -571,7 +571,7 @@ namespace StreamJsonRpc
         public T Attach<T>(JsonRpcProxyOptions options)
             where T : class
         {
-            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo(), disposable: false);
+            var proxyType = ProxyGeneration.Get(typeof(T).GetTypeInfo());
             T proxy = (T)Activator.CreateInstance(proxyType.AsType(), this, options ?? JsonRpcProxyOptions.Default);
 
             return proxy;

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+StreamJsonRpc.IJsonRpcClientProxy
+StreamJsonRpc.IJsonRpcClientProxy.JsonRpc.get -> StreamJsonRpc.JsonRpc
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T


### PR DESCRIPTION
Fixes #298 by ensuring that *all* dynamic client proxies implement IDisposable.
Fixes #295 by implementing a new IJsonRpcClientProxy interface in each proxy that provides access to the JsonRpc object.