### PR TITLE
Add support for custom (string based) request IDs

### DIFF
--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -321,7 +321,7 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         await clientHandler.WriteAsync(
             new StreamJsonRpc.Protocol.JsonRpcRequest
             {
-                Id = 1,
+                RequestId = new RequestId(1),
                 Method = nameof(ServerWithOverloads.OverloadedMethod),
                 ArgumentsList = new object[] { false, oobChannel.Id, new object() },
             },

--- a/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -443,7 +443,7 @@ public class JsonRpcClient20InteropTests : InteropTestBase
             result = "pass",
         });
 
-        string result = await invokeTask;
+        string result = await invokeTask.WithCancellation(this.TimeoutToken);
         Assert.Equal("pass", result);
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcCustomRequestIdTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcCustomRequestIdTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcCustomRequestIdTests : InteropTestBase
+{
+    private JsonRpcWithStringIds clientRpc;
+
+    public JsonRpcCustomRequestIdTests(ITestOutputHelper logger)
+        : base(logger, serverTest: false)
+    {
+        this.clientRpc = new JsonRpcWithStringIds(this.messageHandler)
+        {
+            TraceSource =
+            {
+                Switch = { Level = SourceLevels.Verbose },
+                Listeners = { new XunitTraceListener(logger) },
+            },
+        };
+        this.clientRpc.StartListening();
+    }
+
+    [Fact]
+    public async Task ClientSendsUniqueIdAsString()
+    {
+        var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>("test", cancellationToken: this.TimeoutToken);
+        JToken request = await this.ReceiveAsync();
+        Assert.Equal(JTokenType.String, request["id"].Type);
+        string idAsString = request.Value<string>("id");
+        Assert.StartsWith("prefix-", idAsString);
+        this.Send(new
+        {
+            jsonrpc = "2.0",
+            id = idAsString,
+            result = "pass",
+        });
+
+        string result = await invokeTask.WithCancellation(this.TimeoutToken);
+        Assert.Equal("pass", result);
+    }
+
+    private class JsonRpcWithStringIds : JsonRpc
+    {
+        public JsonRpcWithStringIds(IJsonRpcMessageHandler handler)
+            : base(handler)
+        {
+        }
+
+        protected override RequestId CreateNewRequestId()
+        {
+            return new RequestId("prefix-" + base.CreateNewRequestId().Number.Value.ToString());
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
@@ -162,8 +162,8 @@ public class JsonRpcRemoteTargetTests : InteropTestBase
     [Fact]
     public async Task InvokeRemoteTargetWithExistingId()
     {
-        var resultLocalTask = this.remoteTarget1.InvokeAsync<int>(1, nameof(RemoteTargetOne.AddTwo), 3, CancellationToken.None);
-        var resultRemoteTask = this.originRpc.InvokeAsync<int>(1, nameof(RemoteTargetOne.AddOneLongRunningAsync), 1, CancellationToken.None);
+        var resultLocalTask = this.remoteTarget1.InvokeAsync<int>(new RequestId(1), nameof(RemoteTargetOne.AddTwo), 3, CancellationToken.None);
+        var resultRemoteTask = this.originRpc.InvokeAsync<int>(new RequestId(1), nameof(RemoteTargetOne.AddOneLongRunningAsync), 1, CancellationToken.None);
 
         await Task.WhenAll(resultLocalTask, resultRemoteTask);
 
@@ -269,7 +269,7 @@ public class JsonRpcRemoteTargetTests : InteropTestBase
         {
         }
 
-        public Task<T> InvokeAsync<T>(long requestId, string targetName, object argument, CancellationToken token)
+        public Task<T> InvokeAsync<T>(RequestId requestId, string targetName, object argument, CancellationToken token)
         {
             var arguments = new object[] { argument };
             return this.InvokeCoreAsync<T>(requestId, targetName, arguments, token);

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -99,7 +99,7 @@ public abstract class JsonRpcTests : TestBase
         await helperHandler.WriteAsync(
             new JsonRpcRequest
             {
-                Id = 1,
+                RequestId = new RequestId(1),
                 Method = nameof(Server.MethodThatAccceptsAndReturnsNull),
                 ArgumentsList = new object[] { null },
             },
@@ -1332,7 +1332,7 @@ public abstract class JsonRpcTests : TestBase
 
     /// <summary>
     /// Verifies (with a great deal of help by interactively debugging and freezing a thread) that <see cref="JsonRpc.StartListening"/>
-    /// shouldn't have a race condition with itself and a locally invoked RPC method calling <see cref="JsonRpc.InvokeCoreAsync{TResult}(long?, string, System.Collections.Generic.IReadOnlyList{object}, CancellationToken, bool)"/>.
+    /// shouldn't have a race condition with itself and a locally invoked RPC method calling <see cref="JsonRpc.InvokeCoreAsync{TResult}(RequestId, string, System.Collections.Generic.IReadOnlyList{object}, CancellationToken, bool)"/>.
     /// </summary>
     [Fact]
     public async Task StartListening_ShouldNotAllowIncomingMessageToRaceWithInvokeAsync()

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -26,13 +26,13 @@ public class MessagePackFormatterTests : TestBase
     {
         var original = new JsonRpcRequest
         {
-            Id = 5,
+            RequestId = new RequestId(5),
             Method = "test",
             ArgumentsList = new object[] { 5, "hi", new CustomType { Age = 8 } },
         };
 
         var actual = this.Roundtrip(original);
-        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(original.RequestId, actual.RequestId);
         Assert.Equal(original.Method, actual.Method);
         Assert.Equal(original.ArgumentsList[0], actual.ArgumentsList[0]);
         Assert.Equal(original.ArgumentsList[1], actual.ArgumentsList[1]);
@@ -44,12 +44,12 @@ public class MessagePackFormatterTests : TestBase
     {
         var original = new JsonRpcResult
         {
-            Id = 5,
+            RequestId = new RequestId(5),
             Result = new CustomType { Age = 7 },
         };
 
         var actual = this.Roundtrip(original);
-        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(original.RequestId, actual.RequestId);
         Assert.Equal(((CustomType)original.Result).Age, ((CustomType)actual.Result).Age);
     }
 
@@ -58,7 +58,7 @@ public class MessagePackFormatterTests : TestBase
     {
         var original = new JsonRpcError
         {
-            Id = 5,
+            RequestId = new RequestId(5),
             Error = new JsonRpcError.ErrorDetail
             {
                 Code = JsonRpcErrorCode.InvocationError,
@@ -68,7 +68,7 @@ public class MessagePackFormatterTests : TestBase
         };
 
         var actual = this.Roundtrip(original);
-        Assert.Equal(original.Id, actual.Id);
+        Assert.Equal(original.RequestId, actual.RequestId);
         Assert.Equal(original.Error.Code, actual.Error.Code);
         Assert.Equal(original.Error.Message, actual.Error.Message);
         Assert.Equal(((CustomType)original.Error.Data).Age, ((CustomType)actual.Error.Data).Age);

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
-    <PackageReference Include="MessagePack" Version="2.0.123-beta" />
-    <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" PrivateAssets="all" />
+    <PackageReference Include="MessagePack" Version="2.0.171-beta" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.0.171-beta" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />

--- a/src/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
@@ -186,7 +186,7 @@ public class StreamMessageHandlerTests : TestBase
 
     private static JsonRpcMessage CreateNotifyMessage() => new JsonRpcRequest { Method = "test" };
 
-    private static JsonRpcMessage CreateRequestMessage() => new JsonRpcRequest { Id = 1, Method = "test" };
+    private static JsonRpcMessage CreateRequestMessage() => new JsonRpcRequest { RequestId = new RequestId(1), Method = "test" };
 
     private class DelayedWriter : StreamMessageHandler
     {

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -54,14 +54,14 @@ namespace StreamJsonRpc
         /// A map of outbound calls awaiting responses.
         /// Lock the <see cref="dispatcherMapLock"/> object for all access to this member.
         /// </summary>
-        private readonly Dictionary<long, OutstandingCallData> resultDispatcherMap = new Dictionary<long, OutstandingCallData>();
+        private readonly Dictionary<RequestId, OutstandingCallData> resultDispatcherMap = new Dictionary<RequestId, OutstandingCallData>();
 
         /// <summary>
         /// A map of id's from inbound calls that have not yet completed and may be canceled,
         /// to their <see cref="CancellationTokenSource"/> instances.
         /// Lock the <see cref="dispatcherMapLock"/> object for all access to this member.
         /// </summary>
-        private readonly Dictionary<object, CancellationTokenSource> inboundCancellationSources = new Dictionary<object, CancellationTokenSource>();
+        private readonly Dictionary<RequestId, CancellationTokenSource> inboundCancellationSources = new Dictionary<RequestId, CancellationTokenSource>();
 
         /// <summary>
         /// A delegate for the <see cref="CancelPendingOutboundRequest"/> method.
@@ -926,8 +926,7 @@ namespace StreamJsonRpc
         {
             // If argument is null, this indicates that the method does not take any parameters.
             object[] argumentToPass = argument == null ? null : new object[] { argument };
-            long id = Interlocked.Increment(ref this.nextId);
-            return this.InvokeCoreAsync<TResult>(id, targetName, argumentToPass, cancellationToken, isParameterObject: true);
+            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, argumentToPass, cancellationToken, isParameterObject: true);
         }
 
         /// <summary>
@@ -978,8 +977,7 @@ namespace StreamJsonRpc
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
         public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object> arguments = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            long id = Interlocked.Increment(ref this.nextId);
-            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken);
+            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, cancellationToken);
         }
 
         /// <summary>
@@ -997,8 +995,7 @@ namespace StreamJsonRpc
         {
             var arguments = new object[] { argument };
 
-            int? id = null;
-            return this.InvokeCoreAsync<object>(id, targetName, arguments, CancellationToken.None);
+            return this.InvokeCoreAsync<object>(RequestId.NotSpecified, targetName, arguments, CancellationToken.None);
         }
 
         /// <summary>
@@ -1014,8 +1011,7 @@ namespace StreamJsonRpc
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
         public Task NotifyAsync(string targetName, params object[] arguments)
         {
-            int? id = null;
-            return this.InvokeCoreAsync<object>(id, targetName, arguments, CancellationToken.None);
+            return this.InvokeCoreAsync<object>(RequestId.NotSpecified, targetName, arguments, CancellationToken.None);
         }
 
         /// <summary>
@@ -1034,9 +1030,7 @@ namespace StreamJsonRpc
             // If argument is null, this indicates that the method does not take any parameters.
             object[] argumentToPass = argument == null ? null : new object[] { argument };
 
-            int? id = null;
-
-            return this.InvokeCoreAsync<object>(id, targetName, argumentToPass, CancellationToken.None, isParameterObject: true);
+            return this.InvokeCoreAsync<object>(RequestId.NotSpecified, targetName, argumentToPass, CancellationToken.None, isParameterObject: true);
         }
 
         /// <summary>
@@ -1107,9 +1101,10 @@ namespace StreamJsonRpc
         /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        [Obsolete("Use the InvokeCoreAsync(RequestId, ...) overload instead.")]
         protected Task<TResult> InvokeCoreAsync<TResult>(long? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken, isParameterObject: false);
+            return this.InvokeCoreAsync<TResult>(id.HasValue ? new RequestId(id.Value) : default, targetName, arguments, cancellationToken);
         }
 
         /// <summary>
@@ -1121,9 +1116,39 @@ namespace StreamJsonRpc
         /// <param name="targetName">Name of the method to invoke.</param>
         /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        protected Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
+        {
+            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken, isParameterObject: false);
+        }
+
+        /// <summary>
+        /// Invokes the specified RPC method.
+        /// </summary>
+        /// <typeparam name="TResult">RPC method return type.</typeparam>
+        /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
+        /// <param name="targetName">Name of the method to invoke.</param>
+        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
-        protected async Task<TResult> InvokeCoreAsync<TResult>(long? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken, bool isParameterObject)
+        [Obsolete("Use the InvokeCoreAsync(RequestId, ...) overload instead.")]
+        protected Task<TResult> InvokeCoreAsync<TResult>(long? id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken, bool isParameterObject)
+        {
+            return this.InvokeCoreAsync<TResult>(id.HasValue ? new RequestId(id.Value) : default, targetName, arguments, cancellationToken, isParameterObject);
+        }
+
+        /// <summary>
+        /// Invokes the specified RPC method.
+        /// </summary>
+        /// <typeparam name="TResult">RPC method return type.</typeparam>
+        /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
+        /// <param name="targetName">Name of the method to invoke.</param>
+        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
+        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken, bool isParameterObject)
         {
             Requires.NotNullOrEmpty(targetName, nameof(targetName));
 
@@ -1132,7 +1157,7 @@ namespace StreamJsonRpc
 
             var request = new JsonRpcRequest
             {
-                Id = id,
+                RequestId = id,
                 Method = targetName,
             };
             if (isParameterObject)
@@ -1176,6 +1201,16 @@ namespace StreamJsonRpc
             {
                 return default;
             }
+        }
+
+        /// <summary>
+        /// Creates a unique <see cref="RequestId"/> for an outbound request.
+        /// </summary>
+        /// <returns>The unique <see cref="RequestId"/>.</returns>
+        protected virtual RequestId CreateNewRequestId()
+        {
+            long id = Interlocked.Increment(ref this.nextId);
+            return new RequestId(id);
         }
 
         /// <summary>
@@ -1385,7 +1420,7 @@ namespace StreamJsonRpc
                     {
                         lock (this.dispatcherMapLock)
                         {
-                            this.resultDispatcherMap.Remove((long)request.Id);
+                            this.resultDispatcherMap.Remove(request.RequestId);
                         }
 
                         try
@@ -1394,12 +1429,12 @@ namespace StreamJsonRpc
                             {
                                 if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Warning))
                                 {
-                                    this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.RequestAbandonedByRemote, "Aborting pending request \"{0}\" because the connection was lost.", request.Id);
+                                    this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.RequestAbandonedByRemote, "Aborting pending request \"{0}\" because the connection was lost.", request.RequestId);
                                 }
 
                                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Warning, System.Diagnostics.Tracing.EventKeywords.None))
                                 {
-                                    JsonRpcEventSource.Instance.ReceivedNoResponse((long)request.Id);
+                                    JsonRpcEventSource.Instance.ReceivedNoResponse(request.RequestId.NumberIfPossibleForEvent);
                                 }
 
                                 if (cancellationToken.IsCancellationRequested)
