### PR TITLE
Only complete PipeReader/PipeWriter after operations complete

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1394,12 +1394,12 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
-    public void Completion_BeforeListeningAndAfterDisposal()
+    public async Task Completion_BeforeListeningAndAfterDisposal()
     {
         var rpc = new JsonRpc(Stream.Null, Stream.Null);
         Task completion = rpc.Completion;
         rpc.Dispose();
-        Assert.True(completion.IsCompleted);
+        await completion.WithCancellation(this.TimeoutToken);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
@@ -207,7 +207,7 @@ public class StreamMessageHandlerTests : TestBase
         protected override ValueTask WriteCoreAsync(JsonRpcMessage content, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref this.WriteCoreCallCount);
-            return new ValueTask(this.WriteBlock.WaitAsync());
+            return new ValueTask(this.WriteBlock.WaitAsync(cancellationToken));
         }
     }
 

--- a/src/StreamJsonRpc/MessageHandlerBase.cs
+++ b/src/StreamJsonRpc/MessageHandlerBase.cs
@@ -41,7 +41,17 @@ namespace StreamJsonRpc
         private readonly object syncObject = new object();
 
         /// <summary>
-        /// A value indicating whether the <see cref="ReadAsync(CancellationToken)"/> method is in progress.
+        /// A signal that the last read operation has completed.
+        /// </summary>
+        private readonly AsyncManualResetEvent readingCompleted = new AsyncManualResetEvent();
+
+        /// <summary>
+        /// A signal that the last write operation has completed.
+        /// </summary>
+        private readonly AsyncManualResetEvent writingCompleted = new AsyncManualResetEvent();
+
+        /// <summary>
+        /// A value indicating whether the <see cref="ReadAsync(CancellationToken)"/> and/or <see cref="WriteAsync(JsonRpcMessage, CancellationToken)"/> methods are in progress.
         /// </summary>
         private MessageHandlerState state;
 
@@ -53,6 +63,10 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(formatter, nameof(formatter));
             this.Formatter = formatter;
+
+            Task readerDisposal = this.readingCompleted.WaitAsync().ContinueWith((_, s) => ((MessageHandlerBase)s).DisposeReader(), this, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+            Task writerDisposal = this.writingCompleted.WaitAsync().ContinueWith((_, s) => ((MessageHandlerBase)s).DisposeWriter(), this, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+            this.Completion = Task.WhenAll(readerDisposal, writerDisposal).ContinueWith((_, s) => ((MessageHandlerBase)s).Dispose(true), this, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         [Flags]
@@ -71,12 +85,7 @@ namespace StreamJsonRpc
             /// <summary>
             /// Indicates that the <see cref="ReadAsync(CancellationToken)"/> method is in running.
             /// </summary>
-            Reading = 0x4,
-
-            /// <summary>
-            /// Indicates that the <see cref="Dispose(bool)"/> method has been called.
-            /// </summary>
-            DisposeVirtualMethodInvoked = 0x10,
+            Reading = 0x2,
         }
 
         /// <summary>
@@ -101,6 +110,11 @@ namespace StreamJsonRpc
         /// Gets a token that is canceled when this instance is disposed.
         /// </summary>
         protected CancellationToken DisposalToken => this.disposalTokenSource.Token;
+
+        /// <summary>
+        /// Gets a task that completes when this instance has completed disposal.
+        /// </summary>
+        private Task Completion { get; }
 
         /// <summary>
         /// Reads a distinct and complete message from the transport, waiting for one if necessary.
@@ -140,9 +154,13 @@ namespace StreamJsonRpc
             }
             finally
             {
-                if (this.CheckIfDisposalAppropriate(MessageHandlerState.Reading))
+                lock (this.syncObject)
                 {
-                    this.Dispose(true);
+                    this.state &= ~MessageHandlerState.Reading;
+                    if (this.DisposalToken.IsCancellationRequested)
+                    {
+                        this.readingCompleted.Set();
+                    }
                 }
             }
         }
@@ -165,7 +183,6 @@ namespace StreamJsonRpc
             Verify.Operation(this.CanWrite, "No sending stream.");
             cancellationToken.ThrowIfCancellationRequested();
 
-            bool shouldDispose = false;
             try
             {
                 using (await this.sendingSemaphore.EnterAsync(cancellationToken).ConfigureAwait(false))
@@ -179,7 +196,14 @@ namespace StreamJsonRpc
                     }
                     finally
                     {
-                        shouldDispose = this.CheckIfDisposalAppropriate(MessageHandlerState.Writing);
+                        lock (this.syncObject)
+                        {
+                            this.state &= ~MessageHandlerState.Writing;
+                            if (this.DisposalToken.IsCancellationRequested)
+                            {
+                                this.writingCompleted.Set();
+                            }
+                        }
                     }
                 }
             }
@@ -189,38 +213,22 @@ namespace StreamJsonRpc
                 cancellationToken.ThrowIfCancellationRequested();
                 throw;
             }
-            finally
-            {
-                if (shouldDispose)
-                {
-                    this.Dispose(true);
-                }
-            }
         }
 
