### PR TITLE
Add IAsyncEnumerable<T> support

### DIFF
--- a/doc/asyncenumerable.md
+++ b/doc/asyncenumerable.md
@@ -1,0 +1,349 @@
+# `IAsyncEnumerable<T>` support
+
+StreamJsonRpc allows transmitting `IAsyncEnumerable<T>` objects in requests and response messages.
+This "Just Works" but some important considerations should be taken.
+
+This allows for the transmission of expensive or large sequences/collections while only paying
+the generation cost for the values actually enumerated by the receiver.
+It also helps to keep individual JSON-RPC message sizes small by breaking up a large collection result
+across several messages.
+
+## Use cases
+
+It is recommended to use strongly-typed proxies (such as [dynamic proxies](dynamicproxy.md))
+to invoke RPC methods that include `IAsyncEnumerable<T>` types.
+This helps ensure that the expected parameter and return types are agreed upon by both sides.
+
+### C# 8 async iterator methods
+
+A server method which returns an async enumeration may be defined as:
+
+```cs
+IAsyncEnumerable<int> GenerateNumbersAsync(CancellationToken cancellationToken);
+```
+
+The server method may be implemented in C# 8 as:
+
+```cs
+public async IAsyncEnumerable<int> GenerateNumbersAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+{
+    for (int i = 1; i <= 20; i++)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return i;
+    }
+}
+```
+
+Notice how it is not necessary (or desirable) to wrap the resulting `IAsyncEnumerable<T>` in a `Task<T>` object.
+
+C# 8 lets you consume such an async enumerable using `await foreach`:
+
+```cs
+await foreach (int number in this.clientProxy.GenerateNumbersAsync(token))
+{
+    Console.WriteLine(number);
+}
+```
+
+All the foregoing is simple C# 8 async enumerable syntax and use cases.
+StreamJsonRpc lets you use this natural syntax over an RPC connection.
+
+### Transmitting large collections
+
+Most C# iterator methods return `IEnumerable<T>` and produce values synchronously.
+An async iterator method returns `IAsyncEnumerable<T>` and is useful when producing values is expensive
+or requires I/O to fetch or produce those values.
+
+When you have an existing collection of items or you can produce items cheaply, sending them as
+a collection or `IEnumerable<T>` over an RPC connection results in the entire collection being sent
+as a JSON array in a single JSON-RPC message. For a large collection this may be undesirable
+when it makes the message so large that other messages can't be sent in the meantime, or when
+the client is likely to only want a subset of that collection.
+
+Exposing any collection or `IEnumerable<T>` as an `IAsyncEnumerable<T>` changes the RPC behavior
+from transmitting the entire collection at once to the streaming, client-pull model so only items
+the receiver wants are produced and transmitted. This can be done using our
+`IEnumerable<T>.AsAsyncEnumerable()` extension method, like so:
+
+```cs
+IList<int> allMyData; // set elsewhere
+await clientProxy.SendCollectedDataAsync(allMyData.AsAsyncEnumerable());
+```
+
+This extension method also works when *returning* collections as the result of an RPC call.
+
+The receiver should always enter an `await foreach` loop over this enumeration or manually get the iterator
+and dispose it in order to avoid a resource leak on the sender.
+
+## Resource leaks concerns
+
+The most important consideration is that of resource leaks. The party that transmits the `IAsyncEnumerable<T>`
+has to reserve resources to respond to remote requests for more elements. This memory will be held until
+the receiving party has called `IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken)` and
+`IAsyncEnumerator<T>.DisposeAsync` on the result. When using C# 8 to `foreach` over the async enumerable,
+this disposal pattern is guaranteed to happen. For example, this is the preferred usage pattern:
+
+```cs
+await foreach(int item in clientProxy.GetLongListAsync(cancellationToken))
+{
+    Console.WriteLine(item);
+}
+```
+
+But take care if enumerating manually to ensure you set
+up a `try/finally` block pattern that ensures it will be disposed. For example:
+
+```cs
+IAsyncEnumerable<int> enumerable = clientProxy.GetLongListAsync(cancellationToken);
+IAsyncEnumerator<int> enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+try
+{
+    while(await enumerator.MoveNextAsync())
+    {
+        Console.WriteLine(enumerator.Current);
+    }
+}
+finally
+{
+    await enumerator.DisposeAsync();
+}
+```
+
+All memory is automatically released when a JSON-RPC connection ends.
+When sent within an argument, any RPC-related resources for an `IAsyncEnumerable<T>` are
+automatically released by the client if the server responds with an error.
+`IAsyncEnumerable<T>` may *not* be sent in notifications to avoid leaks when the server
+does not handle the notification and send the disposal message.
+
+### Type mismatches
+
+Another resource leak danger can come from a mismatch between the transmitter and the receiver
+with regard to expected types. The server may send an `IAsyncEnumerable<T>` as a result for example,
+but if the client is only expecting a `void` or `object` result then the necessary client proxy for
+`IAsyncEnumerable<T>` will not be produced, making disposal difficult or impossible and leaving a leak
+on the server.
+
+Always make sure the remote party is expecting the `IAsyncEnumerable<T>` when you send one.
+
+## Comparison with `IProgress<T>`
+
+StreamJsonRpc also supports [`IProgress<T>` support](progresssupport.md) parameters.
+When a server method wants to return streaming results, accepting an `IProgress<T>` argument
+and returning `IAsyncEnumerable<T>` are valid options. To choose, review these design considerations:
+
+| Area | `IProgress<T>` | `IAsyncEnumerable<T>` |
+|--|--|--|
+| Pattern | Typically an optional argument for a caller to pass into a method and is used to get details on how the operation is progressing so that a human operator gets visual feedback on a long-running operation. | Typically used as a required argument or return type to provide data that the caller is expected to process to be functionally complete.
+| Placement | Parameter or member of object used as a parameter. | Parameter, return type, or member of an object used as one.
+| Lifetime | Works until the RPC method has completed, or the connection drops. | Works until disposed, or the connection drops.
+| Resource leak risk | Resources are automatically released at the completion of the RPC method. | Resources leak unless the `IAsyncEnumerator<T>.DisposeAsync()` method is consistently called.
+| Push vs. pull | Uses a "push" model where the callee sets the pace of updates. The client can only stop these updates by cancelling the original request. | Uses a "pull" model, so the server only calculates and sends data as the client needs it. The client can pause or even break out of enumeration at any time.
+| Chattiness | Sends each report in its own message. | Supports batching values together.
+| Server utilization | Server never waits for client before continuing its work. | Server only computes values when client asks for them, or when configured to "read ahead" for faster response times to client.
+
+## Performance tuning
+
+The `IAsyncEnumerator<T>` interface is defined assuming that every single value produced may be acquired asynchronously.
+Thus an RPC implementation of this feature might be that every request for a value results in an RPC call to request
+that value. Such a design would minimize memory consumption and cost of generating values unnecessarily,
+but would be particularly noisy on the network and performance would suffer on high latency connections.
+
+To improve performance across a network, this behavior can be modified:
+
+1. **Batching**: When the consumer requests a value from the generator, the server may respond
+   with the next several values in the same response message in order to reduce the number
+   of round-trips the client must make while enumerating the sequence.
+   This improves performance when network latency is significant.
+1. **Read ahead**: The generator will do work to produce the next value(s) _before_ receiving
+   the consumer's request for them. This allows for the possibility that the server is processing
+   the data while the last value(s) are in transit to the client or being processed by the client.
+   This improves performance when the time to generate the values is significant.
+
+The above optimizations are configured individually and may be used in combination.
+
+To accomplish this, we define these properties which tune the RPC bridge for async enumerables:
+
+```cs
+public class JsonRpcEnumerableSettings
+{
+    /// <summary>
+    /// Gets or sets the maximum number of elements to read ahead and cache from the generator in anticipation of the consumer requesting those values.
+    /// </summary>
+    public int MaxReadAhead { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum number of elements to obtain from the generator before sending a batch of values to the consumer.
+    /// </summary>
+    public int MinBatchSize { get; set; } = 1;
+}
+```
+
+The default values for these properties will result in the same behavior as one would observe
+with `IAsyncEnumerable<T>` without any RPC: one value is produced or consumed at a time.
+Individual services may choose based on expected use cases and performance costs to change these values
+to improve the user experience.
+
+To apply customized settings to an `IAsyncEnumerable<T>`, the generator should use our `WithJsonRpcSettings`
+decorator extension method and provide the resulting value as the enumerable object.
+For example given method `GenerateNumbersCoreAsync()` which returns an `IAsyncEnumerable<int>` object,
+an RPC method can expose its result with custom RPC settings like this:
+
+```cs
+public IAsyncEnumerable<int> GenerateNumbersAsync(CancellationToken cancellationToken)
+{
+    return this.GenerateNumbersCoreAsync(cancellationToken)
+        .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = 10 });
+}
+```
+
+A batch size of 10 with the default `MaxReadAhead` value of `0` means the server will not produce any values
+until the client requests them, but when the client requests them, the client will get 10 or the rest of the
+sequence, whichever is fewer.
+
+Suppose `MaxReadAhead = 15` and `MinBatchSize = 10`. After the client calls `GenerateNumbersAsync` but before
+it asks for the first element in the sequence, the server is already generating values till it fills a cache
+of 15. When the client request comes in for the first value(s), the server will wait till at least 10 items have
+ been produced before returning any to the client. If more than 10 were cached (e.g. the server was able to
+ produce all 15 as part of "read ahead"), the client will get all that are cached. After the client's request
+ is fulfilled, the read ahead server will continue generating items till the read ahead cache is full, in
+ preparation for the next client request.
+
+In short: `MinBatchSize` guarantees a minimum number of values the server will send to the client except where
+the sequence is finished, and `MaxReadAhead` is how many values may be produced on the server in anticipation
+of the next request from the client for more values.
+
+The state machine and any cached values are released from the generator when the `IAsyncEnumerator<T>` is disposed.
+
+Customized settings must be applied at the *generator* side. They are ignored if applied to the consumer side.
+If the consumer is better positioned to determine the value of these settings, it may pass the values for
+these settings to the generator for use in decorating the generator's object. For example, a server method
+might be implemented like this:
+
+```cs
+public IAsyncEnumerable<int> GetNumbersAsync(int batchSize)
+    => this.GetNumbersCoreAsync().WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize });
+```
+
+The above delegates to an C# iterator method, but decorates the result with a batch size determined by the client.
+
+## Protocol
+
+This section is primarily for JSON-RPC library authors that want to interop with StreamJsonRpc's
+async enumerable feature.
+
+### Originating message
+
+A JSON-RPC message that carries an `IAsyncEnumerator<T>` provides a token to the enumerator
+so that the message receiver can use this token to request values from or dispose the remote enumerator.
+This token may be any valid JSON token except `null`:
+
+A result that returns an `IAsyncEnumerable<T>` would look something like this:
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 1,
+   "result": "enum-handle"
+}
+```
+
+A request that includes an `IAsyncEnumerable<T>` as a method argument might look like this:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "FooAsync",
+    "params": [
+        "hi",
+        "enum-handle"
+    ]
+}
+```
+
+An `IAsyncEnumerable<T>` might also appear as a property of an object that is included in the return value
+or method argument:
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 1,
+   "result": {
+       "enumerable": "enum-handle",
+       "count": 10
+   }
+}
+```
+
+A client should not send an `IAsyncEnumerable<T>` object in a notification, since that would lead to
+a memory leak on the client if the server does not handle a particular method or throws before it
+could process the enumerable.
+
+### Consumer request for values
+
+A request from the consumer to the producer for (more) value(s) is done via a standard JSON-RPC
+request method call with `$/enumerator/next` as the method name and one argument that carries
+the enumerator token. When using named arguments this is named `token`.
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 2,
+   "method": "$/enumerator/next",
+   "params": { "token": "enum-handle" }
+}
+```
+
+or:
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 2,
+   "method": "$/enumerator/next",
+   "params": [ "enum-handle" ]
+}
+```
+
+### Producer's response with values
+
+A response with value(s) from the producer always comes as an object that contains an array of values
+(even if only one element is provided) and a boolean indicating whether the last value has been provided:
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 2,
+   "result": {
+      "values": [ 1, 2, 3 ],
+      "finished": false
+   }
+}
+```
+
+Note the `finished` property is a hint from the producer for when the last value has been returned.
+The server *may* not know that the last value has been returned and should specify `false` unless it is sure
+the last value has been produced.
+
+The client *may* ask for more values without regard to the `finished` property, but if `finished: true`
+the client may optimize to not ask for more values but instead go directly to dispose of the enumerator.
+
+The server should never return an empty array of values unless the last value in the sequence has already
+been returned to the client.
+
+### Consumer disposes enumerator
+
+The consumer always notifies the producer when the local enumerator proxy is disposed
+by invoking the `$/enumerator/dispose` method.
+The arguments follow the same schema as the `$/enumerator/next` method.
+This *may* be a notification.
+
+```json
+{
+   "jsonrpc": "2.0",
+   "method": "$/enumerator/dispose",
+   "params": { "token": "enum-handle" },
+}
+```