@@ -1416,7 +1451,7 @@ namespace StreamJsonRpc
                             {
                                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Warning, System.Diagnostics.Tracing.EventKeywords.None))
                                 {
-                                    JsonRpcEventSource.Instance.ReceivedError((long)request.Id, error.Error.Code);
+                                    JsonRpcEventSource.Instance.ReceivedError(request.RequestId.NumberIfPossibleForEvent, error.Error.Code);
                                 }
 
                                 if (error.Error?.Code == JsonRpcErrorCode.RequestCanceled)
@@ -1432,7 +1467,7 @@ namespace StreamJsonRpc
                             {
                                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                                 {
-                                    JsonRpcEventSource.Instance.ReceivedResult((long)request.Id);
+                                    JsonRpcEventSource.Instance.ReceivedResult(request.RequestId.NumberIfPossibleForEvent);
                                 }
 
                                 tcs.SetResult(response);
@@ -1447,14 +1482,14 @@ namespace StreamJsonRpc
                     var callData = new OutstandingCallData(tcs, dispatcher);
                     lock (this.dispatcherMapLock)
                     {
-                        this.resultDispatcherMap.Add((long)request.Id, callData);
+                        this.resultDispatcherMap.Add(request.RequestId, callData);
                     }
 
                     try
                     {
                         if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Verbose, System.Diagnostics.Tracing.EventKeywords.None))
                         {
-                            JsonRpcEventSource.Instance.SendingRequest((long)request.Id, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.SendingRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
                         }
 
                         await this.TransmitAsync(request, cts.Token).ConfigureAwait(false);
@@ -1464,14 +1499,14 @@ namespace StreamJsonRpc
                         // Since we aren't expecting a response to this request, clear out our memory of it to avoid a memory leak.
                         lock (this.dispatcherMapLock)
                         {
-                            this.resultDispatcherMap.Remove((long)request.Id);
+                            this.resultDispatcherMap.Remove(request.RequestId);
                         }
 
                         throw;
                     }
 
                     // Arrange for sending a cancellation message if canceled while we're waiting for a response.
