### PR TITLE
Replace specialized tracker code in formatters with general APIs

### DIFF
--- a/src/StreamJsonRpc/Reflection/IJsonRpcFormatterCallbacks.cs
+++ b/src/StreamJsonRpc/Reflection/IJsonRpcFormatterCallbacks.cs
@@ -4,8 +4,6 @@
 namespace StreamJsonRpc.Reflection
 {
     using System;
-    using Microsoft;
-    using StreamJsonRpc.Protocol;
 
     /// <summary>
     /// Implemented by <see cref="JsonRpc"/> to expose callbacks allowing an <see cref="IJsonRpcMessageFormatter"/> to perform resource cleanup.
@@ -18,48 +16,16 @@ namespace StreamJsonRpc.Reflection
         /// <remarks>
         /// This usually occurs because of an exception during serialization or transmission, possibly due to cancellation.
         /// </remarks>
-        event EventHandler<JsonRpcFormatterCallbackEventArgs> RequestTransmissionAborted;
+        event EventHandler<JsonRpcMessageEventArgs> RequestTransmissionAborted;
 
         /// <summary>
-        /// Occurs when <see cref="JsonRpc"/> receives a successful response to a previously sent request.
+        /// Occurs when <see cref="JsonRpc"/> receives a response to a previously sent request.
         /// </summary>
-        event EventHandler<JsonRpcFormatterCallbackEventArgs> ResultReceived;
+        event EventHandler<JsonRpcResponseEventArgs> ResponseReceived;
 
         /// <summary>
-        /// Occurs when <see cref="JsonRpc"/> receives an error response to a previously sent request.
+        /// Occurs when <see cref="JsonRpc"/> transmits a response message.
         /// </summary>
-        event EventHandler<JsonRpcFormatterCallbackEventArgs> ErrorReceived;
-    }
-
-    /// <summary>
-    /// The data passed to <see cref="IJsonRpcFormatterCallbacks"/> event handlers.
-    /// </summary>
-    public class JsonRpcFormatterCallbackEventArgs : EventArgs
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonRpcFormatterCallbackEventArgs"/> class.
-        /// </summary>
-        /// <param name="requestId">The ID from the request or response that the event is regarding.</param>
-        public JsonRpcFormatterCallbackEventArgs(RequestId requestId)
-        {
-            Requires.Argument(!requestId.IsEmpty, nameof(requestId), "Non-default ID required.");
-            this.RequestId = requestId;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonRpcFormatterCallbackEventArgs"/> class.
-        /// </summary>
-        /// <param name="message">The message the event is regarding.</param>
-        internal JsonRpcFormatterCallbackEventArgs(IJsonRpcMessageWithId message)
-        {
-            Requires.NotNull(message, nameof(message));
-            Requires.Argument(!message.RequestId.IsEmpty, nameof(message), "Non-default ID required.");
-            this.RequestId = message.RequestId;
-        }
-
-        /// <summary>
-        /// Gets the id on the request, result or error.
-        /// </summary>
-        public RequestId RequestId { get; private set; }
+        event EventHandler<JsonRpcResponseEventArgs> ResponseSent;
     }
 }

--- a/src/StreamJsonRpc/Reflection/JsonRpcMessageEventArgs.cs
+++ b/src/StreamJsonRpc/Reflection/JsonRpcMessageEventArgs.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using Microsoft;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// Carries the <see cref="RequestId"/> from request or response messages.
+    /// </summary>
+    public class JsonRpcMessageEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonRpcMessageEventArgs"/> class.
+        /// </summary>
+        /// <param name="requestId">The ID from the request or response that the event is regarding.</param>
+        public JsonRpcMessageEventArgs(RequestId requestId)
+        {
+            Requires.Argument(!requestId.IsEmpty, nameof(requestId), "Non-default ID required.");
+            this.RequestId = requestId;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonRpcMessageEventArgs"/> class.
+        /// </summary>
+        /// <param name="message">The message the event is regarding.</param>
+        internal JsonRpcMessageEventArgs(IJsonRpcMessageWithId message)
+        {
+            Requires.NotNull(message, nameof(message));
+            Requires.Argument(!message.RequestId.IsEmpty, nameof(message), "Non-default ID required.");
+            this.RequestId = message.RequestId;
+        }
+
+        /// <summary>
+        /// Gets the id on the request, result or error.
+        /// </summary>
+        public RequestId RequestId { get; private set; }
+    }
+}

