### PR TITLE
Fix bugs in IProgress<T> handling

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -991,6 +991,65 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task InvokeWithArrayParameters_SendingWithProgressProperty()
+    {
+        int report = 0;
+        var progress = new ProgressWithCompletion<int>(n => report += n);
+
+        int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new XAndYFieldsWithProgress { x = 2, y = 5, p = progress } }, this.TimeoutToken);
+
+        await progress.WaitAsync();
+
+        Assert.Equal(1, report);
+        Assert.Equal(7, sum);
+    }
+
+    [Fact]
+    public async Task InvokeWithArrayParameters_SendingWithProgressConcreteTypeProperty()
+    {
+        int report = 0;
+        var progress = new ProgressWithCompletion<int>(n => report += n);
+
+        int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new StrongTypedProgressType { x = 2, y = 5, p = progress } }, this.TimeoutToken);
+
+        await progress.WaitAsync();
+
+        Assert.Equal(1, report);
+        Assert.Equal(7, sum);
+    }
+
+    [Fact]
+    public async Task InvokeWithArrayParameters_SendingWithNullProgressProperty()
+    {
+        int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new XAndYFieldsWithProgress { x = 2, y = 5 } }, this.TimeoutToken);
+        Assert.Equal(7, sum);
+    }
+
+    [Fact]
+    public async Task InvokeWithArrayParameters_SendingWithNullProgressConcreteTypeProperty()
+    {
+        int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new StrongTypedProgressType { x = 2, y = 5 } }, this.TimeoutToken);
+        Assert.Equal(7, sum);
+    }
+
+    [Fact]
+    public async Task Invoke_MultipleProgressArguments()
+    {
+        bool progress1Reported = false;
+        bool progress2Reported = false;
+
+        var progress1 = new ProgressWithCompletion<int>(n => progress1Reported = true);
+        var progress2 = new ProgressWithCompletion<int>(n => progress2Reported = true);
+
+        await this.clientRpc.InvokeWithCancellationAsync(nameof(Server.MethodWithMultipleProgressParameters), new object[] { progress1, progress2 }, this.TimeoutToken);
+
+        await progress1.WaitAsync(this.TimeoutToken);
+        Assert.True(progress1Reported);
+        await progress2.WaitAsync(this.TimeoutToken);
+        Assert.True(progress2Reported);
+    }
+
+    [Fact]
     public async Task CanInvokeServerMethodWithNoParameterPassedAsArray()
     {
         string result1 = await this.clientRpc.InvokeAsync<string>(nameof(Server.TestParameter));
@@ -1736,7 +1795,7 @@ public abstract class JsonRpcTests : TestBase
         [JsonRpcMethod("test/MethodWithSingleObjectParameterWithProgress", UseSingleObjectParameterDeserialization = true)]
         public static int MethodWithSingleObjectParameterWithProgress(XAndYFieldsWithProgress fields)
         {
-            fields.p!.Report(fields.x + fields.y);
+            fields.p?.Report(fields.x + fields.y);
             return fields.x + fields.y;
         }
 
@@ -1760,22 +1819,22 @@ public abstract class JsonRpcTests : TestBase
             return sum;
         }
 
-        public static int MethodWithProgressArrayParameter(params IProgress<int>[] progressArray)
-        {
-            int report = 0;
-
-            foreach (IProgress<int> progress in progressArray)
-            {
-                report++;
-                progress.Report(report);
-            }
-
-            return 0;
-        }
-
         public static int MethodWithInvalidProgressParameter(Progress<int> p)
         {
             return 1;
+        }
+
+        public int MethodWithParameterContainingIProgress(XAndYFieldsWithProgress p)
+        {
+            int sum = p.x + p.y;
+            p.p?.Report(1);
+            return sum;
+        }
+
+        public void MethodWithMultipleProgressParameters(IProgress<int> progress1, IProgress<int> progress2)
+        {
+            progress1.Report(1);
+            progress2.Report(2);
         }
 
         public int InstanceMethodWithSingleObjectParameterAndCancellationToken(XAndYFields fields, CancellationToken token)
@@ -2133,6 +2192,20 @@ public abstract class JsonRpcTests : TestBase
         public int y;
         [DataMember]
         public IProgress<int>? p;
+#pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+    }
+
+    [DataContract]
+    public class StrongTypedProgressType
+    {
+        // We disable SA1307 because we have to match the members of XAndYFieldsWithProgress exactly.
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+        [DataMember]
+        public int x;
+        [DataMember]
+        public int y;
+        [DataMember]
+        public ProgressWithCompletion<int>? p;
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
     }
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -742,6 +742,9 @@ namespace StreamJsonRpc
             public void Return(T[] array) => this.arrayPool.Return(array);
         }
 
+        /// <summary>
+        /// Converts an instance of <see cref="IProgress{T}"/> to a progress token.
+        /// </summary>
         private class JsonProgressClientConverter : JsonConverter
         {
             private readonly JsonMessageFormatter formatter;
@@ -765,6 +768,9 @@ namespace StreamJsonRpc
             }
         }
 
