### PR TITLE
Fix hang on deserialization exception

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -189,8 +189,28 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
 
     protected override void InitializeFormattersAndHandlers()
     {
-        this.clientMessageFormatter = new JsonMessageFormatter { JsonSerializer = { Converters = { new UnserializableTypeConverter() } } };
-        this.serverMessageFormatter = new JsonMessageFormatter { JsonSerializer = { Converters = { new UnserializableTypeConverter() } } };
+        this.clientMessageFormatter = new JsonMessageFormatter
+        {
+            JsonSerializer =
+            {
+                Converters =
+                {
+                    new UnserializableTypeConverter(),
+                    new TypeThrowsWhenDeserializedConverter(),
+                },
+            },
+        };
+        this.serverMessageFormatter = new JsonMessageFormatter
+        {
+            JsonSerializer =
+            {
+                Converters =
+                {
+                    new UnserializableTypeConverter(),
+                    new TypeThrowsWhenDeserializedConverter(),
+                },
+            },
+        };
 
         this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
         this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
@@ -218,6 +238,20 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             writer.WriteValue(((CustomSerializedType)value).Value);
+        }
+    }
+
+    private class TypeThrowsWhenDeserializedConverter : JsonConverter<TypeThrowsWhenDeserialized>
+    {
+        public override TypeThrowsWhenDeserialized ReadJson(JsonReader reader, Type objectType, TypeThrowsWhenDeserialized existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new Exception("This exception is meant to be thrown.");
+        }
+
+        public override void WriteJson(JsonWriter writer, TypeThrowsWhenDeserialized value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
         }
     }
 

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -62,7 +62,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
 
         var options = MessagePackSerializerOptions.Standard
             .WithResolver(CompositeResolver.Create(
-                new IMessagePackFormatter[] { new UnserializableTypeFormatter() },
+                new IMessagePackFormatter[] { new UnserializableTypeFormatter(), new TypeThrowsWhenDeserializedFormatter() },
                 new IFormatterResolver[] { StandardResolverAllowPrivate.Instance }));
         ((MessagePackFormatter)this.serverMessageFormatter).SetMessagePackSerializerOptions(options);
         ((MessagePackFormatter)this.clientMessageFormatter).SetMessagePackSerializerOptions(options);
@@ -81,6 +81,19 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
         public void Serialize(ref MessagePackWriter writer, CustomSerializedType value, MessagePackSerializerOptions options)
         {
             writer.Write(value?.Value);
+        }
+    }
+
+    private class TypeThrowsWhenDeserializedFormatter : IMessagePackFormatter<TypeThrowsWhenDeserialized>
+    {
+        public TypeThrowsWhenDeserialized Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            throw new Exception("This exception is meant to be thrown.");
+        }
+
+        public void Serialize(ref MessagePackWriter writer, TypeThrowsWhenDeserialized value, MessagePackSerializerOptions options)
+        {
+            writer.WriteArrayHeader(0);
         }
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1629,6 +1629,12 @@ public abstract class JsonRpcTests : TestBase
         await Assert.ThrowsAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethod), "Fail"));
     }
 
+    [Fact]
+    public async Task ReturnTypeThrowsOnDeserialization()
+    {
+        await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.InvokeWithCancellationAsync<TypeThrowsWhenDeserialized>(nameof(Server.GetTypeThrowsWhenDeserialized), cancellationToken: this.TimeoutToken)).WithCancellation(this.TimeoutToken);
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -1860,6 +1866,8 @@ public abstract class JsonRpcTests : TestBase
         {
             return fields.x + fields.y;
         }
+
+        public TypeThrowsWhenDeserialized GetTypeThrowsWhenDeserialized() => new TypeThrowsWhenDeserialized();
 
         public int? MethodReturnsNullableInt(int a) => a > 0 ? (int?)a : null;
 
@@ -2163,6 +2171,10 @@ public abstract class JsonRpcTests : TestBase
         [JsonIgnore]
         [IgnoreDataMember]
         public string? Value { get; set; }
+    }
+
+    public class TypeThrowsWhenDeserialized
+    {
     }
 
     [DataContract]

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -11,6 +11,7 @@ namespace StreamJsonRpc
     using System.IO;
     using System.IO.Pipelines;
     using System.Reflection;
+    using System.Runtime.ExceptionServices;
     using System.Runtime.Serialization;
     using MessagePack;
     using MessagePack.Formatters;
@@ -1330,12 +1331,6 @@ namespace StreamJsonRpc
                     value = MessagePackSerializer.Deserialize(typeHint ?? typeof(object), ref reader, this.formatter.userDataSerializationOptions);
                     return true;
                 }
-                catch (NotSupportedException)
-                {
-                    // This block can be removed after https://github.com/neuecc/MessagePack-CSharp/pull/633 is applied.
-                    value = null;
-                    return false;
-                }
                 catch (MessagePackSerializationException)
                 {
                     value = null;
@@ -1353,6 +1348,8 @@ namespace StreamJsonRpc
         private class JsonRpcResult : Protocol.JsonRpcResult, IJsonRpcMessageBufferManager, IJsonRpcMessagePackRetention
         {
             private readonly MessagePackSerializerOptions serializerOptions;
+
+            private Exception? resultDeserializationException;
 
             internal JsonRpcResult(MessagePackSerializerOptions serializerOptions)
             {
@@ -1372,6 +1369,11 @@ namespace StreamJsonRpc
 
             public override T GetResult<T>()
             {
+                if (this.resultDeserializationException != null)
+                {
+                    ExceptionDispatchInfo.Capture(this.resultDeserializationException).Throw();
+                }
+
                 return this.MsgPackResult.IsEmpty
                     ? (T)this.Result!
                     : MessagePackSerializer.Deserialize<T>(this.MsgPackResult, this.serializerOptions);
@@ -1382,8 +1384,16 @@ namespace StreamJsonRpc
                 Verify.Operation(!this.MsgPackResult.IsEmpty, "Result is no longer available or has already been deserialized.");
 
                 var reader = new MessagePackReader(this.MsgPackResult);
-                this.Result = MessagePackSerializer.Deserialize(resultType, ref reader, this.serializerOptions);
-                this.MsgPackResult = default;
+                try
+                {
+                    this.Result = MessagePackSerializer.Deserialize(resultType, ref reader, this.serializerOptions);
+                    this.MsgPackResult = default;
+                }
+                catch (MessagePackSerializationException ex)
+                {
+                    // This was a best effort anyway. We'll throw again later at a more convenient time for JsonRpc.
+                    this.resultDeserializationException = ex;
+                }
             }
         }
 


### PR DESCRIPTION
Fix handling of exceptions thrown from result deserializers

I do this in two ways:
1. If any formatter throws an exception at this fragile point, kill the connection (as we were already doing) but also complete the one Task that we were abandoning before.
1. Fix the MessagePackFormatter to save its exception for a better time so the connection doesn't have to die.