### PR TITLE
Add async JSON deserialization support

### DIFF
--- a/src/StreamJsonRpc/IJsonRpcAsyncMessageFormatter.cs
+++ b/src/StreamJsonRpc/IJsonRpcAsyncMessageFormatter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System.Buffers;
+    using System.IO.Pipelines;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An interface that offers <see cref="JsonRpcMessage"/> serialization to an <see cref="IBufferWriter{T}"/> and asynchronous deserialization.
+    /// </summary>
+    public interface IJsonRpcAsyncMessageFormatter : IJsonRpcMessageFormatter
+    {
+        /// <summary>
+        /// Deserializes a <see cref="JsonRpcMessage"/>.
+        /// </summary>
+        /// <param name="reader">The reader to deserialize from.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The deserialized <see cref="JsonRpcMessage"/>.</returns>
+        ValueTask<JsonRpcMessage> DeserializeAsync(PipeReader reader, CancellationToken cancellationToken);
+    }
+}

--- a/src/StreamJsonRpc/IJsonRpcAsyncMessageTextFormatter.cs
+++ b/src/StreamJsonRpc/IJsonRpcAsyncMessageTextFormatter.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System.Buffers;
+    using System.IO.Pipelines;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An interface that offers <see cref="JsonRpcMessage"/> serialization to an <see cref="IBufferWriter{T}"/> and asynchronous deserialization
+    /// and formats messages as JSON (text).
+    /// </summary>
+    public interface IJsonRpcAsyncMessageTextFormatter : IJsonRpcAsyncMessageFormatter, IJsonRpcMessageTextFormatter
+    {
+        /// <summary>
+        /// Deserializes a sequence of bytes to a <see cref="JsonRpcMessage"/>.
+        /// </summary>
+        /// <param name="reader">The reader to deserialize from.</param>
+        /// <param name="encoding">The encoding to read the bytes from <paramref name="reader"/> with. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The deserialized message.</returns>
+        ValueTask<JsonRpcMessage> DeserializeAsync(PipeReader reader, Encoding encoding, CancellationToken cancellationToken);
+    }
+}

--- a/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
+++ b/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
@@ -85,11 +85,7 @@ namespace StreamJsonRpc
             int length = Utilities.ReadInt32BE(lengthBuffer);
             this.Reader.AdvanceTo(lengthBuffer.End);
 
-            readResult = await this.ReadAtLeastAsync(length, allowEmpty: false, cancellationToken).ConfigureAwait(false);
-            ReadOnlySequence<byte> content = readResult.Buffer.Slice(0, length);
-            JsonRpcMessage message = this.formatter.Deserialize(content);
-            this.Reader.AdvanceTo(content.End);
-            return message;
+            return await this.DeserializeMessageAsync(length, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
+StreamJsonRpc.IJsonRpcAsyncMessageFormatter
+StreamJsonRpc.IJsonRpcAsyncMessageFormatter.DeserializeAsync(System.IO.Pipelines.PipeReader reader, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
+StreamJsonRpc.IJsonRpcAsyncMessageTextFormatter
+StreamJsonRpc.IJsonRpcAsyncMessageTextFormatter.DeserializeAsync(System.IO.Pipelines.PipeReader reader, System.Text.Encoding encoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
 StreamJsonRpc.IJsonRpcClientProxy
 StreamJsonRpc.IJsonRpcClientProxy.JsonRpc.get -> StreamJsonRpc.JsonRpc
+StreamJsonRpc.JsonMessageFormatter.DeserializeAsync(System.IO.Pipelines.PipeReader reader, System.Text.Encoding encoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
+StreamJsonRpc.JsonMessageFormatter.DeserializeAsync(System.IO.Pipelines.PipeReader reader, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.2.26" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.3.25-alpha" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />


### PR DESCRIPTION
This replaces buffering large messages with async streaming deserialization where the formatter supports it.
The JsonMessageFormatter supports it with this change.

Fixes #310