### PR TITLE
Add built-in MessagePack formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Bonus features beyond the JSON-RPC spec include:
 1. Request cancellation
 1. .NET Events as notifications
 1. Dynamic client proxy generation
-1. Support for [compact binary serialization](doc/extensibility.md) (e.g. MessagePack)
+1. Support for [compact binary serialization](doc/extensibility.md) via MessagePack
+1. Pluggable architecture for custom message handling and formatting.
 
 Learn about the use cases for JSON-RPC and how to use this library from our [documentation](doc/index.md).
 

--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -71,31 +71,33 @@ so that it can be used with an `IJsonRpcMessageHandler` such as `HeaderDelimited
 text encoding to use at the transport level.
 Interop with other parties is most likely with a UTF-8 text encoding of JSON-RPC messages.
 
-StreamJsonRpc includes just one `IJsonRpcMessageFormatter` implementation:
+StreamJsonRpc includes the following `IJsonRpcMessageFormatter` implementations:
 
 1. `JsonMessageFormatter` - Uses Newtonsoft.Json to serialize each JSON-RPC message as actual JSON.
-    The text encoding is configurable via a proeprty. All RPC method parameters and return types must be serializable
-    by Newtonsoft.Json. You can leverage `JsonConverter` and add your custom converters via attributes or by
+    The text encoding is configurable via a property.
+    All RPC method parameters and return types must be serializable by Newtonsoft.Json.
+    You can leverage `JsonConverter` and add your custom converters via attributes or by
     contributing them to the `JsonMessageFormatter.JsonSerializer.Converters` collection.
+
+1. `MessagePackFormatter` - Uses the [MessagePack-CSharp][MessagePackLibrary] library to serialize each
+    JSON-RPC message using the very fast and compact binary [MessagePack format][MessagePackFormat].
+    All RPC method parameters and return types must be serializable by `IMessagePackFormatter<T>`.
+    You can contribute your own via `MessagePackFormatter.SetOptions(MessagePackSerializationOptions)`.
+    See alternative formatters below.
 
 ### Alternative formatters
 
 For performance reasons when both parties can agree, it may be appropriate to switch out the textual JSON
  representation for something that can be serialized faster and/or in a more compact format.
 
-The [MessagePack](https://msgpack.org/) protocol is a fast, binary serialization format that resembles the
+The [MessagePack format][MessagePackFormat] is a fast, binary serialization format that resembles the
 structure of JSON. It can be used as a substitute for JSON when both parties agree on the protocol for
 significant wins in terms of performance and payload size.
 
-We recommend the [MessagePack for C#](https://www.nuget.org/packages/messagepack) implementation of MessagePack
-because of its incredibly high serialization speed and more compact message sizes.
+Utilizing `MessagePack` for exchanging JSON-RPC messages is incredibly easy.
+Check out the `BasicJsonRpc` method in our [MessagePackFormatterTests][MessagePackUsage] class.
 
-Utilizing `MessagePack` for exchanging JSON-RPC messages is incredibly easy. Check out our sample
-[MessagePackFormatter][MessagePackFormatter] and a small [set of unit tests][MessagePackUsage] that demonstrate
-its usage. While the sample defines the `IJsonRpcMessageFormatter`-derived type that is implemented in terms of
-MessagePack, this class is not included in the StreamJsonRpc library, but you can use the sample as a starting
-point for using MessagePack with StreamJsonRpc in your application today.
-
-[MessagePackFormatter]: ../src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+[MessagePackLibrary]: https://github.com/neuecc/MessagePack-CSharp
 [MessagePackUsage]: ../src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+[MessagePackFormat]: https://msgpack.org/
 [spec]: https://www.jsonrpc.org/specification

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingJsonTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingJsonTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class DuplexPipeMarshalingJsonTests : DuplexPipeMarshalingTests
+{
+    public DuplexPipeMarshalingJsonTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new JsonMessageFormatter { MultiplexingStream = this.serverMx };
+        this.clientMessageFormatter = new JsonMessageFormatter { MultiplexingStream = this.clientMx };
+    }
+}

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingMessagePackTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingMessagePackTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class DuplexPipeMarshalingMessagePackTests : DuplexPipeMarshalingTests
+{
+    public DuplexPipeMarshalingMessagePackTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new MessagePackFormatter { MultiplexingStream = this.serverMx };
+        this.clientMessageFormatter = new MessagePackFormatter { MultiplexingStream = this.clientMx };
+    }
+}

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -75,8 +75,8 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 
         this.InitializeFormattersAndHandlers();
 
-        var serverHandler = new HeaderDelimitedMessageHandler(rpcServerStream, this.serverMessageFormatter);
-        var clientHandler = new HeaderDelimitedMessageHandler(rpcClientStream, this.clientMessageFormatter);
+        var serverHandler = new LengthHeaderMessageHandler(rpcServerStream, this.serverMessageFormatter);
+        var clientHandler = new LengthHeaderMessageHandler(rpcClientStream, this.clientMessageFormatter);
 
         this.serverRpc = new JsonRpc(serverHandler, this.server);
         this.clientRpc = new JsonRpc(clientHandler);

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -16,17 +16,19 @@ using StreamJsonRpc;
 using Xunit;
 using Xunit.Abstractions;
 
-public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
+public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 {
+    protected readonly Server server = new Server();
+    protected JsonRpc serverRpc;
+    protected IJsonRpcMessageFormatter serverMessageFormatter;
+    protected MultiplexingStream serverMx;
+
+    protected JsonRpc clientRpc;
+    protected IJsonRpcMessageFormatter clientMessageFormatter;
+    protected MultiplexingStream clientMx;
+
     private const string ExpectedFileName = "somefile.jpg";
     private static readonly byte[] MemoryBuffer = Enumerable.Range(1, 50).Select(i => (byte)i).ToArray();
-
-    private readonly Server server = new Server();
-    private JsonRpc serverRpc;
-    private MultiplexingStream serverMx;
-
-    private JsonRpc clientRpc;
-    private MultiplexingStream clientMx;
 
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
     public DuplexPipeMarshalingTests(ITestOutputHelper logger)
@@ -71,11 +73,10 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         MultiplexingStream.Channel rpcServerStream = rpcStreams[0];
         MultiplexingStream.Channel rpcClientStream = rpcStreams[1];
 
-        var serverFormatter = new JsonMessageFormatter { MultiplexingStream = this.serverMx };
-        var clientFormatter = new JsonMessageFormatter { MultiplexingStream = this.clientMx };
+        this.InitializeFormattersAndHandlers();
 
-        var serverHandler = new HeaderDelimitedMessageHandler(rpcServerStream, serverFormatter);
-        var clientHandler = new HeaderDelimitedMessageHandler(rpcClientStream, clientFormatter);
+        var serverHandler = new HeaderDelimitedMessageHandler(rpcServerStream, this.serverMessageFormatter);
+        var clientHandler = new HeaderDelimitedMessageHandler(rpcClientStream, this.clientMessageFormatter);
 
         this.serverRpc = new JsonRpc(serverHandler, this.server);
         this.clientRpc = new JsonRpc(clientHandler);
@@ -507,6 +508,8 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         pipePair.Item1.Input.Complete();
     }
 
+    protected abstract void InitializeFormattersAndHandlers();
+
     private static async Task TwoWayTalkAsync(IDuplexPipe pipe, bool writeOnOdd, CancellationToken cancellationToken)
     {
         for (int i = 0; i < 10; i++)
@@ -562,7 +565,7 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         Assert.True(isDisposed());
     }
 
-    private class ServerWithOverloads
+    protected class ServerWithOverloads
     {
         public void OverloadedMethod(bool foo, IDuplexPipe pipe, int[] values)
         {
@@ -579,7 +582,7 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         public void OverloadedMethod(bool foo, int value, string[] values) => Assert.NotNull(values);
     }
 
-    private class Server
+    protected class Server
     {
         internal Task? ChatLaterTask { get; private set; }
 
@@ -706,12 +709,12 @@ public class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         public object ReturnPipeAsObject() => FullDuplexStream.CreatePipePair().Item1;
     }
 
-    private class ServerWithIDuplexPipeReturningMethod
+    protected class ServerWithIDuplexPipeReturningMethod
     {
         public IDuplexPipe? MethodThatReturnsIDuplexPipe() => null;
     }
 
-    private class OneWayStreamWrapper : Stream
+    protected class OneWayStreamWrapper : Stream
     {
         private readonly Stream innerStream;
         private readonly bool canRead;

--- a/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
@@ -52,11 +52,11 @@ public class JsonRpcClient10InteropTests : InteropTestBase
     public async Task ClientRecognizesErrorWithNullResult()
     {
         var invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>("test");
-        dynamic request = await this.ReceiveAsync();
+        JToken request = await this.ReceiveAsync();
         const string expectedErrorMessage = "some result";
         this.Send(new
         {
-            id = request.id,
+            id = request["id"],
             result = (object?)null, // JSON-RPC 1.0 requires that result be specified and null if there is an error.
             error = new { message = expectedErrorMessage },
         });

--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -189,7 +189,12 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
 #pragma warning restore SA1139 // Use literal suffix notation instead of casting
         RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.MethodThatThrowsUnauthorizedAccessException)));
         Assert.Equal((int)JsonRpcErrorCode.InvocationError, exception.ErrorCode);
+
         var errorData = ((JToken?)exception.ErrorData)!.ToObject<CommonErrorData>();
+        Assert.NotNull(errorData.StackTrace);
+        Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
+
+        errorData = Assert.IsType<CommonErrorData>(exception.DeserializedErrorData);
         Assert.NotNull(errorData.StackTrace);
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
 using Xunit;
@@ -30,7 +31,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
     [Fact]
     public async Task ExceptionControllingErrorData()
     {
-        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowRemoteInvocationException)));
+        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowRemoteInvocationException))).WithCancellation(this.TimeoutToken);
 
         IDictionary<object, object>? data = (IDictionary<object, object>?)exception.ErrorData;
         object myCustomData = data!["myCustomData"];

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2158,6 +2158,7 @@ public abstract class JsonRpcTests : TestBase
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
     }
 
+    [DataContract]
     internal class InternalClass
     {
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -935,11 +935,9 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(12, sum);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_SendingExpectedObject()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
-
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>("test/MethodWithSingleObjectParameter", new XAndYFields { x = 2, y = 5 }, this.TimeoutToken);
         Assert.Equal(7, sum);
     }
@@ -950,11 +948,9 @@ public abstract class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(async () => await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithSingleObjectParameterWithoutDeserializationProperty), new XAndYFields { x = 2, y = 5 }, this.TimeoutToken));
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_ServerMethodExpectsObjectButSendingDifferentType()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
-
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>("test/MethodWithSingleObjectParameterVAndW", new XAndYFields { x = 2, y = 5 }, this.TimeoutToken);
 
         Assert.Equal(0, sum);
@@ -966,29 +962,23 @@ public abstract class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(async () => await this.clientRpc.InvokeWithParameterObjectAsync<int>("test/MethodWithObjectAndExtraParameters", new XAndYFields { x = 2, y = 5 }, this.TimeoutToken));
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_SendingExpectedObjectAndCancellationToken()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
-
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithSingleObjectParameterAndCancellationToken), new XAndYFields { x = 2, y = 5 }, this.TimeoutToken);
         Assert.Equal(7, sum);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_SendingExpectedObjectAndCancellationToken_InterfaceMethodAttributed()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
-
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(IServer.InstanceMethodWithSingleObjectParameterAndCancellationToken), new XAndYFields { x = 2, y = 5 }, this.TimeoutToken);
         Assert.Equal(7, sum);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_SendingWithProgressProperty()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
-
         int report = 0;
         var progress = new ProgressWithCompletion<int>(n => report += n);
 

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -291,17 +291,15 @@ public abstract class JsonRpcTests : TestBase
     [Trait("TestCategory", "FailsInCloudTest")] // Test showing unstability on Azure Pipelines, but always succeeds locally.
     public async Task InvokeWithProgressParameter_NoMemoryLeakConfirm()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
         Skip.If(IsRunningUnderLiveUnitTest);
         WeakReference weakRef = await this.InvokeWithProgressParameter_NoMemoryLeakConfirm_Helper();
         GC.Collect();
         Assert.False(weakRef.IsAlive);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task NotifyWithProgressParameter_NoMemoryLeakConfirm()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
         WeakReference weakRef = await this.NotifyAsyncWithProgressParameter_NoMemoryLeakConfirm_Helper();
         GC.Collect();
         Assert.False(weakRef.IsAlive);
@@ -861,11 +859,9 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(12, sum);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithParameterObject_ProgressParameter()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
-
         int report = 0;
         ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report = n);
 
@@ -877,11 +873,9 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(1, result);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithParameterObject_ProgressParameterMultipleRequests()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
-
         int report1 = 0;
         ProgressWithCompletion<int> progress1 = new ProgressWithCompletion<int>(n => report1 = n);
 
@@ -904,22 +898,18 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(3, report3);
     }
 
-    [SkippableFact]
-    public async Task InvokeWithParameterObject_InvalidParamMethod()
+    [Fact]
+    public async Task InvokeWithParameterObject_Progress_InvalidParamMethod()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
-
         int report = 0;
         ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report = n);
 
         await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithInvalidProgressParameter), new { p = progress }, this.TimeoutToken));
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithParameterObject_ProgressParameterAndFields()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
-
         int report = 0;
         ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report += n);
 
@@ -931,11 +921,9 @@ public abstract class JsonRpcTests : TestBase
         Assert.Equal(7, sum);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task InvokeWithParameterObject_ProgressAndDefaultParameters()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
-
         int report = 0;
         ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report += n);
 
@@ -999,7 +987,7 @@ public abstract class JsonRpcTests : TestBase
     [SkippableFact]
     public async Task InvokeWithSingleObjectParameter_SendingWithProgressProperty()
     {
-        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "IProgress<T> serialization is not supported for MessagePack");
+        Skip.If(this.clientMessageFormatter is MessagePackFormatter, "Single object deserialization is not supported for MessagePack");
 
         int report = 0;
         var progress = new ProgressWithCompletion<int>(n => report += n);

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -261,7 +261,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task CanCallAsyncMethodThatThrows()
     {
         RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrows)));
-        Assert.NotNull(exception.ErrorData);
+        Assert.IsType<CommonErrorData>(exception.DeserializedErrorData);
     }
 
     [Fact]
@@ -683,7 +683,7 @@ public abstract class JsonRpcTests : TestBase
             await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
             cts.Cancel();
             this.server.AllowServerMethodToReturn.Set();
-            string result = await invokeTask;
+            string result = await invokeTask.WithCancellation(this.TimeoutToken);
             Assert.Equal("a!", result);
         }
     }
@@ -699,7 +699,7 @@ public abstract class JsonRpcTests : TestBase
             this.server.AllowServerMethodToReturn.Set();
             try
             {
-                await invokeTask;
+                await invokeTask.WithCancellation(this.TimeoutToken);
                 Assert.False(true, "Expected exception not thrown.");
             }
             catch (RemoteInvocationException ex)

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -54,9 +54,7 @@ namespace StreamJsonRpc
                 RequestIdFormatter.Instance,
                 JsonRpcMessageFormatter.Instance,
                 JsonRpcRequestFormatter.Instance,
-                ProtocolJsonRpcRequestFormatter.Instance,
                 JsonRpcResultFormatter.Instance,
-                ProtocolJsonRpcResultFormatter.Instance,
                 JsonRpcErrorDetailFormatter.Instance,
             };
             var resolvers = new IFormatterResolver[]
@@ -228,9 +226,9 @@ namespace StreamJsonRpc
 
                 switch ((MessageSubTypes)reader.ReadInt32())
                 {
-                    case MessageSubTypes.Request: return options.Resolver.GetFormatterWithVerify<JsonRpcRequest>().Deserialize(ref reader, options);
-                    case MessageSubTypes.Result: return options.Resolver.GetFormatterWithVerify<JsonRpcResult>().Deserialize(ref reader, options);
-                    case MessageSubTypes.Error: return options.Resolver.GetFormatterWithVerify<JsonRpcError>().Deserialize(ref reader, options);
+                    case MessageSubTypes.Request: return options.Resolver.GetFormatterWithVerify<Protocol.JsonRpcRequest>().Deserialize(ref reader, options);
+                    case MessageSubTypes.Result: return options.Resolver.GetFormatterWithVerify<Protocol.JsonRpcResult>().Deserialize(ref reader, options);
+                    case MessageSubTypes.Error: return options.Resolver.GetFormatterWithVerify<Protocol.JsonRpcError>().Deserialize(ref reader, options);
                     case MessageSubTypes value: throw new NotSupportedException("Unexpected distinguishing subtype value: " + value);
                 }
             }
@@ -260,7 +258,7 @@ namespace StreamJsonRpc
             }
         }
 
-        private class JsonRpcRequestFormatter : IMessagePackFormatter<JsonRpcRequest>
+        private class JsonRpcRequestFormatter : IMessagePackFormatter<Protocol.JsonRpcRequest>
         {
             internal static readonly JsonRpcRequestFormatter Instance = new JsonRpcRequestFormatter();
 
@@ -268,7 +266,7 @@ namespace StreamJsonRpc
             {
             }
 
-            public JsonRpcRequest Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+            public Protocol.JsonRpcRequest Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
             {
                 int arrayLength = reader.ReadArrayHeader();
                 if (arrayLength != 4)
@@ -313,25 +311,6 @@ namespace StreamJsonRpc
                 return result;
             }
 
-            public void Serialize(ref MessagePackWriter writer, JsonRpcRequest value, MessagePackSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class ProtocolJsonRpcRequestFormatter : IMessagePackFormatter<Protocol.JsonRpcRequest>
-        {
-            internal static readonly ProtocolJsonRpcRequestFormatter Instance = new ProtocolJsonRpcRequestFormatter();
-
-            private ProtocolJsonRpcRequestFormatter()
-            {
-            }
-
-            public Protocol.JsonRpcRequest Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-
             public void Serialize(ref MessagePackWriter writer, Protocol.JsonRpcRequest value, MessagePackSerializerOptions options)
             {
                 writer.WriteArrayHeader(4);
@@ -342,7 +321,7 @@ namespace StreamJsonRpc
             }
         }
 
-        private class JsonRpcResultFormatter : IMessagePackFormatter<JsonRpcResult>
+        private class JsonRpcResultFormatter : IMessagePackFormatter<Protocol.JsonRpcResult>
         {
             internal static readonly JsonRpcResultFormatter Instance = new JsonRpcResultFormatter();
 
@@ -350,7 +329,7 @@ namespace StreamJsonRpc
             {
             }
 
-            public JsonRpcResult Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+            public Protocol.JsonRpcResult Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
             {
                 int arrayLength = reader.ReadArrayHeader();
                 if (arrayLength != 3)
@@ -364,25 +343,6 @@ namespace StreamJsonRpc
                     RequestId = options.Resolver.GetFormatterWithVerify<RequestId>().Deserialize(ref reader, options),
                     MsgPackResult = GetSliceForNextToken(ref reader),
                 };
-            }
-
-            public void Serialize(ref MessagePackWriter writer, JsonRpcResult value, MessagePackSerializerOptions options)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class ProtocolJsonRpcResultFormatter : IMessagePackFormatter<Protocol.JsonRpcResult>
-        {
-            internal static readonly ProtocolJsonRpcResultFormatter Instance = new ProtocolJsonRpcResultFormatter();
-
-            private ProtocolJsonRpcResultFormatter()
-            {
-            }
-
-            public Protocol.JsonRpcResult Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
-            {
-                throw new NotImplementedException();
             }
 
             public void Serialize(ref MessagePackWriter writer, Protocol.JsonRpcResult value, MessagePackSerializerOptions options)

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -410,10 +410,15 @@ namespace StreamJsonRpc
                 // If anyone asks us for an argument *after* we've been told deserialization is done, there's something very wrong.
                 Assumes.True(this.MsgPackNamedArguments != null || this.MsgPackPositionalArguments != null);
 
-                ReadOnlySequence<byte> msgpackArgument =
-                    this.MsgPackPositionalArguments != null && position >= 0 ? this.MsgPackPositionalArguments[position] :
-                    this.MsgPackNamedArguments != null && name is object ? this.MsgPackNamedArguments[name] :
-                    default;
+                ReadOnlySequence<byte> msgpackArgument = default;
+                if (position >= 0 && this.MsgPackPositionalArguments?.Count > position)
+                {
+                    msgpackArgument = this.MsgPackPositionalArguments[position];
+                }
+                else if (name is object && this.MsgPackNamedArguments != null)
+                {
+                    this.MsgPackNamedArguments.TryGetValue(name, out msgpackArgument);
+                }
 
                 if (msgpackArgument.IsEmpty)
                 {

--- a/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatter.cs
@@ -445,8 +445,9 @@ namespace StreamJsonRpc
                     value = MessagePackSerializer.Deserialize(typeHint ?? typeof(object), ref reader, StandardOptions);
                     return true;
                 }
-                catch (InvalidOperationException) // can be removed when https://github.com/neuecc/MessagePack-CSharp/pull/627 is applied
+                catch (InvalidOperationException)
                 {
+                    // This block can be removed when https://github.com/neuecc/MessagePack-CSharp/pull/627 is applied.
                     value = null;
                     return false;
                 }

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -34,9 +34,15 @@ public class MessagePackFormatterTests : TestBase
         var actual = this.Roundtrip(original);
         Assert.Equal(original.RequestId, actual.RequestId);
         Assert.Equal(original.Method, actual.Method);
-        Assert.Equal(original.ArgumentsList[0], actual.ArgumentsList?[0]);
-        Assert.Equal(original.ArgumentsList[1], actual.ArgumentsList?[1]);
-        Assert.Equal(((CustomType?)original.ArgumentsList[2])!.Age, ((CustomType?)actual.ArgumentsList![2])!.Age);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex(null, 0, typeof(int), out object? actualArg0));
+        Assert.Equal(original.ArgumentsList[0], actualArg0);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex(null, 1, typeof(string), out object? actualArg1));
+        Assert.Equal(original.ArgumentsList[1], actualArg1);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex(null, 2, typeof(CustomType), out object? actualArg2));
+        Assert.Equal(((CustomType?)original.ArgumentsList[2])!.Age, ((CustomType)actualArg2!).Age);
     }
 
     [Fact]
@@ -50,7 +56,7 @@ public class MessagePackFormatterTests : TestBase
 
         var actual = this.Roundtrip(original);
         Assert.Equal(original.RequestId, actual.RequestId);
-        Assert.Equal(((CustomType?)original.Result)!.Age, ((CustomType?)actual.Result)!.Age);
+        Assert.Equal(((CustomType?)original.Result)!.Age, actual.GetResult<CustomType>().Age);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -22,7 +22,7 @@ public class MessagePackFormatterTests : TestBase
     }
 
     [Fact]
-    public void JsonRpcRequest_ArgsArray()
+    public void JsonRpcRequest_PositionalArgs()
     {
         var original = new JsonRpcRequest
         {
@@ -43,6 +43,35 @@ public class MessagePackFormatterTests : TestBase
 
         Assert.True(actual.TryGetArgumentByNameOrIndex(null, 2, typeof(CustomType), out object? actualArg2));
         Assert.Equal(((CustomType?)original.ArgumentsList[2])!.Age, ((CustomType)actualArg2!).Age);
+    }
+
+    [Fact]
+    public void JsonRpcRequest_NamedArgs()
+    {
+        var original = new JsonRpcRequest
+        {
+            RequestId = new RequestId(5),
+            Method = "test",
+            NamedArguments = new Dictionary<string, object?>
+            {
+                { "Number", 5 },
+                { "Message", "hi" },
+                { "Custom", new CustomType { Age = 8 } },
+            },
+        };
+
+        var actual = this.Roundtrip(original);
+        Assert.Equal(original.RequestId, actual.RequestId);
+        Assert.Equal(original.Method, actual.Method);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex("Number", -1, typeof(int), out object? actualArg0));
+        Assert.Equal(original.NamedArguments["Number"], actualArg0);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex("Message", -1, typeof(string), out object? actualArg1));
+        Assert.Equal(original.NamedArguments["Message"], actualArg1);
+
+        Assert.True(actual.TryGetArgumentByNameOrIndex("Custom", -1, typeof(CustomType), out object? actualArg2));
+        Assert.Equal(((CustomType?)original.NamedArguments["Custom"])!.Age, ((CustomType)actualArg2!).Age);
     }
 
     [Fact]
@@ -77,7 +106,7 @@ public class MessagePackFormatterTests : TestBase
         Assert.Equal(original.RequestId, actual.RequestId);
         Assert.Equal(original.Error.Code, actual.Error!.Code);
         Assert.Equal(original.Error.Message, actual.Error.Message);
-        Assert.Equal(((CustomType)original.Error.Data).Age, ((CustomType?)actual.Error.Data)!.Age);
+        Assert.Equal(((CustomType)original.Error.Data).Age, actual.Error.GetData<CustomType>().Age);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -113,8 +113,8 @@ public class MessagePackFormatterTests : TestBase
     public async Task BasicJsonRpc()
     {
         var (clientStream, serverStream) = FullDuplexStream.CreatePair();
-        var clientFormatter = new MessagePackFormatter(compress: false);
-        var serverFormatter = new MessagePackFormatter(compress: false);
+        var clientFormatter = new MessagePackFormatter();
+        var serverFormatter = new MessagePackFormatter();
 
         var clientHandler = new LengthHeaderMessageHandler(clientStream.UsePipe(), clientFormatter);
         var serverHandler = new LengthHeaderMessageHandler(serverStream.UsePipe(), serverFormatter);

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -141,7 +141,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInArray()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalArg = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalRequest = new JsonRpcRequest
         {
@@ -159,7 +159,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_AnonymousType()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new { Prop1 = 3, Prop2 = 5 };
         var originalRequest = new JsonRpcRequest
         {
@@ -177,7 +177,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_DataContractObject()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new DataContractWithSubsetOfMembersIncluded { ExcludedField = "A", ExcludedProperty = "B", IncludedField = "C", IncludedProperty = "D" };
         var originalRequest = new JsonRpcRequest
         {
@@ -197,7 +197,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_NonDataContractObject()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new NonDataContractWithExcludedMembers { ExcludedField = "A", ExcludedProperty = "B", InternalField = "C", InternalProperty = "D", PublicField = "E", PublicProperty = "F" };
         var originalRequest = new JsonRpcRequest
         {
@@ -233,7 +233,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_Result()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalResultValue = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalResult = new JsonRpcResult
         {
@@ -249,7 +249,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_ErrorData()
     {
-        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
+        this.formatter.SetMessagePackSerializerOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalErrorData = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalError = new JsonRpcError
         {

--- a/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -141,7 +141,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInArray()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new CustomFormatter());
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalArg = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalRequest = new JsonRpcRequest
         {
@@ -159,7 +159,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_AnonymousType()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance });
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new { Prop1 = 3, Prop2 = 5 };
         var originalRequest = new JsonRpcRequest
         {
@@ -177,7 +177,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_DataContractObject()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance });
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new DataContractWithSubsetOfMembersIncluded { ExcludedField = "A", ExcludedProperty = "B", IncludedField = "C", IncludedProperty = "D" };
         var originalRequest = new JsonRpcRequest
         {
@@ -197,7 +197,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_RequestArgInNamedArgs_NonDataContractObject()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance });
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new IMessagePackFormatter[] { new CustomFormatter() }, new IFormatterResolver[] { BuiltinResolver.Instance })));
         var originalArg = new NonDataContractWithExcludedMembers { ExcludedField = "A", ExcludedProperty = "B", InternalField = "C", InternalProperty = "D", PublicField = "E", PublicProperty = "F" };
         var originalRequest = new JsonRpcRequest
         {
@@ -233,7 +233,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_Result()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new CustomFormatter());
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalResultValue = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalResult = new JsonRpcResult
         {
@@ -249,7 +249,7 @@ public class MessagePackFormatterTests : TestBase
     [Fact]
     public void Resolver_ErrorData()
     {
-        this.formatter.Resolver = CompositeResolver.Create(new CustomFormatter());
+        this.formatter.SetOptions(MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(new CustomFormatter())));
         var originalErrorData = new TypeRequiringCustomFormatter { Prop1 = 3, Prop2 = 5 };
         var originalError = new JsonRpcError
         {

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
-    <PackageReference Include="MessagePack" Version="2.0.171-beta" />
+    <PackageReference Include="MessagePack" Version="2.0.204-beta" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.0.171-beta" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -18,8 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
-    <PackageReference Include="MessagePack" Version="2.0.221-beta" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.0.221-beta" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
-    <PackageReference Include="MessagePack" Version="2.0.204-beta" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.0.171-beta" PrivateAssets="all" />
+    <PackageReference Include="MessagePack" Version="2.0.221-beta" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.0.221-beta" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -32,6 +32,21 @@ namespace StreamJsonRpc
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
         /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="errorCode">The value of the error.code field in the response.</param>
+        /// <param name="errorData">The value of the error.data field in the response.</param>
+        /// <param name="deserializedErrorData">The value of the error.data field in the response, deserialized according to <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.</param>
+        public RemoteInvocationException(string? message, int errorCode, object? errorData, object? deserializedErrorData)
+            : base(message)
+        {
+            this.ErrorCode = errorCode;
+            this.ErrorData = errorData;
+            this.DeserializedErrorData = deserializedErrorData;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
+        /// </summary>
         /// <param name="info">Serialization info.</param>
         /// <param name="context">Streaming context.</param>
         protected RemoteInvocationException(
@@ -59,5 +74,14 @@ namespace StreamJsonRpc
         /// Deserializing this or casting this object to <see cref="CommonErrorData"/> <em>may</em> succeed, and be a means to extract useful error information.
         /// </remarks>
         public object? ErrorData { get; }
+
+        /// <summary>
+        /// Gets the <c>error.data</c> value in the error response, if one was provided.
+        /// </summary>
+        /// <remarks>
+        /// The type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
+        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
+        /// </remarks>
+        public object? DeserializedErrorData { get; }
     }
 }

--- a/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
@@ -6,7 +6,7 @@ namespace StreamJsonRpc
     using System;
 
     /// <summary>
-    /// Base exception class for any exception that happens while receiving an JSON RPC communication.
+    /// Base exception class for any exception that happens while receiving an JSON-RPC communication.
     /// </summary>
     [System.Serializable]
     public abstract class RemoteRpcException : Exception

--- a/src/StreamJsonRpc/Exceptions/UnrecognizedJsonRpcMessageException.cs
+++ b/src/StreamJsonRpc/Exceptions/UnrecognizedJsonRpcMessageException.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// An exception thrown when an incoming JSON-RPC message could not be recognized as conforming to any known JSON-RPC message.
+    /// </summary>
+    [Serializable]
+    public class UnrecognizedJsonRpcMessageException : RemoteRpcException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnrecognizedJsonRpcMessageException"/> class.
+        /// </summary>
+        public UnrecognizedJsonRpcMessageException()
+            : base(Resources.UnrecognizableMessage)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnrecognizedJsonRpcMessageException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public UnrecognizedJsonRpcMessageException(string? message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnrecognizedJsonRpcMessageException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public UnrecognizedJsonRpcMessageException(string? message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnrecognizedJsonRpcMessageException"/> class.
+        /// </summary>
+        /// <param name="info">Serialization info.</param>
+        /// <param name="context">Streaming context.</param>
+        public UnrecognizedJsonRpcMessageException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/StreamJsonRpc/IJsonRpcMessageBufferManager.cs
+++ b/src/StreamJsonRpc/IJsonRpcMessageBufferManager.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An interface that may be found on an <see cref="IJsonRpcMessageHandler"/> object to request notification of when
+    /// message deserialization is completed so buffers can be released or safely recycled.
+    /// </summary>
+    public interface IJsonRpcMessageBufferManager
+    {
+        /// <summary>
+        /// Notifies that it is safe to free buffers held to deserialize the payload for a message because all deserialization attempts are completed.
+        /// </summary>
+        /// <param name="message">The message whose deserialization is done.</param>
+        /// <remarks>
+        /// Implementations are guaranteed to be called at least once for each message when deserialization is completed.
+        /// This method will be invoked before the next request to <see cref="IJsonRpcMessageHandler.ReadAsync(System.Threading.CancellationToken)"/>.
+        /// </remarks>
+        void DeserializationComplete(JsonRpcMessage message);
+    }
+}

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -603,7 +603,7 @@ namespace StreamJsonRpc
                     if (parameters[0].ParameterType == typeof(JToken))
                     {
                         var obj = new JObject();
-                        foreach (KeyValuePair<string, object> property in this.NamedArguments)
+                        foreach (KeyValuePair<string, object?> property in this.NamedArguments)
                         {
                             obj.Add(new JProperty(property.Key, property.Value));
                         }
@@ -619,7 +619,7 @@ namespace StreamJsonRpc
                         if (attribute?.UseSingleObjectParameterDeserialization ?? false)
                         {
                             var obj = new JObject();
-                            foreach (KeyValuePair<string, object> property in this.NamedArguments)
+                            foreach (KeyValuePair<string, object?> property in this.NamedArguments)
                             {
                                 obj.Add(new JProperty(property.Key, property.Value));
                             }

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -760,7 +760,7 @@ namespace StreamJsonRpc
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
             {
-                object progressId = this.formatter.formatterProgressTracker.GetTokenForProgress(value);
+                long progressId = this.formatter.formatterProgressTracker.GetTokenForProgress(value);
                 writer.WriteValue(progressId);
             }
         }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2168,7 +2168,7 @@ namespace StreamJsonRpc
                         {
                             resultMessage.SetExpectedResultType(data.ExpectedResultType);
                         }
-                        else if (rpc is JsonRpcError errorMessage && errorMessage.Error?.Data != null)
+                        else if (rpc is JsonRpcError errorMessage && errorMessage.Error != null)
                         {
                             Type? errorType = this.GetErrorDetailsDataType(errorMessage);
                             if (errorType != null)

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2255,7 +2255,7 @@ namespace StreamJsonRpc
                     var cancellationMessage = new JsonRpcRequest
                     {
                         Method = CancelRequestSpecialMethod,
-                        NamedArguments = new Dictionary<string, object>
+                        NamedArguments = new Dictionary<string, object?>
                         {
                             { "id", requestId },
                         },

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -20,7 +20,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets the detail about the error.
         /// </summary>
-        [DataMember(Name = "error", Order = 1, IsRequired = true)]
+        [DataMember(Name = "error", Order = 2, IsRequired = true)]
         public ErrorDetail? Error { get; set; }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
-        [DataMember(Name = "id", Order = 2, IsRequired = true, EmitDefaultValue = true)]
+        [DataMember(Name = "id", Order = 1, IsRequired = true, EmitDefaultValue = true)]
         public RequestId RequestId { get; set; }
 
         /// <summary>

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -89,6 +89,26 @@ namespace StreamJsonRpc.Protocol
             /// </summary>
             [DataMember(Name = "data", Order = 2, IsRequired = false)]
             public object? Data { get; set; }
+
+            /// <summary>
+            /// Gets the value of the <see cref="Data"/>, taking into account any possible type coercion.
+            /// </summary>
+            /// <typeparam name="T">The <see cref="Type"/> to coerce the <see cref="Data"/> to.</typeparam>
+            /// <returns>The result.</returns>
+            /// <remarks>
+            /// Derived types may override this method in order to deserialize the <see cref="Data"/>
+            /// such that it can be assignable to <typeparamref name="T"/>.
+            /// </remarks>
+            public virtual T GetData<T>() => (T)this.Data!;
+
+            /// <summary>
+            /// Provides a hint for a deferred deserialization of the <see cref="Data"/> value as to the type
+            /// argument that will be used when calling <see cref="GetData{T}"/> later.
+            /// </summary>
+            /// <param name="dataType">The type that will be used as the generic type argument to <see cref="GetData{T}"/>.</param>
+            protected internal virtual void SetExpectedResultType(Type dataType)
+            {
+            }
         }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -7,6 +7,7 @@ namespace StreamJsonRpc.Protocol
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Runtime.Serialization;
+    using Microsoft;
     using Newtonsoft.Json.Linq;
 
     /// <summary>
@@ -95,18 +96,33 @@ namespace StreamJsonRpc.Protocol
             /// </summary>
             /// <typeparam name="T">The <see cref="Type"/> to coerce the <see cref="Data"/> to.</typeparam>
             /// <returns>The result.</returns>
+            public T GetData<T>() => (T)this.GetData(typeof(T))!;
+
+            /// <summary>
+            /// Gets the value of the <see cref="Data"/>, taking into account any possible type coercion.
+            /// </summary>
+            /// <param name="dataType">The <see cref="Type"/> to deserialize the data object to.</param>
+            /// <returns>The result.</returns>
+            /// <exception cref="ArgumentNullException">Thrown if <paramref name="dataType"/> is null.</exception>
             /// <remarks>
             /// Derived types may override this method in order to deserialize the <see cref="Data"/>
-            /// such that it can be assignable to <typeparamref name="T"/>.
+            /// such that it can be assignable to <paramref name="dataType"/>.
+            /// The default implementation does nothing to convert the <see cref="Data"/> object to match <paramref name="dataType"/>, but simply returns the existing object.
+            /// Derived types should *not* throw exceptions. This is a best effort method and returning null or some other value is preferable to throwing
+            /// as it can disrupt an existing exception handling path.
             /// </remarks>
-            public virtual T GetData<T>() => (T)this.Data!;
+            public virtual object? GetData(Type dataType)
+            {
+                Requires.NotNull(dataType, nameof(dataType));
+                return this.Data;
+            }
 
             /// <summary>
             /// Provides a hint for a deferred deserialization of the <see cref="Data"/> value as to the type
             /// argument that will be used when calling <see cref="GetData{T}"/> later.
             /// </summary>
             /// <param name="dataType">The type that will be used as the generic type argument to <see cref="GetData{T}"/>.</param>
-            protected internal virtual void SetExpectedResultType(Type dataType)
+            protected internal virtual void SetExpectedDataType(Type dataType)
             {
             }
         }

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -103,9 +103,9 @@ namespace StreamJsonRpc.Protocol
         /// Gets or sets the dictionary of named arguments, if applicable.
         /// </summary>
         [IgnoreDataMember]
-        public IReadOnlyDictionary<string, object>? NamedArguments
+        public IReadOnlyDictionary<string, object?>? NamedArguments
         {
-            get => this.Arguments as IReadOnlyDictionary<string, object>;
+            get => this.Arguments as IReadOnlyDictionary<string, object?>;
             set => this.Arguments = value;
         }
 

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -47,7 +47,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets the name of the method to be invoked.
         /// </summary>
-        [DataMember(Name = "method", Order = 1, IsRequired = true)]
+        [DataMember(Name = "method", Order = 2, IsRequired = true)]
         public string? Method { get; set; }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace StreamJsonRpc.Protocol
         /// and the value is the argument, or an array of <see cref="object"/>.
         /// If neither of these, <see cref="ArgumentCount"/> and <see cref="TryGetArgumentByNameOrIndex(string, int, Type, out object)"/> should be overridden.
         /// </value>
-        [DataMember(Name = "params", Order = 2, IsRequired = false, EmitDefaultValue = false)]
+        [DataMember(Name = "params", Order = 3, IsRequired = false, EmitDefaultValue = false)]
         public object? Arguments { get; set; }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
-        [DataMember(Name = "id", Order = 3, IsRequired = false, EmitDefaultValue = false)]
+        [DataMember(Name = "id", Order = 1, IsRequired = false, EmitDefaultValue = false)]
         public RequestId RequestId { get; set; }
 
         /// <summary>

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -97,7 +97,7 @@ namespace StreamJsonRpc.Protocol
         /// Gets the number of arguments supplied in the request.
         /// </summary>
         [IgnoreDataMember]
-        public int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsList?.Count ?? 0;
+        public virtual int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsList?.Count ?? 0;
 
         /// <summary>
         /// Gets or sets the dictionary of named arguments, if applicable.

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -64,5 +64,14 @@ namespace StreamJsonRpc.Protocol
                 new JProperty("id", this.RequestId.ObjectValue),
             }.ToString(Newtonsoft.Json.Formatting.None);
         }
+
+        /// <summary>
+        /// Provides a hint for a deferred deserialization of the <see cref="Result"/> value as to the type
+        /// argument that will be used when calling <see cref="GetResult{T}"/> later.
+        /// </summary>
+        /// <param name="resultType">The type that will be used as the generic type argument to <see cref="GetResult{T}"/>.</param>
+        protected internal virtual void SetExpectedResultType(Type resultType)
+        {
+        }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -19,7 +19,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets the value of the result of an invocation, if any.
         /// </summary>
-        [DataMember(Name = "result", Order = 1, IsRequired = true, EmitDefaultValue = true)]
+        [DataMember(Name = "result", Order = 2, IsRequired = true, EmitDefaultValue = true)]
         public object? Result { get; set; }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace StreamJsonRpc.Protocol
         /// <summary>
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
-        [DataMember(Name = "id", Order = 2, IsRequired = true)]
+        [DataMember(Name = "id", Order = 1, IsRequired = true)]
         public RequestId RequestId { get; set; }
 
         /// <summary>

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -6,7 +6,7 @@ namespace StreamJsonRpc.Reflection
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO.Pipelines;
     using System.Threading;
     using System.Threading.Tasks;
@@ -92,6 +92,7 @@ namespace StreamJsonRpc.Reflection
         /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public int? GetToken(IDuplexPipe? duplexPipe)
         {
             Verify.NotDisposed(this);
@@ -132,6 +133,7 @@ namespace StreamJsonRpc.Reflection
         /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public int? GetToken(PipeReader? reader) => this.GetToken(reader != null ? new DuplexPipe(reader) : null);
 
         /// <summary>
@@ -144,6 +146,7 @@ namespace StreamJsonRpc.Reflection
         /// When the response is received, a call should always be made to <see cref="OnResponseReceived(RequestId, bool)"/>.
         /// </remarks>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public int? GetToken(PipeWriter? writer) => this.GetToken(writer != null ? new DuplexPipe(writer) : null);
 
         /// <summary>
@@ -153,6 +156,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The <see cref="IDuplexPipe"/> from the token; or <c>null</c> if <paramref name="token"/> was <c>null</c>.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the token does not match up with an out of band channel offered by the client.</exception>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public IDuplexPipe? GetPipe(int? token)
         {
             Verify.NotDisposed(this);
@@ -195,6 +199,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The <see cref="PipeReader"/> from the token; or <c>null</c> if <paramref name="token"/> was <c>null</c>.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the token does not match up with an out of band channel offered by the client.</exception>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public PipeReader? GetPipeReader(int? token)
         {
             IDuplexPipe? duplexPipe = this.GetPipe(token);
@@ -214,6 +219,7 @@ namespace StreamJsonRpc.Reflection
         /// <returns>The <see cref="PipeWriter"/> from the token; or <c>null</c> if <paramref name="token"/> was <c>null</c>.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the token does not match up with an out of band channel offered by the client.</exception>
         /// <exception cref="NotSupportedException">Thrown if no <see cref="MultiplexingStream"/> was provided to the constructor.</exception>
+        [return: NotNullIfNotNull("token")]
         public PipeWriter? GetPipeWriter(int? token)
         {
             IDuplexPipe? duplexPipe = this.GetPipe(token);

--- a/src/StreamJsonRpc/RequestId.cs
+++ b/src/StreamJsonRpc/RequestId.cs
@@ -4,6 +4,7 @@
 namespace StreamJsonRpc
 {
     using System;
+    using System.Diagnostics;
     using System.Globalization;
     using Newtonsoft.Json;
 
@@ -47,11 +48,13 @@ namespace StreamJsonRpc
         /// <summary>
         /// Gets the ID if it is a number.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public long? Number { get; }
 
         /// <summary>
         /// Gets the ID if it is a string.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public string? String { get; }
 
         /// <summary>
@@ -67,6 +70,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Gets the ID if it is a number, or -1.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal long NumberIfPossibleForEvent => this.Number ?? -1;
 
         /// <inheritdoc/>

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -502,6 +502,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types..
+        /// </summary>
+        internal static string UnrecognizableMessage {
+            get {
+                return ResourceManager.GetString("UnrecognizableMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Incoming JSON-RPC message did not conform to a recognized pattern..
         /// </summary>
         internal static string UnrecognizedIncomingJsonRpc {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -105,14 +105,14 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
     <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -283,6 +283,9 @@
   <data name="UnexpectedTokenReadingHeader" xml:space="preserve">
     <value>Unexpected token '{0}' while parsing header.</value>
     <comment>{0} is the token, which is typically a single character.</comment>
+  </data>
+  <data name="UnrecognizableMessage" xml:space="preserve">
+    <value>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</value>
   </data>
   <data name="UnrecognizedIncomingJsonRpc" xml:space="preserve">
     <value>Incoming JSON-RPC message did not conform to a recognized pattern.</value>

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -16,6 +16,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="MessagePack" Version="2.0.221-beta-gfcaaed3da4" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.0.221-beta-gfcaaed3da4" PrivateAssets="all" />
     <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" /> -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.16" />

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -16,8 +16,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.0.221-beta-gfcaaed3da4" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.0.221-beta-gfcaaed3da4" PrivateAssets="all" />
+    <PackageReference Include="MessagePack" Version="2.0.221-beta" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.0.221-beta" PrivateAssets="all" />
     <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" /> -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.16" />

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -224,7 +224,6 @@ StreamJsonRpc.Protocol.JsonRpcMessage.JsonRpcMessage() -> void
 StreamJsonRpc.Protocol.JsonRpcMessage.Version.get -> string
 StreamJsonRpc.Protocol.JsonRpcMessage.Version.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest
-StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentCount.get -> int
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult.MissingArgument = 3 -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult.ParameterArgumentCountMismatch = 1 -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
@@ -289,6 +288,7 @@ override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(StreamJsonRpc.Prot
 override sealed StreamJsonRpc.PipeMessageHandler.WriteCoreAsync(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual StreamJsonRpc.JsonRpc.CreateErrorDetails(StreamJsonRpc.Protocol.JsonRpcRequest request, System.Exception exception) -> StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail
 virtual StreamJsonRpc.MessageHandlerBase.Dispose(bool disposing) -> void
+virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentCount.get -> int
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetArgumentByNameOrIndex(string name, int position, System.Type typeHint, out object value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetTypedArguments(System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters, System.Span<object> typedArguments) -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 virtual StreamJsonRpc.Protocol.JsonRpcResult.GetResult<T>() -> T

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -38,4 +38,6 @@ virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedResultType(System.Type dataType) -> void
 virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -9,8 +9,11 @@ StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
 StreamJsonRpc.MessagePackFormatter
 StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
+StreamJsonRpc.MessagePackFormatter.Dispose() -> void
 StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
 StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
+StreamJsonRpc.MessagePackFormatter.MultiplexingStream.get -> Nerdbank.Streams.MultiplexingStream
+StreamJsonRpc.MessagePackFormatter.MultiplexingStream.set -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -12,7 +12,7 @@ StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<b
 StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
 StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
-StreamJsonRpc.MessagePackFormatter.SetOptions(MessagePack.MessagePackSerializerOptions options) -> void
+StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
@@ -36,6 +36,11 @@ StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
 StreamJsonRpc.RequestId.RequestId(string id) -> void
 StreamJsonRpc.RequestId.String.get -> string
+StreamJsonRpc.UnrecognizedJsonRpcMessageException
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException() -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message) -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -7,6 +7,12 @@ StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, strin
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.MessagePackFormatter
+StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
+StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
+StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
+StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
+StreamJsonRpc.MessagePackFormatter.SetOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+StreamJsonRpc.IJsonRpcMessageBufferManager
+StreamJsonRpc.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, object target, StreamJsonRpc.JsonRpcMethodAttribute methodRpcSettings) -> void
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
@@ -36,3 +38,4 @@ virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
+virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, strin
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.get -> StreamJsonRpc.RequestId
@@ -20,6 +21,8 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSeriali
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
+StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
+StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
 StreamJsonRpc.RequestId
 StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
@@ -35,9 +38,10 @@ override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
+virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedResultType(System.Type dataType) -> void
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData(System.Type dataType) -> object
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedDataType(System.Type dataType) -> void
 virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -224,7 +224,6 @@ StreamJsonRpc.Protocol.JsonRpcMessage.JsonRpcMessage() -> void
 StreamJsonRpc.Protocol.JsonRpcMessage.Version.get -> string
 StreamJsonRpc.Protocol.JsonRpcMessage.Version.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest
-StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentCount.get -> int
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult.MissingArgument = 3 -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult.ParameterArgumentCountMismatch = 1 -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
@@ -289,6 +288,7 @@ override StreamJsonRpc.WebSocketMessageHandler.WriteCoreAsync(StreamJsonRpc.Prot
 override sealed StreamJsonRpc.PipeMessageHandler.WriteCoreAsync(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual StreamJsonRpc.JsonRpc.CreateErrorDetails(StreamJsonRpc.Protocol.JsonRpcRequest request, System.Exception exception) -> StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail
 virtual StreamJsonRpc.MessageHandlerBase.Dispose(bool disposing) -> void
+virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentCount.get -> int
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetArgumentByNameOrIndex(string name, int position, System.Type typeHint, out object value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.TryGetTypedArguments(System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters, System.Span<object> typedArguments) -> StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentMatchResult
 virtual StreamJsonRpc.Protocol.JsonRpcResult.GetResult<T>() -> T

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -38,4 +38,6 @@ virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedResultType(System.Type dataType) -> void
 virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,8 +9,11 @@ StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
 StreamJsonRpc.MessagePackFormatter
 StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
+StreamJsonRpc.MessagePackFormatter.Dispose() -> void
 StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
 StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
+StreamJsonRpc.MessagePackFormatter.MultiplexingStream.get -> Nerdbank.Streams.MultiplexingStream
+StreamJsonRpc.MessagePackFormatter.MultiplexingStream.set -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -12,7 +12,7 @@ StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<b
 StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
 StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
-StreamJsonRpc.MessagePackFormatter.SetOptions(MessagePack.MessagePackSerializerOptions options) -> void
+StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
@@ -36,6 +36,11 @@ StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
 StreamJsonRpc.RequestId.RequestId(string id) -> void
 StreamJsonRpc.RequestId.String.get -> string
+StreamJsonRpc.UnrecognizedJsonRpcMessageException
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException() -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message) -> void
+StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,12 @@ StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, strin
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.MessagePackFormatter
+StreamJsonRpc.MessagePackFormatter.Deserialize(System.Buffers.ReadOnlySequence<byte> contentBuffer) -> StreamJsonRpc.Protocol.JsonRpcMessage
+StreamJsonRpc.MessagePackFormatter.GetJsonText(StreamJsonRpc.Protocol.JsonRpcMessage message) -> object
+StreamJsonRpc.MessagePackFormatter.MessagePackFormatter() -> void
+StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
+StreamJsonRpc.MessagePackFormatter.SetOptions(MessagePack.MessagePackSerializerOptions options) -> void
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+StreamJsonRpc.IJsonRpcMessageBufferManager
+StreamJsonRpc.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, object target, StreamJsonRpc.JsonRpcMethodAttribute methodRpcSettings) -> void
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
@@ -36,3 +38,4 @@ virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
+virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, strin
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.get -> StreamJsonRpc.RequestId
@@ -20,6 +21,8 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSeriali
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
+StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
+StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
 StreamJsonRpc.RequestId
 StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
@@ -35,9 +38,10 @@ override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
+virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
-virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedResultType(System.Type dataType) -> void
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData(System.Type dataType) -> object
+virtual StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.SetExpectedDataType(System.Type dataType) -> void
 virtual StreamJsonRpc.Protocol.JsonRpcResult.SetExpectedResultType(System.Type resultType) -> void

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Neočekávaná chyba při zpracování zprávy JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Příchozí zpráva JSON-RPC se neshoduje s rozpoznávaným vzorkem.</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Unerwarteter Fehler beim Verarbeiten der JSON-RPC-Nachricht: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Die eingehende JSON-RPC-Nachricht entsprach keinem bekannten Muster.</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Mensaje de error inesperado al procesar JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">El mensaje de JSON-RPC entrante no se ajusta a un patrón reconocido.</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Erreur inattendue durant le traitement du message JSON-RPC : {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Le message JSON-RPC entrant n’est pas conforme à un modèle reconnu.</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Errore imprevisto durante l'elaborazione del messaggio JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Il messaggio JSON-RPC in arrivo non è conforme a un modello riconosciuto.</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -112,6 +112,11 @@
         <target state="translated">JSON-RPC メッセージの処理で予期しないエラーが発生しました: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">JSON-RPC 受信メッセージは、認識されるパターンに準拠していません。</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -112,6 +112,11 @@
         <target state="translated">JSON-RPC 메시지를 처리하는 동안 예기치 않은 오류 발생: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">들어오는 JSON-RPC 메시지가 인식되는 패턴과 일치하지 않습니다.</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Nieoczekiwany błąd podczas przetwarzania komunikatu JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Przychodzący komunikat JSON-RPC nie był zgodny z rozpoznanym wzorcem.</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Erro inesperado ao processar a mensagem JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">A mensagem JSON-RPC de entrada não estava em conformidade com um padrão reconhecido.</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Непредвиденная ошибка при обработке сообщения JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Входящее сообщение JSON-RPC не соответствует распознанному шаблону.</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">JSON-RPC iletisi işlenirken beklenmeyen hata oluştu: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">Gelen JSON-RPC iletisi tanınan bir desene uymuyor.</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="translated">处理 JSON-RPC 消息时出现意外错误: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">传入的 JSON-RPC 消息不符合已识别的模式。</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -112,6 +112,11 @@
         <target state="translated">處理 JSON-RPC 訊息時發生未預期的錯誤: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnrecognizableMessage">
+        <source>Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</source>
+        <target state="new">Unable to recognize incoming message as one the JSON-RPC 2.0 defined message types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedIncomingJsonRpc" translate="yes" xml:space="preserve">
         <source>Incoming JSON-RPC message did not conform to a recognized pattern.</source>
         <target state="translated">內送 JSON-RPC 訊息不符合已識別的模式。</target>


### PR DESCRIPTION
Adds `MessagePackFormatter` as a built-in formatter, and enhances the tests to cover more scenarios than the sample had.

Closes #365 