-                    using (cancellationToken.Register(this.cancelPendingOutboundRequestAction, request.Id, useSynchronizationContext: false))
+                    using (cancellationToken.Register(this.cancelPendingOutboundRequestAction, request.RequestId, useSynchronizationContext: false))
                     {
                         // This task will be completed when the Response object comes back from the other end of the pipe
                         return await tcs.Task.ConfigureAwait(false);
@@ -1491,8 +1526,8 @@ namespace StreamJsonRpc
 
             if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Error))
             {
-                this.TraceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.LocalInvocationError, "Exception thrown from request \"{0}\" for method {1}: {2}", request.Id, request.Method, exception);
-                this.TraceSource.TraceData(TraceEventType.Error, (int)TraceEvents.LocalInvocationError, exception, request.Method, request.Id, request.Arguments);
+                this.TraceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.LocalInvocationError, "Exception thrown from request \"{0}\" for method {1}: {2}", request.RequestId, request.Method, exception);
+                this.TraceSource.TraceData(TraceEventType.Error, (int)TraceEvents.LocalInvocationError, exception, request.Method, request.RequestId, request.Arguments);
             }
 
             exception = StripExceptionToInnerException(exception);
@@ -1516,7 +1551,7 @@ namespace StreamJsonRpc
 
             return new JsonRpcError
             {
-                Id = request.Id,
+                RequestId = request.RequestId,
                 Error = errorDetails,
             };
         }