+        /// <summary>
+        /// Converts a progress token to an <see cref="IProgress{T}"/>.
+        /// </summary>
         private class JsonProgressServerConverter : JsonConverter
         {
             private readonly JsonMessageFormatter formatter;

--- a/src/StreamJsonRpc/Reflection/TrackerHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/TrackerHelpers.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft;
+
+    /// <summary>
+    /// Helper methods for message formatter tracker classes.
+    /// </summary>
+    /// <typeparam name="TInterface">A generic interface. We only need the generic type definition, but since C# doesn't let us pass in open generic types, use <see cref="int"/> as a generic type argument.</typeparam>
+    internal static class TrackerHelpers<TInterface>
+        where TInterface : class
+    {
+        /// <summary>
+        /// Dictionary to record the calculation made in <see cref="FindInterfaceImplementedBy(Type)"/> to obtain the <typeparamref name="TInterface"/> type from a given <see cref="Type"/>.
+        /// </summary>
+        private static readonly Dictionary<Type, Type> TypeToImplementedInterfaceMap = new Dictionary<Type, Type>();
+
+        /// <summary>
+        /// Gets the generic type definition for whatever type parameter was given by <typeparamref name="TInterface" />.
+        /// </summary>
+        private static readonly Type InterfaceGenericTypeDefinition = typeof(TInterface).GetGenericTypeDefinition();
+
+        /// <summary>
+        /// Extracts some interface from a given <see cref="Type"/>, if it is implemented.
+        /// </summary>
+        /// <param name="objectType">The type which may implement <typeparamref name="TInterface"/>.</param>
+        /// <returns>The <typeparamref name="TInterface"/> type from given <see cref="Type"/> object, or <c>null</c>  if no such interface was found in the given <paramref name="objectType" />.</returns>
+        internal static Type? FindInterfaceImplementedBy(Type objectType)
+        {
+            Requires.NotNull(objectType, nameof(objectType));
+
+            if (objectType.IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(InterfaceGenericTypeDefinition))
+            {
+                return objectType;
+            }
+
+            Type? interfaceFromType;
+            lock (TypeToImplementedInterfaceMap)
+            {
+                if (!TypeToImplementedInterfaceMap.TryGetValue(objectType, out interfaceFromType))
+                {
+                    interfaceFromType = objectType.GetTypeInfo().GetInterfaces().FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == InterfaceGenericTypeDefinition);
+                    TypeToImplementedInterfaceMap.Add(objectType, interfaceFromType);
+                }
+            }
+
+            return interfaceFromType;
+        }
+
+        /// <summary>
+        /// Checks if a given <see cref="Type"/> implements <typeparamref name="TInterface"/>.
+        /// </summary>
+        /// <param name="objectType">The type which may implement <typeparamref name="TInterface"/>.</param>
+        /// <returns>true if given <see cref="Type"/> implements <typeparamref name="TInterface"/>; otherwise, false.</returns>
+        internal static bool CanSerialize(Type objectType) => FindInterfaceImplementedBy(objectType) != null;
+
+        /// <summary>
+        /// Checks whether the given type is an interface compatible with <typeparamref name="TInterface"/>.
+        /// </summary>
+        /// <param name="objectType">The type that may be deserialized.</param>
+        /// <returns><c>true</c> if <paramref name="objectType"/> is a closed generic form of <typeparamref name="TInterface"/>; <c>false</c> otherwise.</returns>
+        internal static bool CanDeserialize(Type objectType) => IsActualInterfaceMatch(objectType);
+
+        /// <summary>
+        /// Checks whether the given type is an interface compatible with <typeparamref name="TInterface"/>.
+        /// </summary>
+        /// <param name="objectType">The type that may be deserialized.</param>
+        /// <returns><c>true</c> if <paramref name="objectType"/> is a closed generic form of <typeparamref name="TInterface"/>; <c>false</c> otherwise.</returns>
+        internal static bool IsActualInterfaceMatch(Type objectType) => Requires.NotNull(objectType, nameof(objectType)).IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(InterfaceGenericTypeDefinition);
+    }
+}

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -331,7 +331,6 @@ StreamJsonRpc.Reflection.MessageFormatterProgressTracker.GetTokenForProgress(obj
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.InvokeReport(object typedValue) -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ProgressParamInformation(object progressObject) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ValueType.get -> System.Type
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.set -> void
 const StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressRequestSpecialMethod = "$/progress" -> string

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -331,7 +331,6 @@ StreamJsonRpc.Reflection.MessageFormatterProgressTracker.GetTokenForProgress(obj
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.InvokeReport(object typedValue) -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ProgressParamInformation(object progressObject) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ValueType.get -> System.Type
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.set -> void
 const StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressRequestSpecialMethod = "$/progress" -> string


### PR DESCRIPTION
* Fixes #371: Missing support for multiple `IProgress<T>` parameters on a single method
* Fix issues with IProgress<T> handling in the MessagePackFormatter, including around storing and reusing a buffer after it has been recycled by making a *copy* of the token we need to use later.
* Fixes MessagePackFormatter serialization of `IProgress<T>` instances when the concrete type is known statically due to being a member on a data contract class.

Also extract some general helper methods to another class so we can reuse it in IAsyncEnumerable<T> support.

