### PR TITLE
Added lock form bufferTextWritter

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -305,11 +305,14 @@ namespace StreamJsonRpc
 
         private void WriteJToken(IBufferWriter<byte> contentBuffer, JToken json)
         {
-            this.bufferTextWriter.Initialize(contentBuffer, this.Encoding);
-            using (var jsonWriter = new JsonTextWriter(this.bufferTextWriter))
+            lock (this.bufferTextWriter)
             {
-                json.WriteTo(jsonWriter);
-                jsonWriter.Flush();
+                this.bufferTextWriter.Initialize(contentBuffer, this.Encoding);
+                using (var jsonWriter = new JsonTextWriter(this.bufferTextWriter))
+                {
+                    json.WriteTo(jsonWriter);
+                    jsonWriter.Flush();
+                }
             }
         }
 


### PR DESCRIPTION
This a fix for Bug 959430: StreamJsonRpc - System.InvalidOperationException : This instance must be flushed before being reinitialized. (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/959430)
