### PR TITLE
Fix handling of events declared on the base types of target objects

### DIFF
--- a/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/src/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -24,7 +24,7 @@ public class TargetObjectEventsTests : TestBase
     public TargetObjectEventsTests(ITestOutputHelper logger)
         : base(logger)
     {
-        this.server = new Server();
+        this.server = new ServerDerived();
         this.client = new Client();
 
         var streams = FullDuplexStream.CreateStreams();
@@ -266,6 +266,10 @@ public class TargetObjectEventsTests : TestBase
         protected virtual void OnPrivateServerEvent(EventArgs args) => this.PrivateServerEvent?.Invoke(this, args);
 
         protected virtual void OnServerEventWithCustomGenericDelegateAndArgs(MessageEventArgs<string> args) => this.ServerEventWithCustomGenericDelegateAndArgs?.Invoke(this, args);
+    }
+
+    private class ServerDerived : Server
+    {
     }
 
     private class ServerWithIncompatibleEvents

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -670,21 +670,24 @@ namespace StreamJsonRpc
 
                 if (options.NotifyClientOfEvents)
                 {
-                    foreach (var evt in target.GetType().GetTypeInfo().DeclaredEvents)
+                    for (TypeInfo t = target.GetType().GetTypeInfo(); t != null && t != typeof(object).GetTypeInfo(); t = t.BaseType?.GetTypeInfo())
                     {
-                        if (evt.AddMethod.IsPublic && !evt.AddMethod.IsStatic)
+                        foreach (var evt in t.DeclaredEvents)
                         {
-                            if (this.eventReceivers == null)
+                            if (evt.AddMethod.IsPublic && !evt.AddMethod.IsStatic)
                             {
-                                this.eventReceivers = new List<EventReceiver>();
-                            }
+                                if (this.eventReceivers == null)
+                                {
+                                    this.eventReceivers = new List<EventReceiver>();
+                                }
 
-                            if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Information))
-                            {
-                                this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.LocalEventListenerAdded, "Listening for events from {0}.{1} to raise notification.", target.GetType().FullName, evt.Name);
-                            }
+                                if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Information))
+                                {
+                                    this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.LocalEventListenerAdded, "Listening for events from {0}.{1} to raise notification.", target.GetType().FullName, evt.Name);
+                                }
 
-                            this.eventReceivers.Add(new EventReceiver(this, target, evt, options));
+                                this.eventReceivers.Add(new EventReceiver(this, target, evt, options));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Tips for reviewers: 
* I changed the existing tests to use a derived type, which caused several to fail.
* I wrapped the existing event enumerating code to do so within an enumeration of the type hierarchy, using exactly the same technique we already used to find methods all the way up the hierarchy. All tests passed after that.

Fixes #340