--- a/doc/dynamicproxy.md
+++ b/doc/dynamicproxy.md
@@ -16,7 +16,7 @@ A proxy can only be dynamically generated for an interface that meets these requ
 1. Is public
 1. No properties
 1. No generic methods
-1. All methods return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>`
+1. All methods return `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`, or `IAsyncEnumerable<T>`
 1. All events are typed with `EventHandler` or `EventHandler<T>`
 1. Methods *may* accept a `CancellationToken` as the last parameter.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,7 +12,10 @@ The rest of our documentation are organized around use case.
 1. [Test your code](testing.md)
 1. [Write resilient code](resiliency.md)
 1. [Remote Targets](remotetargets.md)
-1. [Passing `Stream`/`IDuplexPipe` around](oob_streams.md)
+1. Passing around
+   1. [`Stream`/`IDuplexPipe`](oob_streams.md)
+   1. [`IProgress<T>`](progresssupport.md)
+   1. [`IAsyncEnumerable<T>`](asyncenumerable.md)
 1. [Troubleshoot](troubleshooting.md)
 
 See [full samples](https://github.com/AArnott/StreamJsonRpc.Sample) demonstrating two processes

--- a/src/StreamJsonRpc.Tests/AsyncEnumerableJsonTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableJsonTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class AsyncEnumerableJsonTests : AsyncEnumerableTests
+{
+    public AsyncEnumerableJsonTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new JsonMessageFormatter();
+        this.clientMessageFormatter = new JsonMessageFormatter();
+    }
+}

--- a/src/StreamJsonRpc.Tests/AsyncEnumerableMessagePackTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableMessagePackTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class AsyncEnumerableMessagePackTests : AsyncEnumerableTests
+{
+    public AsyncEnumerableMessagePackTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        this.serverMessageFormatter = new MessagePackFormatter();
+        this.clientMessageFormatter = new MessagePackFormatter();
+    }
+}

--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -1,0 +1,445 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
+{
+    protected readonly Server server = new Server();
+    protected JsonRpc serverRpc;
+    protected IJsonRpcMessageFormatter serverMessageFormatter;
+
+    protected Lazy<IServer> clientProxy;
+    protected JsonRpc clientRpc;
+    protected IJsonRpcMessageFormatter clientMessageFormatter;
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+    protected AsyncEnumerableTests(ITestOutputHelper logger)
+        : base(logger)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+    {
+    }
+
+    /// <summary>
+    /// This interface should NOT be implemented by <see cref="Server"/>,
+    /// since the server implements the one method on this interface with a return type of Task{T}
+    /// but we want the client proxy to NOT be that.
+    /// </summary>
+    protected interface IServer2
+    {
+        IAsyncEnumerable<int> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken);
+    }
+
+    protected interface IServer
+    {
+        IAsyncEnumerable<int> GetNumbersInBatchesAsync(CancellationToken cancellationToken);
+
+        IAsyncEnumerable<int> GetNumbersWithReadAheadAsync(CancellationToken cancellationToken);
+
+        IAsyncEnumerable<int> GetNumbersAsync(CancellationToken cancellationToken);
+
+        IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemAsync(CancellationToken cancellationToken);
+
+        Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken);
+
+        Task<CompoundEnumerableResult> GetNumbersAndMetadataAsync(CancellationToken cancellationToken);
+
+        Task PassInNumbersAsync(IAsyncEnumerable<int> numbers, CancellationToken cancellationToken);
+    }
+
+    public Task InitializeAsync()
+    {
+        Tuple<Nerdbank.FullDuplexStream, Nerdbank.FullDuplexStream> streams = Nerdbank.FullDuplexStream.CreateStreams();
+
+        this.InitializeFormattersAndHandlers();
+
+        var serverHandler = new LengthHeaderMessageHandler(streams.Item1.UsePipe(), this.serverMessageFormatter);
+        var clientHandler = new LengthHeaderMessageHandler(streams.Item2.UsePipe(), this.clientMessageFormatter);
+
+        this.serverRpc = new JsonRpc(serverHandler, this.server);
+        this.clientRpc = new JsonRpc(clientHandler);
+
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Information);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Information);
+
+        this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+
+        this.serverRpc.StartListening();
+        this.clientRpc.StartListening();
+
+        this.clientProxy = new Lazy<IServer>(() => this.clientRpc.Attach<IServer>());
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        this.serverRpc.Dispose();
+        this.clientRpc.Dispose();
+
+        if (this.serverRpc.Completion.IsFaulted)
+        {
+            this.Logger.WriteLine("Server faulted with: " + this.serverRpc.Completion.Exception);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task GetIAsyncEnumerableAsReturnType(bool useProxy)
+    {
+        int realizedValuesCount = 0;
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.GetNumbersAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.GetNumbersAsync), cancellationToken: this.TimeoutToken);
+        await foreach (int number in enumerable)
+        {
+            realizedValuesCount++;
+            this.Logger.WriteLine(number.ToString(CultureInfo.InvariantCulture));
+        }
+
+        Assert.Equal(Server.ValuesReturnedByEnumerables, realizedValuesCount);
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task GetIAsyncEnumerableAsMemberWithinReturnType(bool useProxy)
+    {
+        int realizedValuesCount = 0;
+        CompoundEnumerableResult result = useProxy
+            ? await this.clientProxy.Value.GetNumbersAndMetadataAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<CompoundEnumerableResult>(nameof(Server.GetNumbersAndMetadataAsync), cancellationToken: this.TimeoutToken);
+        Assert.Equal("Hello!", result.Message);
+        Assert.NotNull(result.Enumeration);
+        await foreach (int number in result.Enumeration!)
+        {
+            realizedValuesCount++;
+            this.Logger.WriteLine(number.ToString(CultureInfo.InvariantCulture));
+        }
+
+        Assert.Equal(Server.ValuesReturnedByEnumerables, realizedValuesCount);
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task GetIAsyncEnumerableAsReturnType_MinBatchSize(bool useProxy)
+    {
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.GetNumbersInBatchesAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.GetNumbersInBatchesAsync), cancellationToken: this.TimeoutToken);
+        var enumerator = enumerable.GetAsyncEnumerator(this.TimeoutToken);
+
+        for (int i = 0; i < Server.ValuesReturnedByEnumerables; i++)
+        {
+            // Assert that the server is always in a state of having produced values to fill a batch.
+            Assert.True(this.server.ActuallyGeneratedValueCount % Server.MinBatchSize == 0 || this.server.ActuallyGeneratedValueCount == Server.ValuesReturnedByEnumerables);
+
+            // Assert that the ValueTask completes synchronously within a batch.
+            if (i % Server.MinBatchSize == 0)
+            {
+                // A new batch should be requested here. Allow for an async completion.
+                // But avoid asserting that it completed asynchronously or else in certain race conditions the test will fail
+                // simply because the async portion happened before the test could check the completion flag.
+                Assert.True(await enumerator.MoveNextAsync());
+            }
+            else
+            {
+                // Within a batch, the MoveNextAsync call should absolutely complete synchronously.
+                ValueTask<bool> valueTask = enumerator.MoveNextAsync();
+                Assert.True(valueTask.IsCompleted);
+                Assert.True(valueTask.GetAwaiter().GetResult());
+            }
+
+            int number = enumerator.Current;
+            this.Logger.WriteLine(number.ToString(CultureInfo.InvariantCulture));
+        }
+
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task GetIAsyncEnumerableAsReturnType_MaxReadAhead()
+    {
+        IAsyncEnumerable<int> enumerable = this.clientProxy.Value.GetNumbersWithReadAheadAsync(this.TimeoutToken);
+
+        async Task ExpectReadAhead(int expected)
+        {
+            while (true)
+            {
+                Task valueGenerated = this.server.ValueGenerated.WaitAsync(this.TimeoutToken);
+                if (this.server.ActuallyGeneratedValueCount >= expected)
+                {
+                    break;
+                }
+
+                await valueGenerated;
+            }
+        }
+
+        // Without reading the first value, the server should be getting ahead.
+        await ExpectReadAhead(Server.MaxReadAhead);
+
+        // Read the first value. That should cause the client to get everything the server had, leading to the server refilling the read-ahead.
+        var enumerator = enumerable.GetAsyncEnumerator(this.TimeoutToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        await ExpectReadAhead(Server.ValuesReturnedByEnumerables);
+
+        async Task Consume(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                await enumerator.MoveNextAsync();
+            }
+        }
+
+        // Consume the rest of the batch. Confirm the server hasn't produced any more.
+        await Consume(Server.MaxReadAhead - 1);
+        Assert.Equal(Server.ValuesReturnedByEnumerables, this.server.ActuallyGeneratedValueCount);
+
+        // Consume one more, which should consume the batch.
+        Assert.True(await enumerator.MoveNextAsync());
+        await Consume(3);
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task PassInIAsyncEnumerableAsArgument(bool useProxy)
+    {
+        async IAsyncEnumerable<int> Generator(CancellationToken cancellationToken)
+        {
+            for (int i = 1; i <= Server.ValuesReturnedByEnumerables; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+                yield return i;
+            }
+        }
+
+        if (useProxy)
+        {
+            await this.clientProxy.Value.PassInNumbersAsync(Generator(this.TimeoutToken), this.TimeoutToken);
+        }
+        else
+        {
+            await this.clientRpc.InvokeWithCancellationAsync(nameof(Server.PassInNumbersAsync), new object[] { Generator(this.TimeoutToken) }, this.TimeoutToken);
+        }
+    }
+
+    [Fact]
+    public void EnumerablesAndBatchSizeAreAsIntended()
+    {
+        // As per the comment on Server.ValuesReturnedByEnumerables, assert that the value of the test is ensured
+        // by checking that an enumeration will not end at a convenient batch size boundary.
+        Assert.NotEqual(0, Server.ValuesReturnedByEnumerables % Server.MinBatchSize);
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task Cancellation_BeforeMoveNext(bool useProxy)
+    {
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.GetNumbersAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.GetNumbersAsync), cancellationToken: this.TimeoutToken);
+
+        var cts = new CancellationTokenSource();
+        var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task Cancellation_AfterFirstMoveNext(bool useProxy)
+    {
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.GetNumbersAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.GetNumbersAsync), cancellationToken: this.TimeoutToken);
+
+        var cts = new CancellationTokenSource();
+        var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+        Assert.True(await enumerator.MoveNextAsync());
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task Cancellation_DuringLongRunningServerMoveNext(bool useProxy)
+    {
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.WaitTillCanceledBeforeFirstItemAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.WaitTillCanceledBeforeFirstItemAsync), cancellationToken: this.TimeoutToken);
+
+        var cts = new CancellationTokenSource();
+        var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
+        Assert.False(moveNextTask.IsCompleted);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await moveNextTask);
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task Cancellation_DuringLongRunningServerBeforeReturning(bool useProxy)
+    {
+        var cts = new CancellationTokenSource();
+        Task<IAsyncEnumerable<int>> enumerable = useProxy
+            ? this.clientProxy.Value.WaitTillCanceledBeforeReturningAsync(cts.Token)
+            : this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.WaitTillCanceledBeforeReturningAsync), cancellationToken: cts.Token);
+
+        // Make sure the method has been invoked first.
+        await this.server.MethodEntered.WaitAsync(this.TimeoutToken);
+
+        // Now cancel the server method to get it to throw OCE.
+        cts.Cancel();
+
+        // Verify that it does throw OCE. Or timeout and fail the test if it doesn't.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerable).WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
+    public async Task Cancellation_DuringLongRunningServerBeforeReturning_NonTaskReturningProxy()
+    {
+        var clientProxy = this.clientRpc.Attach<IServer2>();
+        var cts = new CancellationTokenSource();
+        IAsyncEnumerable<int> enumerable = clientProxy.WaitTillCanceledBeforeReturningAsync(cts.Token);
+
+        var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
+        Assert.False(moveNextTask.IsCompleted);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await moveNextTask).WithCancellation(this.TimeoutToken);
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task DisposeMidEnumeration(bool useProxy)
+    {
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.GetNumbersAsync(this.TimeoutToken)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.GetNumbersAsync), cancellationToken: this.TimeoutToken);
+
+        await foreach (var item in enumerable)
+        {
+            // Break out after getting the first item.
+            break;
+        }
+
+        await this.server.MethodExited.WaitAsync(this.TimeoutToken);
+    }
+
+    /* TESTS TO ADD:
+     * NotifyAsync throws if an IAsyncEnumerable<T> is sent as or inside an argument.
+     * Resources released if IAsyncEnumerable<T> is sent as or inside an argument and an error response is received.
+     * Memory leaks:
+     *   IAE<T> sent as argument and server returns success response (but server never started enumerating).
+     *   IAE<T> is serialized for a request, but a subsequent serializer throws and the message is never sent. What will release the resources held?
+     */
+
+    protected abstract void InitializeFormattersAndHandlers();
+
+    protected class Server : IServer
+    {
+        /// <summary>
+        /// The number of values produced by the enumerables.
+        /// </summary>
+        /// <value>This is INTENTIONALLY not a multiple of <see cref="MinBatchSize"/> so we can test gathering the last few elements.</value>
+        public const int ValuesReturnedByEnumerables = 7;
+
+        public const int MinBatchSize = 3;
+
+        public const int MaxReadAhead = 4;
+
+        public AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
+
+        public AsyncManualResetEvent MethodExited { get; } = new AsyncManualResetEvent();
+
+        public int ActuallyGeneratedValueCount { get; private set; }
+
+        public AsyncManualResetEvent ValueGenerated { get; } = new AsyncManualResetEvent();
+
+        public IAsyncEnumerable<int> GetNumbersInBatchesAsync(CancellationToken cancellationToken)
+            => this.GetNumbersAsync(cancellationToken).WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = MinBatchSize });
+
+        public IAsyncEnumerable<int> GetNumbersWithReadAheadAsync(CancellationToken cancellationToken)
+            => this.GetNumbersAsync(cancellationToken).WithJsonRpcSettings(new JsonRpcEnumerableSettings { MaxReadAhead = MaxReadAhead, MinBatchSize = MinBatchSize });
+
+        public async IAsyncEnumerable<int> GetNumbersAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            try
+            {
+                for (int i = 1; i <= ValuesReturnedByEnumerables; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Yield();
+                    this.ActuallyGeneratedValueCount++;
+                    this.ValueGenerated.PulseAll();
+                    yield return i;
+                }
+            }
+            finally
+            {
+                this.MethodExited.Set();
+            }
+        }
+
+        public async IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<int>();
+            await tcs.Task.WithCancellation(cancellationToken);
+            yield return 0; // we will never reach this.
+        }
+
+        public Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
+            var tcs = new TaskCompletionSource<IAsyncEnumerable<int>>();
+            return tcs.Task.WithCancellation(cancellationToken);
+        }
+
+        public async Task PassInNumbersAsync(IAsyncEnumerable<int> numbers, CancellationToken cancellationToken)
+        {
+            int realizedValuesCount = 0;
+            await foreach (int number in numbers)
+            {
+                realizedValuesCount++;
+            }
+
+            Assert.Equal(ValuesReturnedByEnumerables, realizedValuesCount);
+        }
+
+        public Task<CompoundEnumerableResult> GetNumbersAndMetadataAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new CompoundEnumerableResult
+            {
+                Message = "Hello!",
+                Enumeration = this.GetNumbersAsync(cancellationToken),
+            });
+        }
+    }
+
+    [DataContract]
+    protected class CompoundEnumerableResult
+    {
+        [DataMember]
+        public string? Message { get; set; }
+
+        [DataMember]
+        public IAsyncEnumerable<int>? Enumeration { get; set; }
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcExtensionsTests : TestBase
+{
+    public JsonRpcExtensionsTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public async Task AsAsyncEnumerable()
+    {
+        var collection = new int[] { 1, 2, 3 };
+        int count = 0;
+        await foreach (int item in collection.AsAsyncEnumerable())
+        {
+            Assert.Equal(++count, item);
+        }
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task AsAsyncEnumerable_Settings()
+    {
+        var collection = new int[] { 1, 2, 3 };
+        int count = 0;
+        await foreach (int item in collection.AsAsyncEnumerable(new JsonRpcEnumerableSettings { MinBatchSize = 3 }))
+        {
+            Assert.Equal(++count, item);
+        }
+
+        Assert.Equal(3, count);
+    }
+}

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -15,6 +15,8 @@
     <Compile Update="DuplexPipeMarshalingMessagePackTests.cs" DependentUpon="DuplexPipeMarshalingTests.cs" />
     <Compile Update="JsonRpcJsonHeadersTests.cs" DependentUpon="JsonRpcTests.cs" />
     <Compile Update="JsonRpcMessagePackLengthTests.cs" DependentUpon="JsonRpcTests.cs" />
+    <Compile Update="AsyncEnumerableJsonTests.cs" DependentUpon="AsyncEnumerableTests.cs" />
+    <Compile Update="AsyncEnumerableMessagePackTests.cs" DependentUpon="AsyncEnumerableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StreamJsonRpc.Tests.ExternalAssembly\StreamJsonRpc.Tests.ExternalAssembly.csproj" />
@@ -25,6 +27,7 @@
     <PackageReference Include="MicroBuild.NonShipping" Version="$(MicroBuildPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.5.31" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1987,7 +1987,7 @@ namespace StreamJsonRpc
                 this.disconnectedSource.Cancel();
 
                 Task messageHandlerDisposal = Task.CompletedTask;
-                if (this.MessageHandler is IAsyncDisposable asyncDisposableMessageHandler)
+                if (this.MessageHandler is Microsoft.VisualStudio.Threading.IAsyncDisposable asyncDisposableMessageHandler)
                 {
                     messageHandlerDisposal = asyncDisposableMessageHandler.DisposeAsync();
                 }

--- a/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
+++ b/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides customizations on performance characteristics of an <see cref="IAsyncEnumerable{T}"/> that is passed over JSON-RPC.
+    /// </summary>
+    public class JsonRpcEnumerableSettings
+    {
+        /// <summary>
+        /// A shared instance with the default settings to use.
+        /// </summary>
+        /// <devremarks>
+        /// This is internal because the type is mutable and thus cannot be safely shared.
+        /// </devremarks>
+        internal static readonly JsonRpcEnumerableSettings DefaultSettings = new JsonRpcEnumerableSettings();
+
+        /// <summary>
+        /// Gets or sets the maximum number of elements to read ahead and cache from the generator in anticipation of the consumer requesting those values.
+        /// </summary>
+        public int MaxReadAhead { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum number of elements to obtain from the generator before sending a batch of values to the consumer.
+        /// </summary>
+        public int MinBatchSize { get; set; } = 1;
+    }
+}

--- a/src/StreamJsonRpc/JsonRpcExtensions.cs
+++ b/src/StreamJsonRpc/JsonRpcExtensions.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using Microsoft;
+
+    /// <summary>
+    /// Extension methods for use with <see cref="JsonRpc"/>.
+    /// </summary>
+    public static class JsonRpcExtensions
+    {
+        /// <summary>
+        /// Decorates an <see cref="IAsyncEnumerable{T}"/> with settings that customize how StreamJsonRpc will send its items to the remote party.
+        /// </summary>
+        /// <typeparam name="T">The type of element enumerated by the sequence.</typeparam>
+        /// <param name="enumerable">The enumerable to be decorated.</param>
+        /// <param name="settings">The settings to associate with this enumerable.</param>
+        /// <returns>The decorated enumerable instance.</returns>
+        public static IAsyncEnumerable<T> WithJsonRpcSettings<T>(this IAsyncEnumerable<T> enumerable, JsonRpcEnumerableSettings? settings)
+        {
+            Requires.NotNull(enumerable, nameof(enumerable));
+
+            return settings != null ? new SettingsBearingEnumerable<T>(enumerable, settings) : enumerable;
+        }
+
+        /// <summary>
+        /// Converts an <see cref="IEnumerable{T}"/> to <see cref="IAsyncEnumerable{T}"/> so it will be streamed over an RPC connection progressively
+        /// instead of as an entire collection in one message.
+        /// </summary>
+        /// <typeparam name="T">The type of element enumerated by the sequence.</typeparam>
+        /// <param name="enumerable">The enumerable to be converted.</param>
+        /// <returns>The async enumerable instance.</returns>
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public static async IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerable<T> enumerable)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            foreach (T item in enumerable)
+            {
+                yield return item;
+            }
+        }
+
+        /// <summary>
+        /// Converts an <see cref="IEnumerable{T}"/> to <see cref="IAsyncEnumerable{T}"/> so it will be streamed over an RPC connection progressively
+        /// instead of as an entire collection in one message.
+        /// </summary>
+        /// <typeparam name="T">The type of element enumerated by the sequence.</typeparam>
+        /// <param name="enumerable">The enumerable to be converted.</param>
+        /// <param name="settings">The settings to associate with this enumerable.</param>
+        /// <returns>The async enumerable instance.</returns>
+        public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerable<T> enumerable, JsonRpcEnumerableSettings? settings)
+        {
+            return AsAsyncEnumerable(enumerable).WithJsonRpcSettings(settings);
+        }
+
+        /// <summary>
+        /// Extracts the <see cref="JsonRpcEnumerableSettings"/> from an <see cref="IAsyncEnumerable{T}"/>
+        /// that may have been previously returned from <see cref="WithJsonRpcSettings{T}(IAsyncEnumerable{T}, JsonRpcEnumerableSettings?)"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of element enumerated by the sequence.</typeparam>
+        /// <param name="enumerable">The enumerable, which may have come from <see cref="WithJsonRpcSettings{T}(IAsyncEnumerable{T}, JsonRpcEnumerableSettings?)"/>.</param>
+        /// <returns>The settings to use.</returns>
+        /// <remarks>
+        /// If the <paramref name="enumerable"/> did not come from <see cref="WithJsonRpcSettings{T}(IAsyncEnumerable{T}, JsonRpcEnumerableSettings?)"/>,
+        /// the default settings will be returned.
+        /// </remarks>
+        internal static JsonRpcEnumerableSettings GetJsonRpcSettings<T>(this IAsyncEnumerable<T> enumerable)
+        {
+            Requires.NotNull(enumerable, nameof(enumerable));
+
+            return enumerable is SettingsBearingEnumerable<T> decorated ? decorated.Settings : JsonRpcEnumerableSettings.DefaultSettings;
+        }
+
+        internal class SettingsBearingEnumerable<T> : IAsyncEnumerable<T>
+        {
+            private readonly IAsyncEnumerable<T> innerEnumerable;
+
+            internal SettingsBearingEnumerable(IAsyncEnumerable<T> enumerable, JsonRpcEnumerableSettings settings)
+            {
+                this.innerEnumerable = enumerable;
+                this.Settings = settings;
+            }
+
+            internal JsonRpcEnumerableSettings Settings { get; }
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken) => this.innerEnumerable.GetAsyncEnumerator(cancellationToken);
+        }
+    }
+}

--- a/src/StreamJsonRpc/MessageHandlerBase.cs
+++ b/src/StreamJsonRpc/MessageHandlerBase.cs
@@ -4,9 +4,6 @@
 namespace StreamJsonRpc
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft;
@@ -23,7 +20,7 @@ namespace StreamJsonRpc
     /// and may be made from any thread.
     /// The caller must take care to call <see cref="ReadAsync(CancellationToken)"/> sequentially.
     /// </remarks>
-    public abstract class MessageHandlerBase : IJsonRpcMessageHandler, IDisposableObservable, IAsyncDisposable
+    public abstract class MessageHandlerBase : IJsonRpcMessageHandler, IDisposableObservable, Microsoft.VisualStudio.Threading.IAsyncDisposable
     {
         /// <summary>
         /// The source of a token that is canceled when this instance is disposed.

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -1,0 +1,386 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Threading.Tasks.Dataflow;
+    using Microsoft;
+    using Microsoft.VisualStudio.Threading;
+    using Nerdbank.Streams;
+
+    /// <summary>
+    /// A helper class that <see cref="IJsonRpcMessageFormatter"/> implementations may use to support <see cref="IAsyncEnumerable{T}"/> return values from RPC methods.
+    /// </summary>
+    public class MessageFormatterEnumerableTracker
+    {
+        private const string DisposeMethodName = "$/enumerator/dispose";
+        private const string NextMethodName = "$/enumerator/next";
+
+        private static readonly MethodInfo GetTokenOpenGenericMethod = typeof(MessageFormatterEnumerableTracker).GetRuntimeMethods().First(m => m.Name == nameof(GetToken) && m.IsGenericMethod);
+        private static readonly MethodInfo CreateEnumerableProxyOpenGenericMethod = typeof(MessageFormatterEnumerableTracker).GetRuntimeMethods().First(m => m.Name == nameof(CreateEnumerableProxy) && m.IsGenericMethod);
+
+        private readonly Dictionary<long, IGeneratingEnumeratorTracker> generatorsByToken = new Dictionary<long, IGeneratingEnumeratorTracker>();
+        private readonly JsonRpc jsonRpc;
+
+        private readonly object syncObject = new object();
+
+        private long nextToken;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageFormatterEnumerableTracker"/> class.
+        /// </summary>
+        /// <param name="jsonRpc">The <see cref="JsonRpc"/> instance that may be used to send or receive RPC messages related to <see cref="IAsyncEnumerable{T}"/>.</param>
+        public MessageFormatterEnumerableTracker(JsonRpc jsonRpc)
+        {
+            this.jsonRpc = jsonRpc ?? throw new ArgumentNullException(nameof(jsonRpc));
+
+            this.jsonRpc.AddLocalRpcMethod(NextMethodName, new Func<long, CancellationToken, ValueTask<object>>(this.OnNextAsync));
+            this.jsonRpc.AddLocalRpcMethod(DisposeMethodName, new Func<long, ValueTask>(this.OnDisposeAsync));
+        }
+
+        private interface IGeneratingEnumeratorTracker : System.IAsyncDisposable
+        {
+            ValueTask<object> GetNextValuesAsync(CancellationToken cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks if a given <see cref="Type"/> implements <see cref="IAsyncEnumerable{T}"/>.
+        /// </summary>
+        /// <param name="objectType">The type which may implement <see cref="IAsyncEnumerable{T}"/>.</param>
+        /// <returns>true if given <see cref="Type"/> implements <see cref="IAsyncEnumerable{T}"/>; otherwise, false.</returns>
+        public static bool CanSerialize(Type objectType) => TrackerHelpers<IAsyncEnumerable<int>>.CanSerialize(objectType);
+
+        /// <summary>
+        /// Checks if a given <see cref="Type"/> is exactly some closed generic type based on <see cref="IAsyncEnumerable{T}"/>.
+        /// </summary>
+        /// <param name="objectType">The type which may be <see cref="IAsyncEnumerable{T}"/>.</param>
+        /// <returns>true if given <see cref="Type"/> is <see cref="IAsyncEnumerable{T}"/>; otherwise, false.</returns>
+        public static bool CanDeserialize(Type objectType) => TrackerHelpers<IAsyncEnumerable<int>>.CanDeserialize(objectType);
+
+        /// <summary>
+        /// Used by the generator to assign a handle to the given <see cref="IAsyncEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value that is produced by the enumerable.</typeparam>
+        /// <param name="enumerable">The enumerable to assign a handle to.</param>
+        /// <returns>The handle that was assigned.</returns>
+        public long GetToken<T>(IAsyncEnumerable<T> enumerable)
+        {
+            long handle = Interlocked.Increment(ref this.nextToken);
+            lock (this.syncObject)
+            {
+                this.generatorsByToken.Add(handle, new GeneratingEnumeratorTracker<T>(enumerable, settings: enumerable.GetJsonRpcSettings()));
+            }
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Used by the generator to assign a handle to the given <see cref="IAsyncEnumerable{T}"/>.
+        /// </summary>
+        /// <param name="enumerable">The enumerable to assign a handle to.</param>
+        /// <returns>The handle that was assigned.</returns>
+        public long GetToken(object enumerable)
+        {
+            Requires.NotNull(enumerable, nameof(enumerable));
+
+            Type? iface = TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(enumerable.GetType());
+            Requires.Argument(iface != null, nameof(enumerable), message: null);
+
+            MethodInfo closedGenericMethod = GetTokenOpenGenericMethod.MakeGenericMethod(iface.GenericTypeArguments[0]);
+            return (long)closedGenericMethod.Invoke(this, new object[] { enumerable });
+        }
+
+        /// <summary>
+        /// Used by the consumer to construct a proxy that implements <see cref="IAsyncEnumerable{T}"/>
+        /// and gets all its values from a remote generator.
+        /// </summary>
+        /// <typeparam name="T">The type of value that is produced by the enumerable.</typeparam>
+        /// <param name="handle">The handle specified by the generator that is used to obtain more values or dispose of the enumerator.</param>
+        /// <returns>The enumerator.</returns>
+        public IAsyncEnumerable<T> CreateEnumerableProxy<T>(object handle)
+        {
+            return new AsyncEnumerableProxy<T>(this.jsonRpc, handle);
+        }
+
+        /// <summary>
+        /// Used by the consumer to construct a proxy that implements <see cref="IAsyncEnumerable{T}"/>
+        /// and gets all its values from a remote generator.
+        /// </summary>
+        /// <param name="enumeratedType">The type of value that is produced by the enumerable.</param>
+        /// <param name="handle">The handle specified by the generator that is used to obtain more values or dispose of the enumerator.</param>
+        /// <returns>The enumerator.</returns>
+        public object CreateEnumerableProxy(Type enumeratedType, object handle)
+        {
+            Requires.NotNull(enumeratedType, nameof(enumeratedType));
+            Requires.NotNull(handle, nameof(handle));
+
+            Requires.Argument(CanDeserialize(enumeratedType), nameof(enumeratedType), message: null);
+            MethodInfo closedGenericMethod = CreateEnumerableProxyOpenGenericMethod.MakeGenericMethod(enumeratedType.GenericTypeArguments[0]);
+            return closedGenericMethod.Invoke(this, new object[] { handle });
+        }
+
+        private ValueTask<object> OnNextAsync(long token, CancellationToken cancellationToken)
+        {
+            IGeneratingEnumeratorTracker generator;
+            lock (this.syncObject)
+            {
+                generator = this.generatorsByToken[token];
+            }
+
+            return generator.GetNextValuesAsync(cancellationToken);
+        }
+
+        private ValueTask OnDisposeAsync(long token)
+        {
+            IGeneratingEnumeratorTracker generator;
+            lock (this.syncObject)
+            {
+                generator = this.generatorsByToken[token];
+                this.generatorsByToken.Remove(token);
+            }
+
+            return generator.DisposeAsync();
+        }
+
+        private class GeneratingEnumeratorTracker<T> : IGeneratingEnumeratorTracker
+        {
+            private readonly IAsyncEnumerator<T> enumerator;
+
+            private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+            private readonly BufferBlock<T>? prefetchedElements;
+
+            internal GeneratingEnumeratorTracker(IAsyncEnumerable<T> enumerable, JsonRpcEnumerableSettings settings)
+            {
+                this.enumerator = enumerable.GetAsyncEnumerator(this.cancellationTokenSource.Token);
+                this.Settings = settings;
+
+                if (settings.MaxReadAhead > 0)
+                {
+                    this.prefetchedElements = new BufferBlock<T>(new DataflowBlockOptions { BoundedCapacity = settings.MaxReadAhead, EnsureOrdered = true });
+                    this.PrefetchAsync().Forget(); // exceptions fault the buffer block
+                }
+            }
+
+            internal JsonRpcEnumerableSettings Settings { get; }
+
+            public async ValueTask<object> GetNextValuesAsync(CancellationToken cancellationToken)
+            {
+                using (cancellationToken.Register(state => ((CancellationTokenSource)state).Cancel(), this.cancellationTokenSource))
+                {
+                    cancellationToken = this.cancellationTokenSource.Token;
+                    bool finished = false;
+                    var results = new List<T>(this.Settings.MinBatchSize);
+                    if (this.prefetchedElements != null)
+                    {
+                        // Fetch at least the min batch size and at most the number that has been cached up to this point (or until we hit the end of the sequence).
+                        // We snap the number of cached elements up front because as we dequeue, we create capacity to store more and we don't want to
+                        // collect and return more than MaxReadAhead.
+                        int cachedOnEntry = this.prefetchedElements.Count;
+                        for (int i = 0; !this.prefetchedElements.Completion.IsCompleted && (i < this.Settings.MinBatchSize || (cachedOnEntry - results.Count > 0)); i++)
+                        {
+                            try
+                            {
+                                T element = await this.prefetchedElements.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                                results.Add(element);
+                            }
+                            catch (InvalidOperationException) when (this.prefetchedElements.Completion.IsCompleted)
+                            {
+                                // Race condition. The sequence is over.
+                                finished = true;
+                                break;
+                            }
+                        }
+
+                        if (this.prefetchedElements.Completion.IsCompleted)
+                        {
+                            // Rethrow any exceptions.
+                            await this.prefetchedElements.Completion.ConfigureAwait(false);
+                            finished = true;
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < this.Settings.MinBatchSize; i++)
+                        {
+                            if (!await this.enumerator.MoveNextAsync().ConfigureAwait(false))
+                            {
+                                finished = true;
+                                break;
+                            }
+
+                            results.Add(this.enumerator.Current);
+                        }
+                    }
+
+                    return new EnumeratorResults<T>
+                    {
+                        Finished = finished,
+                        Values = results,
+                    };
+                }
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                this.cancellationTokenSource.Cancel();
+                this.prefetchedElements?.Complete();
+                return this.enumerator.DisposeAsync();
+            }
+
+            private async Task PrefetchAsync()
+            {
+                Assumes.NotNull(this.prefetchedElements);
+                try
+                {
+                    while (await this.enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        await this.prefetchedElements.SendAsync(this.enumerator.Current, this.cancellationTokenSource.Token).ConfigureAwait(false);
+                    }
+
+                    this.prefetchedElements.Complete();
+                }
+                catch (Exception ex)
+                {
+                    ITargetBlock<T> target = this.prefetchedElements;
+                    target.Fault(ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides the <see cref="IAsyncEnumerable{T}"/> instance that is used by a consumer.
+        /// </summary>
+        /// <typeparam name="T">The type of value produced by the enumerator.</typeparam>
+        private class AsyncEnumerableProxy<T> : IAsyncEnumerable<T>
+        {
+            private readonly JsonRpc jsonRpc;
+            private object? handle;
+
+            internal AsyncEnumerableProxy(JsonRpc jsonRpc, object handle)
+            {
+                this.jsonRpc = jsonRpc;
+                this.handle = handle;
+            }
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
+            {
+                object handle = this.handle ?? throw new InvalidOperationException(Resources.UsableOnceOnly);
+                this.handle = null;
+                return new AsyncEnumeratorProxy<T>(this.jsonRpc, handle, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Provides the <see cref="IAsyncEnumerator{T}"/> instance that is used by a consumer.
+        /// </summary>
+        /// <typeparam name="T">The type of value produced by the enumerator.</typeparam>
+        private class AsyncEnumeratorProxy<T> : IAsyncEnumerator<T>
+        {
+            private readonly JsonRpc jsonRpc;
+            private readonly CancellationToken cancellationToken;
+            private readonly object?[] nextOrDisposeArguments;
+
+            /// <summary>
+            /// A sequence of values that have already been received from the generator but not yet consumed.
+            /// </summary>
+            private Sequence<T> localCachedValues = new Sequence<T>();
+
+            /// <summary>
+            /// A value indicating whether the generator has reported that no more values will be forthcoming.
+            /// </summary>
+            private bool generatorReportsFinished;
+
+            private bool disposed;
+
+            internal AsyncEnumeratorProxy(JsonRpc jsonRpc, object handle, CancellationToken cancellationToken)
+            {
+                this.jsonRpc = jsonRpc;
+                this.nextOrDisposeArguments = new object?[] { handle };
+                this.cancellationToken = cancellationToken;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    Verify.NotDisposed(!this.disposed, this);
+                    if (this.localCachedValues.Length == 0)
+                    {
+                        throw new InvalidOperationException("Call " + nameof(this.MoveNextAsync) + " first and confirm it returns true first.");
+                    }
+
+                    return this.localCachedValues.AsReadOnlySequence.First.Span[0];
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (!this.disposed)
+                {
+                    this.disposed = true;
+
+                    // Recycle buffers
+                    this.localCachedValues.Reset();
+
+                    // Notify server.
+                    await this.jsonRpc.NotifyAsync(DisposeMethodName, this.nextOrDisposeArguments).ConfigureAwait(false);
+                }
+            }
+
+            public async ValueTask<bool> MoveNextAsync()
+            {
+                Verify.NotDisposed(!this.disposed, this);
+
+                // Consume one locally cached value, if we have one.
+                if (this.localCachedValues.Length > 0)
+                {
+                    this.localCachedValues.AdvanceTo(this.localCachedValues.AsReadOnlySequence.GetPosition(1));
+                }
+
+                if (this.localCachedValues.Length == 0 && !this.generatorReportsFinished)
+                {
+                    // Fetch more values
+                    EnumeratorResults<T> results = await this.jsonRpc.InvokeWithCancellationAsync<EnumeratorResults<T>>(NextMethodName, this.nextOrDisposeArguments, this.cancellationToken).ConfigureAwait(false);
+                    if (results.Values != null)
+                    {
+                        Write(this.localCachedValues, results.Values);
+                    }
+
+                    this.generatorReportsFinished = results.Finished;
+                }
+
+                return this.localCachedValues.Length > 0;
+            }
+
+            private static void Write(IBufferWriter<T> writer, IReadOnlyList<T> values)
+            {
+                Span<T> span = writer.GetSpan(values.Count);
+                for (int i = 0; i < values.Count; i++)
+                {
+                    span[i] = values[i];
+                }
+
+                writer.Advance(values.Count);
+            }
+        }
+
+        [DataContract]
+        private class EnumeratorResults<T>
+        {
+            [DataMember(Name = "values", Order = 0)]
+            internal IReadOnlyList<T>? Values { get; set; }
+
+            [DataMember(Name = "finished", Order = 1)]
+            internal bool Finished { get; set; }
+        }
+    }
+}

--- a/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
@@ -210,7 +210,7 @@ namespace StreamJsonRpc.Reflection
             /// <summary>
             /// Gets the token associated with this progress object.
             /// </summary>
-            internal long Token { get; }
+            public long Token { get; }
 
             /// <summary>
             /// Invokes <see cref="reportMethod"/> using the given typed value.

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -563,5 +563,14 @@ namespace StreamJsonRpc {
                 return ResourceManager.GetString("UnsupportedPropertiesOnClientProxyInterface", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This method may only be called once and already has been..
+        /// </summary>
+        internal static string UsableOnceOnly {
+            get {
+                return ResourceManager.GetString("UsableOnceOnly", resourceCulture);
+            }
+        }
     }
 }

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -307,4 +307,7 @@
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>
   </data>
+  <data name="UsableOnceOnly" xml:space="preserve">
+    <value>This method may only be called once and already has been.</value>
+  </data>
 </root>

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -21,6 +21,7 @@
     <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" /> -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.16" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" PrivateAssets="compile" />
     <PackageReference Include="Nerdbank.Streams" Version="2.4.46" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="2.9.7" PrivateAssets="all" />
@@ -30,6 +31,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" PrivateAssets="compile" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.19253.2" PrivateAssets="all" />
   </ItemGroup>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -4,6 +4,13 @@ StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, ob
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpcEnumerableSettings
+StreamJsonRpc.JsonRpcEnumerableSettings.JsonRpcEnumerableSettings() -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.set -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.set -> void
+StreamJsonRpc.JsonRpcExtensions
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
@@ -27,7 +34,14 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(St
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(StreamJsonRpc.RequestId requestId, bool successful) -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.Token.get -> long
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
@@ -50,6 +64,11 @@ override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtim
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
+static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,13 @@ StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, ob
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpcEnumerableSettings
+StreamJsonRpc.JsonRpcEnumerableSettings.JsonRpcEnumerableSettings() -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.set -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.set -> void
+StreamJsonRpc.JsonRpcExtensions
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.set -> void
@@ -27,7 +34,14 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(St
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(StreamJsonRpc.RequestId requestId, bool successful) -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.Token.get -> long
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
@@ -50,6 +64,11 @@ override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtim
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
+static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Chyba při zápisu zprávy JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Fehler beim Schreiben der JSON-RPC-Nachricht: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Error al escribir el mensaje de JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Erreur lors de l'écriture du message RPC JSON : {0} : {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Si è verificato un errore durante la scrittura del messaggio della RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -282,6 +282,11 @@
         <target state="translated">JSON RPC メッセージの書き込み時のエラー: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -282,6 +282,11 @@
         <target state="translated">JSON RPC 메시지를 쓰는 동안 오류 발생: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Błąd zapisywania komunikatu JSON zdalnego wywołania procedury: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Erro ao gravar a Mensagem da RPC do JSON: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -282,6 +282,11 @@
         <target state="translated">Произошла ошибка при записи сообщения RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -282,6 +282,11 @@
         <target state="translated">JSON RPC İletisi yazılırken bir hata oluştu: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -282,6 +282,11 @@
         <target state="translated">写入 JSON RPC 消息时出错: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -282,6 +282,11 @@
         <target state="translated">寫入 JSON RPC 訊息時發生錯誤: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This method may only be called once and already has been.</source>
+        <target state="new">This method may only be called once and already has been.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Closes #328 

To do:
Add tests (and fix any issues found) to assert that:
* [ ] NotifyAsync throws if an IAsyncEnumerable<T> is sent as or inside an argument.
* [ ] Resources released if IAsyncEnumerable<T> is sent as or inside an argument and an error response is received.

Consider how to mitigate these memory leaks:
* [ ] IAE<T> sent as argument and server returns success response (but server never started enumerating).
* [ ] IAE<T> is serialized for a request, but a subsequent serializer throws and the message is never sent. What will release the resources held?