--- a/src/StreamJsonRpc/Reflection/JsonRpcResponseEventArgs.cs
+++ b/src/StreamJsonRpc/Reflection/JsonRpcResponseEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using Microsoft;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// Carries the <see cref="RequestId"/> and success status of response messages.
+    /// </summary>
+    public class JsonRpcResponseEventArgs : JsonRpcMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonRpcResponseEventArgs"/> class.
+        /// </summary>
+        /// <param name="requestId">The ID from the request or response that the event is regarding.</param>
+        /// <param name="isSuccessfulResponse">A flag indicating whether the response is a result (as opposed to an error).</param>
+        public JsonRpcResponseEventArgs(RequestId requestId, bool isSuccessfulResponse)
+            : base(requestId)
+        {
+            this.IsSuccessfulResponse = isSuccessfulResponse;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonRpcResponseEventArgs"/> class.
+        /// </summary>
+        /// <param name="message">The message the event is regarding.</param>
+        internal JsonRpcResponseEventArgs(IJsonRpcMessageWithId message)
+            : this(message.RequestId, message is JsonRpcResult)
+        {
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the response is a result (as opposed to an error).
+        /// </summary>
+        public bool IsSuccessfulResponse { get; }
+    }
+}

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -319,20 +319,15 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetPipeWriter(int? to
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.IDuplexPipe duplexPipe) -> int?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.PipeReader reader) -> int?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.PipeWriter writer) -> int?
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.get -> Nerdbank.Streams.MultiplexingStream
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.set -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc rpc, object token, System.Type valueType) -> object
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc rpc, object token) -> System.IProgress<T>
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.GetTokenForProgress(object value) -> long
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.InvokeReport(object typedValue) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ValueType.get -> System.Type
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.set -> void
 const StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressRequestSpecialMethod = "$/progress" -> string
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -30,31 +30,30 @@ StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.set -> void
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ErrorReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResultReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcMessageEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseSent -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
 StreamJsonRpc.Reflection.IJsonRpcFormatterState
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingRequest.get -> bool
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs.JsonRpcFormatterCallbackEventArgs(StreamJsonRpc.RequestId requestId) -> void
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs.RequestId.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(StreamJsonRpc.RequestId requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.JsonRpcMessageEventArgs(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.RequestId.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.IsSuccessfulResponse.get -> bool
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.JsonRpcResponseEventArgs(StreamJsonRpc.RequestId requestId, bool isSuccessfulResponse) -> void
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.Token.get -> long
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
@@ -84,9 +83,9 @@ static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(S
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type
-virtual StreamJsonRpc.JsonRpc.OnErrorReceived(StreamJsonRpc.Protocol.JsonRpcError error) -> void
 virtual StreamJsonRpc.JsonRpc.OnRequestTransmissionAborted(StreamJsonRpc.Protocol.JsonRpcRequest request) -> void
-virtual StreamJsonRpc.JsonRpc.OnResultReceived(StreamJsonRpc.Protocol.JsonRpcResult result) -> void
+virtual StreamJsonRpc.JsonRpc.OnResponseReceived(StreamJsonRpc.Protocol.JsonRpcMessage response) -> void
+virtual StreamJsonRpc.JsonRpc.OnResponseSent(StreamJsonRpc.Protocol.JsonRpcMessage response) -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -319,20 +319,15 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetPipeWriter(int? to
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.IDuplexPipe duplexPipe) -> int?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.PipeReader reader) -> int?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetToken(System.IO.Pipelines.PipeWriter writer) -> int?
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.get -> Nerdbank.Streams.MultiplexingStream
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MultiplexingStream.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.set -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.set -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc rpc, object token, System.Type valueType) -> object
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc rpc, object token) -> System.IProgress<T>
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.GetTokenForProgress(object value) -> long
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker() -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.InvokeReport(object typedValue) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.ValueType.get -> System.Type
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.set -> void
 const StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressRequestSpecialMethod = "$/progress" -> string
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler) -> T
 static StreamJsonRpc.JsonRpc.Attach<T>(StreamJsonRpc.IJsonRpcMessageHandler handler, StreamJsonRpc.JsonRpcProxyOptions options) -> T

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -30,31 +30,30 @@ StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.set -> void
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ErrorReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
-StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResultReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcMessageEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
+StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseSent -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
 StreamJsonRpc.Reflection.IJsonRpcFormatterState
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingRequest.get -> bool
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs.JsonRpcFormatterCallbackEventArgs(StreamJsonRpc.RequestId requestId) -> void
-StreamJsonRpc.Reflection.JsonRpcFormatterCallbackEventArgs.RequestId.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.OnResponseSent(StreamJsonRpc.RequestId requestId, bool successful) -> void
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingDeserialized.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.JsonRpcMessageEventArgs(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.RequestId.get -> StreamJsonRpc.RequestId
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.IsSuccessfulResponse.get -> bool
+StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.JsonRpcResponseEventArgs(StreamJsonRpc.RequestId requestId, bool isSuccessfulResponse) -> void
+StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.OnResponseReceived(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation.Token.get -> long
-StreamJsonRpc.Reflection.MessageFormatterProgressTracker.RequestIdBeingSerialized.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
@@ -84,9 +83,9 @@ static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(S
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.CreateNewRequestId() -> StreamJsonRpc.RequestId
 virtual StreamJsonRpc.JsonRpc.GetErrorDetailsDataType(StreamJsonRpc.Protocol.JsonRpcError error) -> System.Type
-virtual StreamJsonRpc.JsonRpc.OnErrorReceived(StreamJsonRpc.Protocol.JsonRpcError error) -> void
 virtual StreamJsonRpc.JsonRpc.OnRequestTransmissionAborted(StreamJsonRpc.Protocol.JsonRpcRequest request) -> void
-virtual StreamJsonRpc.JsonRpc.OnResultReceived(StreamJsonRpc.Protocol.JsonRpcResult result) -> void
+virtual StreamJsonRpc.JsonRpc.OnResponseReceived(StreamJsonRpc.Protocol.JsonRpcMessage response) -> void
+virtual StreamJsonRpc.JsonRpc.OnResponseSent(StreamJsonRpc.Protocol.JsonRpcMessage response) -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeAsync() -> System.Threading.Tasks.Task
 virtual StreamJsonRpc.MessageHandlerBase.DisposeReader() -> void
 virtual StreamJsonRpc.MessageHandlerBase.DisposeWriter() -> void


### PR DESCRIPTION
Each tracker came with a burden on each formatter that used it that it had to be called at special times and in special ways. This change leverages some recently introduced interfaces so the trackers can take care of most needs themselves, simplifying the job of the formatters.

This includes breaking API changes to the trackers, but we've already made such changes in 2.3, and on the same basis that we aren't aware of any external users of it, it seems like a reasonable opportunity to simplify it.

The `IProgress<T>` tracker still has one special requirement because of when cleanup happens relative to the $/progress notifications, sadly. When we treat $/progress as just an ordinary method call it can be processed *after* the actual result from the method is received and its callback invoked, which creates a "lossy" progress report because any that are processed on the client after the result callback get dropped. So I ensure $/progress reporting happens directly from the formatter (as it was before) to avoid a significant change in behavior.