### PR TITLE
Fixed a small bug in the decoding of JSON-RPC 1.0 result messages

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -196,7 +196,7 @@ namespace StreamJsonRpc
                         this.VerifyProtocolCompliance(json["id"] != null, json, "\"id\" property missing.");
                         return
                             json["method"] != null ? this.ReadRequest(json) :
-                            json["error"]?.Type == JTokenType.Null ? this.ReadResult(json) :
+                            json["result"]?.Type == JTokenType.Null ? this.ReadResult(json) :
                             json["error"]?.Type != JTokenType.Null ? (JsonRpcMessage)this.ReadError(json) :
                             throw this.CreateProtocolNonComplianceException(json);
                     case 2:


### PR DESCRIPTION
The code did not decode JSON-RPC 1.0 result (response) messages. It did instead decode error messages as a result message.