@@ -1526,7 +1561,6 @@ namespace StreamJsonRpc
             Requires.NotNull(request, nameof(request));
 
             CancellationTokenSource localMethodCancellationSource = null;
-            long idAsLongIfPossible = request.Id is long id ? id : -1;
             try
             {
                 // Add cancelation to inboundCancellationSources before yielding to ensure that
@@ -1559,7 +1593,7 @@ namespace StreamJsonRpc
                     {
                         lock (this.dispatcherMapLock)
                         {
-                            this.inboundCancellationSources.Add(request.Id, localMethodCancellationSource);
+                            this.inboundCancellationSources.Add(request.RequestId, localMethodCancellationSource);
                         }
                     }
 
@@ -1572,7 +1606,7 @@ namespace StreamJsonRpc
                     {
                         if (request.IsResponseExpected)
                         {
-                            JsonRpcEventSource.Instance.ReceivedRequest(idAsLongIfPossible, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.ReceivedRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
                         }
                         else
                         {
@@ -1597,12 +1631,12 @@ namespace StreamJsonRpc
                     {
                         if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                         {
-                            JsonRpcEventSource.Instance.SendingResult(idAsLongIfPossible);
+                            JsonRpcEventSource.Instance.SendingResult(request.RequestId.NumberIfPossibleForEvent);
                         }
 
                         return new JsonRpcResult
                         {
-                            Id = request.Id,
+                            RequestId = request.RequestId,
                             Result = result,
                         };
                     }
@@ -1636,7 +1670,7 @@ namespace StreamJsonRpc
                         {
                             lock (this.dispatcherMapLock)
                             {
-                                this.inboundCancellationSources.Add(request.Id, localMethodCancellationSource);
+                                this.inboundCancellationSources.Add(request.RequestId, localMethodCancellationSource);
                             }
                         }
 
@@ -1650,15 +1684,14 @@ namespace StreamJsonRpc
                         // Before we forward the request to the remote targets, we need to change the request ID so it gets a new ID in case we run into collisions.  For example,
                         // if origin issues a request destined for the remote target at the same time as a request issued by the relay to the remote target, their IDs could be mixed up.
                         // See InvokeRemoteTargetWithExistingId unit test for an example.
-                        object previousId = request.Id;
+                        RequestId previousId = request.RequestId;
 
                         JsonRpcMessage remoteResponse = null;
                         foreach (JsonRpc remoteTarget in remoteRpcTargets)
                         {
                             if (request.IsResponseExpected)
                             {
-                                long substituteId = Interlocked.Increment(ref remoteTarget.nextId);
-                                request.Id = substituteId;
+                                request.RequestId = remoteTarget.CreateNewRequestId();
                             }
 
                             CancellationToken token = request.IsResponseExpected ? localMethodCancellationSource.Token : CancellationToken.None;
@@ -1681,7 +1714,7 @@ namespace StreamJsonRpc
                         {
                             if (remoteResponse is IJsonRpcMessageWithId messageWithId)
                             {
-                                messageWithId.Id = previousId;
+                                messageWithId.RequestId = previousId;
                             }
 
                             return remoteResponse;
@@ -1697,7 +1730,7 @@ namespace StreamJsonRpc
 
                         return new JsonRpcError
                         {
-                            Id = request.Id,
+                            RequestId = request.RequestId,
                             Error = new JsonRpcError.ErrorDetail
                             {
                                 Code = JsonRpcErrorCode.MethodNotFound,
@@ -1714,7 +1747,7 @@ namespace StreamJsonRpc
 
                         return new JsonRpcError
                         {
-                            Id = request.Id,
+                            RequestId = request.RequestId,
                             Error = new JsonRpcError.ErrorDetail
                             {
                                 Code = JsonRpcErrorCode.InvalidParams,
@@ -1730,7 +1763,7 @@ namespace StreamJsonRpc
 
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Warning, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.SendingError(idAsLongIfPossible, error.Error.Code);
+                    JsonRpcEventSource.Instance.SendingError(request.RequestId.NumberIfPossibleForEvent, error.Error.Code);
                 }
 
                 return error;
@@ -1741,7 +1774,7 @@ namespace StreamJsonRpc
                 {
                     lock (this.dispatcherMapLock)
                     {
-                        this.inboundCancellationSources.Remove(request.Id);
+                        this.inboundCancellationSources.Remove(request.RequestId);
                     }
 
                     // Be sure to dispose the CTS because it may be linked to our long-lived disposal token
@@ -1780,7 +1813,7 @@ namespace StreamJsonRpc
             {
                 result = new JsonRpcError
                 {
-                    Id = request.Id,
+                    RequestId = request.RequestId,
                     Error = new JsonRpcError.ErrorDetail
                     {
                         Code = JsonRpcErrorCode.RequestCanceled,
@@ -1792,23 +1825,22 @@ namespace StreamJsonRpc
             {
                 result = new JsonRpcResult
                 {
-                    Id = request.Id,
+                    RequestId = request.RequestId,
                 };
             }
 
-            long idIfPossible = request.Id is long id ? id : -1;
             if (result is JsonRpcError error)
             {
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Warning, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.SendingError(idIfPossible, error.Error.Code);
+                    JsonRpcEventSource.Instance.SendingError(request.RequestId.NumberIfPossibleForEvent, error.Error.Code);
                 }
             }
             else
             {
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.SendingResult(idIfPossible);
+                    JsonRpcEventSource.Instance.SendingResult(request.RequestId.NumberIfPossibleForEvent);
                 }
             }
 
@@ -1977,7 +2009,7 @@ namespace StreamJsonRpc
                     {
                         if (request.IsResponseExpected)
                         {
-                            this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.RequestReceived, "Received request \"{0}\" for method \"{1}\".", request.Id, request.Method);
+                            this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.RequestReceived, "Received request \"{0}\" for method \"{1}\".", request.RequestId, request.Method);
                         }
                         else
                         {
@@ -2025,10 +2057,9 @@ namespace StreamJsonRpc
                     OutstandingCallData data = null;
                     lock (this.dispatcherMapLock)
                     {
-                        long id = Convert.ToInt64(resultOrError.Id);
-                        if (this.resultDispatcherMap.TryGetValue(id, out data))
+                        if (this.resultDispatcherMap.TryGetValue(resultOrError.RequestId, out data))
                         {
-                            this.resultDispatcherMap.Remove(id);
+                            this.resultDispatcherMap.Remove(resultOrError.RequestId);
                         }
                     }
 
@@ -2036,11 +2067,11 @@ namespace StreamJsonRpc
                     {
                         if (resultOrError is JsonRpcResult result)
                         {
-                            this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.ReceivedResult, "Received result for request \"{0}\".", result.Id);
+                            this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.ReceivedResult, "Received result for request \"{0}\".", result.RequestId);
                         }
                         else if (resultOrError is JsonRpcError error)
                         {
-                            this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.ReceivedError, "Received error response for request {0}: {1} \"{2}\": ", error.Id, error.Error.Code, error.Error.Message);
+                            this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.ReceivedError, "Received error response for request {0}: {1} \"{2}\": ", error.RequestId, error.Error.Code, error.Error.Message);
                         }
                     }
 
@@ -2075,8 +2106,9 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(request, nameof(request));
 
-            if (request.TryGetArgumentByNameOrIndex("id", -1, null, out object id))
+            if (request.TryGetArgumentByNameOrIndex("id", -1, null, out object idArg))
             {
+                RequestId id = idArg is RequestId requestId ? requestId : RequestId.Parse(idArg);
                 if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Information))
                 {
                     this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.ReceivedCancellation, "Cancellation request received for \"{0}\".", id);
@@ -2084,7 +2116,7 @@ namespace StreamJsonRpc
 
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.ReceivedCancellationRequest(id is long v ? v : -1);
+                    JsonRpcEventSource.Instance.ReceivedCancellationRequest(id.NumberIfPossibleForEvent);
                 }
 
                 CancellationTokenSource cts;
@@ -2130,10 +2162,11 @@ namespace StreamJsonRpc
         /// <summary>
         /// Cancels an individual outbound pending request.
         /// </summary>
-        /// <param name="state">The ID associated with the request to be canceled.</param>
+        /// <param name="state">The <see cref="RequestId"/> associated with the request to be canceled.</param>
         private void CancelPendingOutboundRequest(object state)
         {
             Requires.NotNull(state, nameof(state));
+            var requestId = (RequestId)state;
             Task.Run(async delegate
             {
                 if (!this.IsDisposed)
@@ -2143,13 +2176,13 @@ namespace StreamJsonRpc
                         Method = CancelRequestSpecialMethod,
                         NamedArguments = new Dictionary<string, object>
                         {
-                            { "id", state },
+                            { "id", requestId },
                         },
                     };
 
                     if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                     {
-                        JsonRpcEventSource.Instance.SendingCancellationRequest(state is long v ? v : -1);
+                        JsonRpcEventSource.Instance.SendingCancellationRequest(requestId.NumberIfPossibleForEvent);
                     }
 
                     await this.TransmitAsync(cancellationMessage, this.DisconnectedToken).ConfigureAwait(false);

--- a/src/StreamJsonRpc/Protocol/IJsonRpcMessageWithId.cs
+++ b/src/StreamJsonRpc/Protocol/IJsonRpcMessageWithId.cs
@@ -8,6 +8,6 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets the ID on a message.
         /// </summary>
-        object Id { get; set; }
+        RequestId RequestId { get; set; }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -3,6 +3,7 @@
 
 namespace StreamJsonRpc.Protocol
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Runtime.Serialization;
@@ -25,20 +26,31 @@ namespace StreamJsonRpc.Protocol
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
         /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <c>null</c>.</value>
+        [Obsolete("Use " + nameof(RequestId) + " instead.")]
+        [IgnoreDataMember]
+        public object Id
+        {
+            get => this.RequestId.ObjectValue;
+            set => this.RequestId = RequestId.Parse(value);
+        }
+
+        /// <summary>
+        /// Gets or sets an identifier established by the client if a response to the request is expected.
+        /// </summary>
         [DataMember(Name = "id", Order = 2, IsRequired = true, EmitDefaultValue = true)]
-        public object Id { get; set; }
+        public RequestId RequestId { get; set; }
 
         /// <summary>
         /// Gets the string to display in the debugger for this instance.
         /// </summary>
-        protected string DebuggerDisplay => $"Error: {this.Error.Code} \"{this.Error.Message}\" ({this.Id})";
+        protected string DebuggerDisplay => $"Error: {this.Error.Code} \"{this.Error.Message}\" ({this.RequestId})";
 
         /// <inheritdoc/>
         public override string ToString()
         {
             return new JObject
             {
-                new JProperty("id", this.Id),
+                new JProperty("id", this.RequestId.ObjectValue),
                 new JProperty("error", new JObject
                 {
                     new JProperty("code", this.Error?.Code),

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -67,20 +67,31 @@ namespace StreamJsonRpc.Protocol
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
         /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <c>null</c>.</value>
+        [Obsolete("Use " + nameof(RequestId) + " instead.")]
+        [IgnoreDataMember]
+        public object Id
+        {
+            get => this.RequestId.ObjectValue;
+            set => this.RequestId = RequestId.Parse(value);
+        }
+
+        /// <summary>
+        /// Gets or sets an identifier established by the client if a response to the request is expected.
+        /// </summary>
         [DataMember(Name = "id", Order = 3, IsRequired = false, EmitDefaultValue = false)]
-        public object Id { get; set; }
+        public RequestId RequestId { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether a response to this request is expected.
         /// </summary>
         [IgnoreDataMember]
-        public bool IsResponseExpected => this.Id != null;
+        public bool IsResponseExpected => !this.RequestId.IsEmpty;
 
         /// <summary>
         /// Gets a value indicating whether this is a notification, and no response is expected.
         /// </summary>
         [IgnoreDataMember]
-        public bool IsNotification => this.Id == null;
+        public bool IsNotification => this.RequestId.IsEmpty;
 
         /// <summary>
         /// Gets the number of arguments supplied in the request.
@@ -122,7 +133,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets the string to display in the debugger for this instance.
         /// </summary>
-        protected string DebuggerDisplay => (this.Id != null ? $"Request {this.Id}" : "Notification") + $": {this.Method}({this.Arguments})";
+        protected string DebuggerDisplay => (!this.RequestId.IsEmpty ? $"Request {this.RequestId}" : "Notification") + $": {this.Method}({this.Arguments})";
 
         /// <summary>
         /// Gets the arguments to supply to the method invocation, coerced to types that will satisfy the given list of parameters.
@@ -215,7 +226,7 @@ namespace StreamJsonRpc.Protocol
         {
             return new JObject
             {
-                new JProperty("id", this.Id),
+                new JProperty("id", this.RequestId.ObjectValue),
                 new JProperty("method", this.Method),
             }.ToString(Newtonsoft.Json.Formatting.None);
         }

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -25,13 +25,24 @@ namespace StreamJsonRpc.Protocol
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
         /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <c>null</c>.</value>
+        [Obsolete("Use " + nameof(RequestId) + " instead.")]
+        [IgnoreDataMember]
+        public object Id
+        {
+            get => this.RequestId.ObjectValue;
+            set => this.RequestId = RequestId.Parse(value);
+        }
+
+        /// <summary>
+        /// Gets or sets an identifier established by the client if a response to the request is expected.
+        /// </summary>
         [DataMember(Name = "id", Order = 2, IsRequired = true)]
-        public object Id { get; set; }
+        public RequestId RequestId { get; set; }
 
         /// <summary>
         /// Gets the string to display in the debugger for this instance.
         /// </summary>
-        protected string DebuggerDisplay => $"Result: {this.Result} ({this.Id})";
+        protected string DebuggerDisplay => $"Result: {this.Result} ({this.RequestId})";
 
         /// <summary>
         /// Gets the value of the <see cref="Result"/>, taking into account any possible type coercion.
@@ -49,7 +60,7 @@ namespace StreamJsonRpc.Protocol
         {
             return new JObject
             {
-                new JProperty("id", this.Id),
+                new JProperty("id", this.RequestId.ObjectValue),
             }.ToString(Newtonsoft.Json.Formatting.None);
         }
     }

--- a/src/StreamJsonRpc/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Shipped.txt
@@ -322,25 +322,18 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pi
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.get -> Nerdbank.Streams.MultiplexingStream
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(long requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(object requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> object
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> long?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.set -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc rpc, object token, System.Type valueType) -> object
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc rpc, object token) -> System.IProgress<T>
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.GetTokenForProgress(object value) -> long
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker() -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(long requestId) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.InvokeReport(object typedValue) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ProgressParamInformation(object progressObject) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ValueType.get -> System.Type
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> long?
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.set -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(object progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 const StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressRequestSpecialMethod = "$/progress" -> string
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T

--- a/src/StreamJsonRpc/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/PublicAPI.Unshipped.txt
@@ -1,0 +1,27 @@
+StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
+StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.set -> void
+StreamJsonRpc.Protocol.JsonRpcResult.RequestId.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Protocol.JsonRpcResult.RequestId.set -> void
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId, bool successful) -> void
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(StreamJsonRpc.RequestId requestId, bool successful) -> void
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
+StreamJsonRpc.RequestId
+StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
+StreamJsonRpc.RequestId.IsEmpty.get -> bool
+StreamJsonRpc.RequestId.Number.get -> long?
+StreamJsonRpc.RequestId.RequestId(long id) -> void
+StreamJsonRpc.RequestId.RequestId(string id) -> void
+StreamJsonRpc.RequestId.String.get -> string
+override StreamJsonRpc.RequestId.Equals(object obj) -> bool
+override StreamJsonRpc.RequestId.GetHashCode() -> int
+override StreamJsonRpc.RequestId.ToString() -> string
+static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
+virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -32,12 +32,12 @@ namespace StreamJsonRpc.Reflection
         /// <summary>
         /// A map of outbound request IDs to channels that they included.
         /// </summary>
-        private ImmutableDictionary<long, ImmutableList<MultiplexingStream.Channel>> outboundRequestChannelMap = ImmutableDictionary<long, ImmutableList<MultiplexingStream.Channel>>.Empty;
+        private ImmutableDictionary<RequestId, ImmutableList<MultiplexingStream.Channel>> outboundRequestChannelMap = ImmutableDictionary<RequestId, ImmutableList<MultiplexingStream.Channel>>.Empty;
 
         /// <summary>
         /// A map of inbound request IDs to channels that they included.
         /// </summary>
-        private ImmutableDictionary<object, ImmutableList<MultiplexingStream.Channel>> inboundRequestChannelMap = ImmutableDictionary<object, ImmutableList<MultiplexingStream.Channel>>.Empty;
+        private ImmutableDictionary<RequestId, ImmutableList<MultiplexingStream.Channel>> inboundRequestChannelMap = ImmutableDictionary<RequestId, ImmutableList<MultiplexingStream.Channel>>.Empty;
 
         /// <summary>
         /// The set of channels that have been opened but not yet closed to support outbound requests, keyed by their ID.
@@ -64,12 +64,12 @@ namespace StreamJsonRpc.Reflection
         /// <summary>
         /// Gets or sets the id of the request currently being serialized for use as a key in <see cref="outboundRequestChannelMap"/>.
         /// </summary>
-        public long? RequestIdBeingSerialized { get; set; }
+        public RequestId RequestIdBeingSerialized { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the request currently being deserialized for use as a key in <see cref="inboundRequestChannelMap"/>.
         /// </summary>
-        public object RequestIdBeingDeserialized { get; set; }
+        public RequestId RequestIdBeingDeserialized { get; set; }
 
         /// <summary>
         /// Gets or sets the multiplexing stream used to create and accept channels.
@@ -89,7 +89,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The token to use as the RPC method argument; or <c>null</c> if <paramref name="duplexPipe"/> was <c>null</c>.</returns>
         /// <remarks>
         /// This method should only be called while serializing requests that include an ID (i.e. requests for which we expect a response).
-        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(long, bool)"/>.
+        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
         public int? GetToken(IDuplexPipe duplexPipe)
@@ -97,7 +97,7 @@ namespace StreamJsonRpc.Reflection
             Verify.NotDisposed(this);
 
             MultiplexingStream mxstream = this.GetMultiplexingStreamOrThrow();
-            if (this.RequestIdBeingSerialized is null)
+            if (this.RequestIdBeingSerialized.IsEmpty)
             {
                 throw new NotSupportedException(Resources.MarshaledObjectInResponseOrNotificationError);
             }
@@ -111,7 +111,7 @@ namespace StreamJsonRpc.Reflection
 
             ImmutableInterlocked.AddOrUpdate(
                 ref this.outboundRequestChannelMap,
-                this.RequestIdBeingSerialized.Value,
+                this.RequestIdBeingSerialized,
                 ImmutableList.Create(channel),
                 (key, value) => value.Add(channel));
 
@@ -129,7 +129,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The token to use as the RPC method argument; or <c>null</c> if <paramref name="reader"/> was <c>null</c>.</returns>
         /// <remarks>
         /// This method should only be called while serializing requests that include an ID (i.e. requests for which we expect a response).
-        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(long, bool)"/>.
+        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
         public int? GetToken(PipeReader reader) => this.GetToken(reader != null ? new DuplexPipe(reader) : null);
@@ -141,7 +141,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The token to use as the RPC method argument; or <c>null</c> if <paramref name="writer"/> was <c>null</c>.</returns>
         /// <remarks>
         /// This method should only be called while serializing requests that include an ID (i.e. requests for which we expect a response).
-        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(long, bool)"/>.
+        /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
         public int? GetToken(PipeWriter writer) => this.GetToken(writer != null ? new DuplexPipe(writer) : null);
@@ -163,7 +163,7 @@ namespace StreamJsonRpc.Reflection
                 return null;
             }
 
-            if (this.RequestIdBeingDeserialized is null)
+            if (this.RequestIdBeingDeserialized.IsEmpty)
             {
                 throw new NotSupportedException(Resources.MarshaledObjectInResponseOrNotificationError);
             }
@@ -232,7 +232,7 @@ namespace StreamJsonRpc.Reflection
         /// </summary>
         /// <param name="requestId">The ID of the request for which a response was sent.</param>
         /// <param name="successful">A value indicating whether the response represents a successful result (i.e. a <see cref="JsonRpcResult"/> instead of an <see cref="JsonRpcError"/>).</param>
-        public void OnResponseSent(object requestId, bool successful)
+        public void OnResponseSent(RequestId requestId, bool successful)
         {
             Verify.NotDisposed(this);
 
@@ -256,7 +256,7 @@ namespace StreamJsonRpc.Reflection
         /// </summary>
         /// <param name="requestId">The ID of the request for which a response was received.</param>
         /// <param name="successful">A value indicating whether the response represents a successful result (i.e. a <see cref="JsonRpcResult"/> instead of an <see cref="JsonRpcError"/>).</param>
-        public void OnResponseReceived(long requestId, bool successful)
+        public void OnResponseReceived(RequestId requestId, bool successful)
         {
             Verify.NotDisposed(this);
 

--- a/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
@@ -28,12 +28,12 @@ namespace StreamJsonRpc.Reflection
         /// <summary>
         /// Dictionary used to map the outbound request id to their progress id token so that the progress objects are cleaned after getting the final response.
         /// </summary>
-        private readonly Dictionary<long, long> requestProgressMap = new Dictionary<long, long>();
+        private readonly Dictionary<RequestId, long> requestProgressMap = new Dictionary<RequestId, long>();
 
         /// <summary>
         /// Dictionary used to map progress id token to its corresponding <see cref="ProgressParamInformation" /> instance containing the progress object and the necessary fields to report the results.
         /// </summary>
-        private readonly Dictionary<object, ProgressParamInformation> progressMap = new Dictionary<object, ProgressParamInformation>();
+        private readonly Dictionary<long, ProgressParamInformation> progressMap = new Dictionary<long, ProgressParamInformation>();
 
         /// <summary>
         /// Object used to lock the access to <see cref="requestProgressMap"/> and <see cref="progressMap"/>.
@@ -48,7 +48,7 @@ namespace StreamJsonRpc.Reflection
         /// <summary>
         /// Gets or Sets the id of the request currently being serialized so the converter can use it to create the request-progress map.
         /// </summary>
-        public long? RequestIdBeingSerialized { get; set; }
+        public RequestId RequestIdBeingSerialized { get; set; }
 
         /// <summary>
         /// Converts given <see cref="Type"/> to its <see cref="IProgress{T}"/> type.
@@ -96,7 +96,7 @@ namespace StreamJsonRpc.Reflection
         {
             Requires.NotNull(value, nameof(value));
 
-            if (this.RequestIdBeingSerialized == null)
+            if (this.RequestIdBeingSerialized.IsEmpty)
             {
                 throw new NotSupportedException(Resources.MarshaledObjectInResponseOrNotificationError);
             }
@@ -104,9 +104,9 @@ namespace StreamJsonRpc.Reflection
             lock (this.progressLock)
             {
                 long progressId = this.nextProgressId++;
-                this.requestProgressMap.Add(this.RequestIdBeingSerialized.Value, progressId);
+                this.requestProgressMap.Add(this.RequestIdBeingSerialized, progressId);
 
-                this.progressMap.Add((object)progressId, new ProgressParamInformation(value));
+                this.progressMap.Add(progressId, new ProgressParamInformation(value));
 
                 return progressId;
             }
@@ -116,7 +116,7 @@ namespace StreamJsonRpc.Reflection
         /// Call this method when a response is received to clear the objects associated with the request and avoid a memory leak.
         /// </summary>
         /// <param name="requestId">The id of the request whose associated objects need to be cleared.</param>
-        public void OnResponseReceived(long requestId)
+        public void OnResponseReceived(RequestId requestId)
         {
             lock (this.progressLock)
             {
@@ -134,7 +134,7 @@ namespace StreamJsonRpc.Reflection
         /// <param name="progressId">The key to obtain the <see cref="ProgressParamInformation"/> object from <see cref="progressMap"/>.</param>
         /// <param name="valueType">Output parameter to store the obtained <see cref="ProgressParamInformation"/> object.</param>
         /// <returns>true if the <see cref="ProgressParamInformation"/> object was found with the specified key; otherwise, false.</returns>
-        public bool TryGetProgressObject(object progressId, out ProgressParamInformation valueType)
+        public bool TryGetProgressObject(long progressId, out ProgressParamInformation valueType)
         {
             lock (this.progressLock)
             {

--- a/src/StreamJsonRpc/RequestId.cs
+++ b/src/StreamJsonRpc/RequestId.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Globalization;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents the ID of a request, whether it is a number of a string.
+    /// </summary>
+    [JsonConverter(typeof(RequestIdJsonConverter))]
+    public struct RequestId : IEquatable<RequestId>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestId"/> struct.
+        /// </summary>
+        /// <param name="id">The ID of the request.</param>
+        public RequestId(long id)
+        {
+            this.Number = id;
+            this.String = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestId"/> struct.
+        /// </summary>
+        /// <param name="id">The ID of the request.</param>
+        public RequestId(string id)
+        {
+            this.String = id;
+            this.Number = null;
+        }
+
+        /// <summary>
+        /// Gets an empty (absent) ID.
+        /// </summary>
+        public static RequestId NotSpecified => default;
+
+        /////// <summary>
+        /////// Creates a <see cref="RequestId"/> based on a <see cref="long"/> ID.
+        /////// </summary>
+        /////// <param name="id">The request ID.</param>
+        ////public static implicit operator RequestId(long id) => new RequestId(id);
+
+        /// <summary>
+        /// Gets the ID if it is a number.
+        /// </summary>
+        public long? Number { get; }
+
+        /// <summary>
+        /// Gets the ID if it is a string.
+        /// </summary>
+        public string String { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether both the <see cref="Number"/> and <see cref="String"/> properties are uninitialized.
+        /// </summary>
+        public bool IsEmpty => this.Number is null && this.String is null;
+
+        /// <summary>
+        /// Gets the ID as an object (whether it is a <see cref="long"/>, a <see cref="string"/> or null).
+        /// </summary>
+        internal object ObjectValue => (object)this.Number ?? this.String;
+
+        /// <summary>
+        /// Gets the ID if it is a number, or -1.
+        /// </summary>
+        internal long NumberIfPossibleForEvent => this.Number ?? -1;
+
+        /// <inheritdoc/>
+        public bool Equals(RequestId other) => this.Number == other.Number && this.String == other.String;
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => obj is RequestId other && this.Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => this.Number?.GetHashCode() ?? this.String?.GetHashCode() ?? 0;
+
+        /// <inheritdoc/>
+        public override string ToString() => this.Number?.ToString(CultureInfo.InvariantCulture) ?? this.String ?? "null";
+
+        internal static RequestId Parse(object value)
+        {
+            return
+                value is null ? default :
+                value is long l ? new RequestId(l) :
+                value is string s ? new RequestId(s) :
+                value is int i ? new RequestId(i) :
+                throw new JsonSerializationException("Unexpected type for id property: " + value.GetType().Name);
+        }
+    }
+}

--- a/src/StreamJsonRpc/RequestIdJsonConverter.cs
+++ b/src/StreamJsonRpc/RequestIdJsonConverter.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Newtonsoft.Json;
+
+    internal class RequestIdJsonConverter : JsonConverter<RequestId>
+    {
+        public override RequestId ReadJson(JsonReader reader, Type objectType, RequestId existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.Integer: return new RequestId(reader.Value is int i ? i : (long)reader.Value);
+                case JsonToken.String: return new RequestId((string)reader.Value);
+                default: throw new JsonSerializationException("Unexpected token type for request ID: " + reader.TokenType);
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, RequestId value, JsonSerializer serializer)
+        {
+            if (value.Number.HasValue)
+            {
+                writer.WriteValue(value.Number.Value);
+            }
+            else
+            {
+                writer.WriteValue(value.String);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a virtual method to the JsonRpc class that allows advanced scenarios that require a specially customized request ID format. It creates a `RequestId` struct to encapsulate the string-or-integer that serves as the request ID and removes all assumptions from our code that our own locally generated request ID is an integer.

This makes some breaking public API changes, which I would typically avoid within a major release. Feel free to push back if you think this is a problem. I am thinking it's not as I've limited them to just the very new formatter-helper classes which are only used within custom formatter implementations of which there are few or none outside this repo at this point AFAIK.

Closes #329