### PR TITLE
Reduce allocations for invocations that have non-cancelable tokens

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1401,7 +1401,7 @@ namespace StreamJsonRpc
 
             try
             {
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.DisconnectedToken))
+                using (CancellationTokenExtensions.CombinedCancellationToken cts = this.DisconnectedToken.CombineWith(cancellationToken))
                 {
                     if (!request.IsResponseExpected)
                     {


### PR DESCRIPTION
This change avoids an allocation if the `cancellationToken` passed in by the caller is the default `CancellationToken.None`.