### PR TITLE
Use user-supplied JsonConverters when deserializing IProgress<T> report

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -513,7 +513,7 @@ namespace StreamJsonRpc
                     MessageFormatterProgressTracker.ProgressParamInformation progressInfo = null;
                     if (this.formatterProgressTracker.TryGetProgressObject(progressToken, out progressInfo))
                     {
-                        object typedValue = value.ToObject(progressInfo.ValueType);
+                        object typedValue = value.ToObject(progressInfo.ValueType, this.JsonSerializer);
                         progressInfo.InvokeReport(typedValue);
                     }
                 }


### PR DESCRIPTION
Fixes #377

The tests are added to the master branch in #382. They aren't added in v2.2 due to complicated merge conflicts.