### PR TITLE
Fix NullReferenceException thrown in invalid proxy gen case

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -214,6 +214,14 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    [Trait("NegativeTest", "")]
+    public void GenerateProxyFromClassNotSuppported_NotNestedClass()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<JsonRpcProxyGenerationTests>(this.clientStream));
+        this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
     public async Task CallMethod_CancellationToken_int()
     {
         await this.clientRpc.HeavyWorkAsync(CancellationToken.None);

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -478,10 +478,12 @@ namespace StreamJsonRpc
 
         private static void VerifySupported(bool condition, string messageFormat, MemberInfo problematicMember, params object[] otherArgs)
         {
+            Requires.NotNull(problematicMember, nameof(problematicMember));
+
             if (!condition)
             {
                 object[] formattingArgs = new object[1 + otherArgs?.Length ?? 0];
-                formattingArgs[0] = problematicMember.DeclaringType.FullName + "." + problematicMember.Name;
+                formattingArgs[0] = problematicMember is TypeInfo problematicType ? problematicType.FullName : problematicMember.DeclaringType?.FullName + "." + problematicMember.Name;
                 if (otherArgs?.Length > 0)
                 {
                     Array.Copy(otherArgs, 0, formattingArgs, 1, otherArgs.Length);


### PR DESCRIPTION
When a concrete type is passed to the proxy generator instead of an interface, we throw. But we have a bug in the construction of the exception message where if the concrete type is NOT a nested type, it throws NRE. This fixes that.