### PR TITLE
Added try finally block to ensure writter is being flushed

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -1338,6 +1339,30 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(2, exception.ErrorCode);
     }
 
+    [Fact]
+    public async Task FormatterNonFatalException()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        this.serverStream = streams.Item1;
+        this.clientStream = streams.Item2;
+
+        this.serverRpc = new JsonRpc(this.serverStream);
+        this.serverRpc.AddLocalRpcTarget(this.server);
+        this.serverRpc.StartListening();
+
+        ExceptionThrowingFormatter clientFormatter = new ExceptionThrowingFormatter();
+        this.clientRpc = new JsonRpc(new HeaderDelimitedMessageHandler(this.clientStream, clientFormatter));
+        this.clientRpc.StartListening();
+
+        clientFormatter.ThrowException = true;
+        await Assert.ThrowsAsync<Exception>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethod), "Fail"));
+
+        clientFormatter.ThrowException = false;
+        string result = await this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethod), "Success");
+        Assert.Equal("Success!", result);
+
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -1849,6 +1874,22 @@ public abstract class JsonRpcTests : TestBase
             this.PostInvoked.Set();
             this.AllowPostToReturn.Wait();
             base.Post(d, state);
+        }
+    }
+
+
+    private class ExceptionThrowingFormatter : JsonMessageFormatter, IJsonRpcMessageFormatter
+    {
+        public bool ThrowException = false;
+
+        public new void Serialize(IBufferWriter<byte> bufferWriter, JsonRpcMessage message)
+        {
+            if (this.ThrowException)
+            {
+                throw new Exception("Non fatal exception...");
+            }
+
+            base.Serialize(bufferWriter, message);
         }
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1360,7 +1360,6 @@ public abstract class JsonRpcTests : TestBase
         clientFormatter.ThrowException = false;
         string result = await this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethod), "Success");
         Assert.Equal("Success!", result);
-
     }
 
     protected override void Dispose(bool disposing)

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -308,8 +308,14 @@ namespace StreamJsonRpc
             this.bufferTextWriter.Initialize(contentBuffer, this.Encoding);
             using (var jsonWriter = new JsonTextWriter(this.bufferTextWriter))
             {
-                json.WriteTo(jsonWriter);
-                jsonWriter.Flush();
+                try
+                {
+                    json.WriteTo(jsonWriter);
+                }
+                finally
+                {
+                    jsonWriter.Flush();
+                }
             }
         }
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -308,8 +308,15 @@ namespace StreamJsonRpc
             this.bufferTextWriter.Initialize(contentBuffer, this.Encoding);
             using (var jsonWriter = new JsonTextWriter(this.bufferTextWriter))
             {
-                json.WriteTo(jsonWriter);
-                jsonWriter.Flush();
+                try
+                {
+                    json.WriteTo(jsonWriter);
+                }
+                finally
+                {
+                    // If an exception happens we make sure the writter gets flushed, otherwise initializing will keep failing.
+                    jsonWriter.Flush();
+                }
             }
         }
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -308,15 +308,8 @@ namespace StreamJsonRpc
             this.bufferTextWriter.Initialize(contentBuffer, this.Encoding);
             using (var jsonWriter = new JsonTextWriter(this.bufferTextWriter))
             {
-                try
-                {
-                    json.WriteTo(jsonWriter);
-                }
-                finally
-                {
-                    // If an exception happens we make sure the writter gets flushed, otherwise initializing will keep failing.
-                    jsonWriter.Flush();
-                }
+                json.WriteTo(jsonWriter);
+                jsonWriter.Flush();
             }
         }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1801,6 +1801,16 @@ namespace StreamJsonRpc
                         catch (ObjectDisposedException)
                         {
                         }
+                        catch (Exception exception)
+                        {
+                            var e = new JsonRpcDisconnectedEventArgs(
+                                string.Format(CultureInfo.CurrentCulture, Resources.ErrorWritingJsonRpcResult, exception.GetType().Name, exception.Message),
+                                DisconnectedReason.StreamError,
+                                exception);
+
+                            // Fatal error. Raise disconnected event.
+                            this.OnJsonRpcDisconnected(e);
+                        }
                     }
                 }
                 else if (rpc is IJsonRpcMessageWithId resultOrError)
@@ -1986,10 +1996,10 @@ namespace StreamJsonRpc
             }
             catch (Exception exception)
             {
-                if ((bool)(this.MessageHandler as IDisposableObservable)?.IsDisposed)
+                if ((this.MessageHandler as IDisposableObservable)?.IsDisposed ?? false)
                 {
                     var e = new JsonRpcDisconnectedEventArgs(
-                        string.Format(CultureInfo.CurrentCulture, Resources.ErrorWritingJsonRpcResult, exception.GetType().Name, exception.Message),
+                        string.Format(CultureInfo.CurrentCulture, Resources.ErrorWritingJsonRpcMessage, exception.GetType().Name, exception.Message),
                         DisconnectedReason.StreamError,
                         exception);
 

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace StreamJsonRpc {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace StreamJsonRpc {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("StreamJsonRpc.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("StreamJsonRpc.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -130,6 +129,15 @@ namespace StreamJsonRpc {
         internal static string DroppingRequestDueToNoTargetObject {
             get {
                 return ResourceManager.GetString("DroppingRequestDueToNoTargetObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error writing JSON RPC Result: {0}: {1}.
+        /// </summary>
+        internal static string ErrorWritingJsonRpcMessage {
+            get {
+                return ResourceManager.GetString("ErrorWritingJsonRpcMessage", resourceCulture);
             }
         }
         

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -281,4 +281,8 @@
   <data name="ParameterObjectsNotSupportedInJsonRpc10" xml:space="preserve">
     <value>JSON-RPC 1.0 does not support named arguments (parameters passed within an object). Use positional arguments (parameter arrays) or set protocol version to 2.0.</value>
   </data>
+  <data name="ErrorWritingJsonRpcMessage" xml:space="preserve">
+    <value>Error writing JSON RPC Result: {0}: {1}</value>
+    <comment>{0} is the exception type, {1} is the exception message.</comment>
+  </data>
 </root>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1-alpha",
+  "version": "2.2-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
Added try finally block to ensure writter is being flushed.
If an exception happens when writting to the json we need to make sure the writter gets flushed, otherwise initializing will keep failing.