+#pragma warning disable VSTHRD002 // We synchronously block, but nothing here should ever require the main thread.
         /// <summary>
         /// Disposes this instance, and cancels any pending read or write operations.
         /// </summary>
-        public void Dispose()
-        {
-            if (!this.disposalTokenSource.IsCancellationRequested)
-            {
-                this.disposalTokenSource.Cancel();
-                if (this.CheckIfDisposalAppropriate())
-                {
-                    this.Dispose(true);
-                }
-            }
-        }
+        public void Dispose() => this.DisposeAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
 
         /// <summary>
-        /// Disposes resources allocated by this instance.
+        /// Disposes resources allocated by this instance that are common to both reading and writing.
         /// </summary>
         /// <param name="disposing"><c>true</c> when being disposed; <c>false</c> when being finalized.</param>
         /// <remarks>
         /// <para>
-        /// This method is guaranteed to not be called until any pending <see cref="WriteCoreAsync(JsonRpcMessage, CancellationToken)"/>
-        /// or <see cref="ReadCoreAsync(CancellationToken)"/> calls have completed.
+        /// This method is called by <see cref="DisposeAsync"/> after both <see cref="DisposeReader"/> and <see cref="DisposeWriter"/> have completed.
         /// </para>
         /// <para>Overrides of this method *should* call the base method as well.</para>
         /// </remarks>
@@ -228,9 +236,7 @@ namespace StreamJsonRpc
         {
             if (disposing)
             {
-                this.sendingSemaphore.Dispose();
                 (this.Formatter as IDisposable)?.Dispose();
-
                 GC.SuppressFinalize(this);
             }
         }
@@ -265,6 +271,59 @@ namespace StreamJsonRpc
         /// </returns>
         protected abstract ValueTask FlushAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Disposes this instance, and cancels any pending read or write operations.
+        /// </summary>
+        private protected virtual async Task DisposeAsync()
+        {
+            if (!this.disposalTokenSource.IsCancellationRequested)
+            {
+                this.disposalTokenSource.Cancel();
+
+                // Kick off disposal of reading and/or writing resources based on whether they're active right now or not.
+                // If they're active, they'll take care of themselves when they finish since we signaled disposal.
+                lock (this.syncObject)
+                {
+                    if (!this.state.HasFlag(MessageHandlerState.Reading))
+                    {
+                        this.readingCompleted.Set();
+                    }
+
+                    if (!this.state.HasFlag(MessageHandlerState.Writing))
+                    {
+                        this.writingCompleted.Set();
+                    }
+                }
+
+                // Wait for completion to actually complete, and re-throw any exceptions.
+                await this.Completion.ConfigureAwait(false);
+
+                this.Dispose(true);
+            }
+        }
+
+        /// <summary>
+        /// Disposes resources allocated by this instance that are used for reading (not writing).
+        /// </summary>
+        /// <remarks>
+        /// This method is called by <see cref="MessageHandlerBase"/> after the last read operation has completed.
+        /// </remarks>
+        private protected virtual void DisposeReader()
+        {
+        }
+
+        /// <summary>
+        /// Disposes resources allocated by this instance that are used for writing (not reading).
+        /// </summary>
+        /// <remarks>
+        /// This method is called by <see cref="MessageHandlerBase"/> after the last write operation has completed.
+        /// Overrides of this method *should* call the base method as well.
+        /// </remarks>
+        private protected virtual void DisposeWriter()
+        {
+            this.sendingSemaphore.Dispose();
+        }
+
         private void SetState(MessageHandlerState startingOperation)
         {
             lock (this.syncObject)
@@ -273,30 +332,6 @@ namespace StreamJsonRpc
                 MessageHandlerState state = this.state;
                 Assumes.False(state.HasFlag(startingOperation));
                 this.state |= startingOperation;
-            }
-        }
-
-        private bool CheckIfDisposalAppropriate(MessageHandlerState completedOperation = MessageHandlerState.None)
-        {
-            lock (this.syncObject)
-            {
-                // Revert the flag of our caller to indicate that writing or reading has finished, if applicable.
-                this.state &= ~completedOperation;
-
-                if (!this.DisposalToken.IsCancellationRequested)
-                {
-                    // Disposal hasn't been requested.
-                    return false;
-                }
-
-                // We should dispose ourselves if we have not done so and if reading and writing are not active.
-                bool shouldDispose = (this.state & (MessageHandlerState.Reading | MessageHandlerState.Writing | MessageHandlerState.DisposeVirtualMethodInvoked)) == MessageHandlerState.None;
-                if (shouldDispose)
-                {
-                    this.state |= MessageHandlerState.DisposeVirtualMethodInvoked;
-                }
-
-                return shouldDispose;
             }
         }
     }


### PR DESCRIPTION
We must not allow a race to exist between PipeReader/PipeWriter use and calling Complete() on them. This not only produces exceptions like the one in #350 but it opens up the possibility of accessing recycled buffers.

Fixes #350

This is the similar to #352 combined with #359, but targets v2.2 instead of v2.3.