### PR TITLE
Optimize RPC traffic for `IAsyncEnumerable<T>`

### DIFF
--- a/doc/asyncenumerable.md
+++ b/doc/asyncenumerable.md
@@ -41,7 +41,7 @@ Notice how it is not necessary (or desirable) to wrap the resulting `IAsyncEnume
 C# 8 lets you consume such an async enumerable using `await foreach`:
 
 ```cs
-await foreach (int number in this.clientProxy.GenerateNumbersAsync(token))
+await foreach (int number in this.clientProxy.GenerateNumbersAsync(token).WithCancellation(token))
 {
     Console.WriteLine(number);
 }
@@ -49,6 +49,9 @@ await foreach (int number in this.clientProxy.GenerateNumbersAsync(token))
 
 All the foregoing is simple C# 8 async enumerable syntax and use cases.
 StreamJsonRpc lets you use this natural syntax over an RPC connection.
+
+We pass `token` in once to the method that calls to the RPC server, and again to the `WithCancellation`
+extension method so that the token is applied to each iteration of the loop over the enumerable.
 
 A remoted `IAsyncEnumerable<T>` can only be enumerated once.
 Calling `IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken)` more than once will

--- a/doc/asyncenumerable.md
+++ b/doc/asyncenumerable.md
@@ -114,6 +114,11 @@ To improve performance across a network, this behavior can be modified:
    the consumer's request for them. This allows for the possibility that the server is processing
    the data while the last value(s) are in transit to the client or being processed by the client.
    This improves performance when the time to generate the values is significant.
+1. **Prefetch**: The generator collects some number of values up front and _includes_ them
+   in the initial message with the token for acquiring more values.
+   While "read ahead" reduces the time the consumer must wait while the generator produces the values
+   for each request, this prefetch setting entirely eliminates the latency of a round-trip for just
+   the first set of items.
 
 The above optimizations are configured individually and may be used in combination.
 
@@ -168,6 +173,22 @@ In short: `MinBatchSize` guarantees a minimum number of values the server will s
 the sequence is finished, and `MaxReadAhead` is how many values may be produced on the server in anticipation
 of the next request from the client for more values.
 
+As the prefetch feature requires an asynchronous operation itself to fill a cache of items for transmission
+to the receiver, it is not merely a setting but a separate extension method: `WithPrefetchAsync`.
+It can be composed with `WithJsonRpcSettings` in either order, but it's syntactically simplest to add last
+since it is an async method:
+
+```cs
+public async ValueTask<IAsyncEnumerable<int>> GenerateNumbersAsync(CancellationToken cancellationToken)
+{
+    return await this.GenerateNumbersCoreAsync(cancellationToken)
+        .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = 10 })
+        .WithPrefetchAsync(count: 20, cancellationToken);
+}
+```
+
+Please refer to the section on RPC interfaces below for a discussion on the return type of the above method.
+
 The state machine and any cached values are released from the generator when the `IAsyncEnumerator<T>` is disposed.
 
 Customized settings must be applied at the *generator* side. They are ignored if applied to the consumer side.
@@ -181,6 +202,106 @@ public IAsyncEnumerable<int> GetNumbersAsync(int batchSize)
 ```
 
 The above delegates to an C# iterator method, but decorates the result with a batch size determined by the client.
+
+## RPC interfaces
+
+When an async iterator method can be written to return `IAsyncEnumerator<T>` directly,
+it makes for a natural implementation of the ideal C# interface, such as:
+
+```cs
+interface IService
+{
+    IAsyncEnumerable<int> GetNumbersAsync(CancellationToken cancellationToken);
+}
+```
+
+This often can be implemented as simply as:
+
+```cs
+public async IAsyncEnumerable<int> GetNumbersAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+{
+    for (int i = 1; i <= 20; i++)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return i;
+    }
+}
+```
+
+But when applying the perf modifiers, additional steps must be taken:
+
+1. Rename the C# iterator method and (optionally) make it private.
+1. Expose a new implementation of the interface method which calls the inner one and applies the modifications.
+
+```cs
+public IAsyncEnumerable<int> GetNumbersAsync(CancellationToken cancellationToken)
+{
+    return this.GetNumbersCoreAsync(cancellationToken)
+        .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize });
+}
+
+private async IAsyncEnumerable<int> GetNumbersCoreAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+{
+    for (int i = 1; i <= 20; i++)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return i;
+    }
+}
+```
+
+The above isn't too inconvenient, but it is a bit of extra work. It still can implement the same interface that is shared with the client.
+But it gets more complicated when adding `WithPrefetchAsync`, since now the wrapper method itself contains an `await`.
+It cannot simply return `IAsyncEnumerable<int>` since it is not using `yield return` but rather it's returning a specially-decorated
+`IAsyncEnumerable<T>` instance.
+So instead, we have to use `async ValueTask<IAsyncEnumerable<T>>` as the return type:
+
+```cs
+public async ValueTask<IAsyncEnumerable<int>> GetNumbersAsync(CancellationToken cancellationToken)
+{
+    return await this.GetNumbersCoreAsync(cancellationToken)
+        .WithPrefetchAsync(10);
+}
+
+private async IAsyncEnumerable<int> GetNumbersCoreAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+{
+    for (int i = 1; i <= 20; i++)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.Yield();
+        yield return i;
+    }
+}
+```
+
+But now we've changed the method signature of the primary method that JSON-RPC will invoke and we can't implement the C# interface
+as it was originally. We can change the interface to also return `ValueTask<IAsyncEnumerable<int>>` but then that changes
+the client's calling pattern to add an extra *await* (the one after `in`):
+
+```cs
+await foreach(var item in await serverProxy.GetNumbersAsync(cancellationToken))
+{
+    //
+}
+```
+
+That's a little more awkward to write. If we want to preserve the original consuming syntax, we can:
+
+1. Keep the interface as simply returning `IAsyncEnumerable<T>`.
+1. Stop implementing the interface on the server class itself.
+1. Change the server method to return `async ValueTask<IAsyncEnumerable<int>>` as required for `WithPrefetchAsync`.
+
+This is a trade-off between convenience in maintaining and verifying the JSON-RPC server actually satisfies
+the required interface vs. the client writing the most natural C# `await foreach` code.
+
+Note that while the proxy generator requires that _all_ methods return either `Task{<T>}`, `ValueTask{<T>}` or
+`IAsyncEnumerable<T>`, the server class itself can return any type, and StreamJsonRpc will ultimately
+make it appear to the client to be asynchronous. For example a server method can return `int` while the client
+proxy interface is written as if the server method returned `Task<int>` and it will work just fine.
+This is why the interface method can return `IAsyncEnumerable<int>` while the server class method can actually
+return `ValueTask<IAsyncEnumerable<int>>` without there being a problem.
 
 ## Resource leaks concerns
 
@@ -246,23 +367,35 @@ Always make sure the client is expecting the `IAsyncEnumerable<T>` when the serv
 This section is primarily for JSON-RPC library authors that want to interop with StreamJsonRpc's
 async enumerable feature.
 
+An `IAsyncEnumerable<T>` object may be included within or as an RPC method argument or return value.
+We use the terms `generator` to refer to the sender and `consumer` to refer to the receiver.
+
+Capitalized words are key words per [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
 ### Originating message
 
-A JSON-RPC message that carries an `IAsyncEnumerator<T>` provides a token to the enumerator
-so that the message receiver can use this token to request values from or dispose the remote enumerator.
-This token may be any valid JSON token except `null`:
+A JSON-RPC message that carries an `IAsyncEnumerator<T>` encodes it as a JSON object.
+The JSON object may contain these properties:
 
-A result that returns an `IAsyncEnumerable<T>` would look something like this:
+| property | description |
+|--|--|
+| `token` | Any valid JSON token except `null` to be used to request additional values or dispose of the enumerator. This property is **required** if there are more values than those included in this message, and must be absent or `null` if all values are included in the message.
+| `values` | A JSON array of the first batch of values. This property is **optional** or may be specified as `null` or an empty array. A lack of values here does not signify the enumerable is empty but rather that the consumer must explicitly request them.
+
+A result that returns an `IAsyncEnumerable<T>` would look something like this if it included the first few items and more might be available should the receiver ask for them:
 
 ```json
 {
    "jsonrpc": "2.0",
    "id": 1,
-   "result": "enum-handle"
+   "result": {
+     "token": "enum-handle",
+     "values": [ 1, 2, 3 ]
+   }
 }
 ```
 
-A request that includes an `IAsyncEnumerable<T>` as a method argument might look like this:
+A request that includes an `IAsyncEnumerable<T>` as a method argument might look like this if it included the first few items and more might be available should the receiver ask for them:
 
 ```json
 {
@@ -271,7 +404,10 @@ A request that includes an `IAsyncEnumerable<T>` as a method argument might look
     "method": "FooAsync",
     "params": [
         "hi",
-        "enum-handle"
+        {
+          "token": "enum-handle",
+          "values": [ 1, 2, 3 ]
+        }
     ]
 }
 ```
@@ -284,19 +420,50 @@ or method argument:
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
-       "enumerable": "enum-handle",
+       "enumerable": {
+         "token": "enum-handle",
+         "values": [ 1, 2, 3 ]
+       },
        "count": 10
    }
 }
 ```
 
-A client should not send an `IAsyncEnumerable<T>` object in a notification, since that would lead to
+The enumerable certainly may include no pre-fetched values. This object (which may appear in any of the above contexts) demonstrates this:
+
+```json
+{
+  "token": "enum-handle"
+}
+```
+
+The inclusion of the `token` property signifies that the receiver should query for more values or dispose of the enumerable.
+
+Alternatively if the prefetched values are known to include *all* values such that the receiver need not ask for more,
+we would have just the other property:
+
+```json
+{
+  "values": [ 1, 2, 3 ]
+}
+```
+
+Finally, if the enumerable is known to be empty, the object may be completely empty:
+
+```json
+{
+}
+```
+
+A client SHOULD NOT send an `IAsyncEnumerable<T>` object in a notification, since that would lead to
 a memory leak on the client if the server does not handle a particular method or throws before it
 could process the enumerable.
 
+The generator MAY pass multiple `IAsyncEnumerable<T>` instances in a single JSON-RPC message.
+
 ### Consumer request for values
 
-A request from the consumer to the producer for (more) value(s) is done via a standard JSON-RPC
+A request from the consumer to the generator for (more) value(s) is done via a standard JSON-RPC
 request method call with `$/enumerator/next` as the method name and one argument that carries
 the enumerator token. When using named arguments this is named `token`.
 
@@ -320,46 +487,71 @@ or:
 }
 ```
 
-The generator should respond to this request with an error containing `error.code = -32001`
-when the specified enumeration token does not exist, possibly because it has already been disposed.
+The consumer MUST NOT send this message after receiving a message related to this enumerable
+with `finished: true` in it.
+The consumer MUST NOT send this message for a given enumerable
+while waiting for a response to a previous request for the same enumerable,
+since the generator may respond to an earlier request with `finished: true`.
 
-### Producer's response with values
+The consumer MAY cancel a request using the `$/cancelRequest` method as described elsewhere.
+The consumer MUST continue the enumeration or dispose it if the server responds with a
+result rather than a cancellation error.
 
-A response with value(s) from the producer always comes as an object that contains an array of values
-(even if only one element is provided) and a boolean indicating whether the last value has been provided:
+The generator SHOULD respond to this request with an error containing `error.code = -32001`
+when the specified enumeration token does not exist, possibly because it has already been disposed
+or because the last set of values provided to the consumer included `finished: true`.
+
+### Generator's response with values
+
+A response with value(s) from the generator is encoded as a JSON object.
+The JSON object may contain these properties:
+
+| property | description |
+|--|--|
+| values | A JSON array of values. This value is **required.**
+| finished | A boolean value indicating whether the last value from the enumerable has been returned. This value is **optional** and defaults to `false`.
+
+Here is an example of a result encoded as a JSON object:
 
 ```json
 {
    "jsonrpc": "2.0",
    "id": 2,
    "result": {
-      "values": [ 1, 2, 3 ],
+      "values": [ 4, 5, 6 ],
       "finished": false
    }
 }
 ```
 
-Note the `finished` property is a hint from the producer for when the last value has been returned.
-The server *may* not know that the last value has been returned and should specify `false` unless it is sure
-the last value has been produced.
+The server MUST specify `finished: true` only when it is sure the last value in the enumerable has been returned.
+The server SHOULD release all resources related to the enumerable and token when doing so.
 
-The client *may* ask for more values without regard to the `finished` property, but if `finished: true`
-the client may optimize to not ask for more values but instead go directly to dispose of the enumerator.
+The server MAY specify `finished: false` in one response and `values: [], finished: true` in the next response.
 
-The server should never return an empty array of values unless the last value in the sequence has already
+The consumer MUST NOT ask for more values when `finished` is `true` or an error response is received.
+The generator MAY respond with an error if this is done.
+
+The generator should never return an empty array of values unless the last value in the sequence has already
 been returned to the client.
 
 ### Consumer disposes enumerator
 
-The consumer always notifies the producer when the local enumerator proxy is disposed
-by invoking the `$/enumerator/dispose` method.
+When the consumer aborts enumeration before the generator has sent `finished: true`,
+the consumer MUST send a disposal message to release resources held by the generator
+unless the generator has already responded with an error message to a previous request for values.
+
+The consumer does this by invoking the `$/enumerator/abort` JSON-RPC method on the generator.
 The arguments follow the same schema as the `$/enumerator/next` method.
-This *may* be a notification.
+This MAY be a notification.
 
 ```json
 {
    "jsonrpc": "2.0",
-   "method": "$/enumerator/dispose",
+   "method": "$/enumerator/abort",
    "params": { "token": "enum-handle" },
 }
 ```
+
+The generator SHOULD release resources upon receipt of the disposal message.
+The generator SHOULD reject any disposal request received after sending a `finished: true` message.

--- a/doc/asyncenumerable.md
+++ b/doc/asyncenumerable.md
@@ -41,7 +41,7 @@ Notice how it is not necessary (or desirable) to wrap the resulting `IAsyncEnume
 C# 8 lets you consume such an async enumerable using `await foreach`:
 
 ```cs
-await foreach (int number in this.clientProxy.GenerateNumbersAsync(token).WithCancellation(token))
+await foreach (int number in this.clientProxy.GenerateNumbersAsync(token))
 {
     Console.WriteLine(number);
 }
@@ -50,12 +50,29 @@ await foreach (int number in this.clientProxy.GenerateNumbersAsync(token).WithCa
 All the foregoing is simple C# 8 async enumerable syntax and use cases.
 StreamJsonRpc lets you use this natural syntax over an RPC connection.
 
-We pass `token` in once to the method that calls to the RPC server, and again to the `WithCancellation`
-extension method so that the token is applied to each iteration of the loop over the enumerable.
-
 A remoted `IAsyncEnumerable<T>` can only be enumerated once.
 Calling `IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken)` more than once will
 result in an `InvalidOperationException` being thrown.
+
+When *not* using the dynamically generated proxies, acquiring and enumerating an `IAsyncEnumerator<T>` looks like this:
+
+```cs
+var enumerable = await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(
+    "GetNumbersAsync", cancellationToken);
+
+await foreach (var item in enumerable.WithCancellation(cancellationToken))
+{
+    // processing
+}
+```
+
+We pass `cancellationToken` into `InvokeWithCancellationAsync` so we can cancel the initial call.
+We pass it again to the `WithCancellation` extension method inside the `foreach` expression
+so that the token is applied to each iteration of the loop over the enumerable when
+we may be awaiting a network call.
+
+Using the `WithCancellation` extension method is not necessary when using dynamically generated proxies
+because they automatically propagate the token from the first call to the enumerator.
 
 ### Transmitting large collections
 

--- a/src/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using StreamJsonRpc;
 using Xunit;
@@ -12,6 +13,8 @@ using Xunit.Abstractions;
 
 public class JsonRpcExtensionsTests : TestBase
 {
+    private static readonly IReadOnlyList<int> SmallList = new int[] { 1, 2, 3 };
+
     public JsonRpcExtensionsTests(ITestOutputHelper logger)
         : base(logger)
     {
@@ -20,22 +23,121 @@ public class JsonRpcExtensionsTests : TestBase
     [Fact]
     public async Task AsAsyncEnumerable()
     {
-        var collection = new int[] { 1, 2, 3 };
-        int count = 0;
-        await foreach (int item in collection.AsAsyncEnumerable())
-        {
-            Assert.Equal(++count, item);
-        }
-
-        Assert.Equal(3, count);
+        await AssertExpectedValues(SmallList.AsAsyncEnumerable());
     }
 
     [Fact]
     public async Task AsAsyncEnumerable_Settings()
     {
-        var collection = new int[] { 1, 2, 3 };
+        await AssertExpectedValues(SmallList.AsAsyncEnumerable(new JsonRpcEnumerableSettings { MinBatchSize = 3 }));
+    }
+
+    [Fact]
+    public async Task AsAsyncEnumerable_Cancellation()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var cts = new CancellationTokenSource();
+
+        var enumerator = asyncEnum.GetAsyncEnumerator(cts.Token);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(SmallList[0], enumerator.Current);
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task WithPrefetchAsync_ZeroCount()
+    {
+        IAsyncEnumerable<int> asyncEnum = SmallList.AsAsyncEnumerable();
+        Assert.Same(asyncEnum, await asyncEnum.WithPrefetchAsync(0, this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task WithPrefetchAsync_NegativeCount()
+    {
+        IAsyncEnumerable<int> asyncEnum = SmallList.AsAsyncEnumerable();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>("count", async () => await asyncEnum.WithPrefetchAsync(-1));
+    }
+
+    [Fact]
+    public async Task WithPrefetchAsync_Twice()
+    {
+        var prefetchEnum = await SmallList.AsAsyncEnumerable().WithPrefetchAsync(2, this.TimeoutToken);
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await prefetchEnum.WithPrefetchAsync(2, this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task WithPrefetchAsync()
+    {
+        await AssertExpectedValues(await SmallList.AsAsyncEnumerable().WithPrefetchAsync(2, this.TimeoutToken));
+    }
+
+    [Fact]
+    public void WithJsonRpcSettings_NullInput()
+    {
+        Assert.Throws<ArgumentNullException>("enumerable", () => JsonRpcExtensions.WithJsonRpcSettings<int>(null!, null));
+    }
+
+    [Fact]
+    public void WithJsonRpcSettings_NullSettings()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        Assert.Same(asyncEnum, asyncEnum.WithJsonRpcSettings(null));
+    }
+
+    [Fact]
+    public void WithJsonRpcSettings_GetAsyncEnumerator_Twice()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var decorated = asyncEnum.WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = 3 });
+        decorated.GetAsyncEnumerator();
+        Assert.Throws<InvalidOperationException>(() => decorated.GetAsyncEnumerator());
+    }
+
+    [Fact]
+    public async Task WithJsonRpcSettings_GetAsyncEnumerator_Prefetch()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var decorated = asyncEnum.WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = 3 });
+        decorated.GetAsyncEnumerator();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await decorated.WithPrefetchAsync(2));
+    }
+
+    [Fact]
+    public async Task WithPrefetch_GetAsyncEnumerator_Twice()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var decorated = await asyncEnum.WithPrefetchAsync(2, this.TimeoutToken);
+        decorated.GetAsyncEnumerator();
+        Assert.Throws<InvalidOperationException>(() => decorated.GetAsyncEnumerator());
+    }
+
+    [Fact]
+    public async Task WithPrefetch_GetAsyncEnumerator_WithPrefetch()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var decorated = await asyncEnum.WithPrefetchAsync(2, this.TimeoutToken);
+        decorated.GetAsyncEnumerator();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await decorated.WithPrefetchAsync(2));
+    }
+
+    [Fact]
+    public void WithJsonRpcSettings_ModifySettings()
+    {
+        var asyncEnum = SmallList.AsAsyncEnumerable();
+        var decorated = asyncEnum.WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = 3 });
+        Assert.NotSame(asyncEnum, decorated);
+
+        // This shouldn't need to rewrap the underlying enumerator or double-decorate.
+        // Rather, it should just modify the existing decorator.
+        Assert.Same(decorated, decorated.WithJsonRpcSettings(new JsonRpcEnumerableSettings { MaxReadAhead = 5 }));
+    }
+
+    private static async Task AssertExpectedValues(IAsyncEnumerable<int> actual)
+    {
         int count = 0;
-        await foreach (int item in collection.AsAsyncEnumerable(new JsonRpcEnumerableSettings { MinBatchSize = 3 }))
+        await foreach (int item in actual)
         {
             Assert.Equal(++count, item);
         }

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This cannot be done after GetAsyncEnumerator has already been called..
+        /// </summary>
+        internal static string CannotBeCalledAfterGetAsyncEnumerator {
+            get {
+                return ResourceManager.GetString("CannotBeCalledAfterGetAsyncEnumerator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; is not an interface..
         /// </summary>
         internal static string ClientProxyTypeArgumentMustBeAnInterface {
@@ -129,6 +138,15 @@ namespace StreamJsonRpc {
         internal static string DroppingRequestDueToNoTargetObject {
             get {
                 return ResourceManager.GetString("DroppingRequestDueToNoTargetObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This enumeration has already prefetched elements once..
+        /// </summary>
+        internal static string ElementsAlreadyPrefetched {
+            get {
+                return ResourceManager.GetString("ElementsAlreadyPrefetched", resourceCulture);
             }
         }
         
@@ -579,15 +597,6 @@ namespace StreamJsonRpc {
         internal static string UnsupportedPropertiesOnClientProxyInterface {
             get {
                 return ResourceManager.GetString("UnsupportedPropertiesOnClientProxyInterface", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This method may only be called once and already has been..
-        /// </summary>
-        internal static string UsableOnceOnly {
-            get {
-                return ResourceManager.GetString("UsableOnceOnly", resourceCulture);
             }
         }
     }

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -123,6 +123,9 @@
   <data name="CancellationTokenMustBeLastParameter" xml:space="preserve">
     <value>A CancellationToken is only allowed as the last parameter.</value>
   </data>
+  <data name="CannotBeCalledAfterGetAsyncEnumerator" xml:space="preserve">
+    <value>This cannot be done after GetAsyncEnumerator has already been called.</value>
+  </data>
   <data name="ClientProxyTypeArgumentMustBeAnInterface" xml:space="preserve">
     <value>"{0}" is not an interface.</value>
   </data>
@@ -143,6 +146,9 @@
   <data name="DroppingRequestDueToNoTargetObject" xml:space="preserve">
     <value>Got a request to execute '{0}' but have no callback object. Dropping the request.</value>
     <comment>{0} is the method name to execute.</comment>
+  </data>
+  <data name="ElementsAlreadyPrefetched" xml:space="preserve">
+    <value>This enumeration has already prefetched elements once.</value>
   </data>
   <data name="ErrorWritingJsonRpcMessage" xml:space="preserve">
     <value>Error writing JSON RPC Message: {0}: {1}</value>
@@ -312,8 +318,5 @@
   </data>
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>
-  </data>
-  <data name="UsableOnceOnly" xml:space="preserve">
-    <value>This method may only be called once and already has been.</value>
   </data>
 </root>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -47,9 +47,7 @@ StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.IsSuccessfulResponse.get -> bo
 StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.JsonRpcResponseEventArgs(StreamJsonRpc.RequestId requestId, bool isSuccessfulResponse) -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle, System.Collections.Generic.IReadOnlyList<T> prefetchedItems) -> System.Collections.Generic.IAsyncEnumerable<T>
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
@@ -69,6 +67,8 @@ StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageExce
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
+const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyName = "token" -> string
+const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -77,7 +77,10 @@ override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.WithPrefetchAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -47,9 +47,7 @@ StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.IsSuccessfulResponse.get -> bo
 StreamJsonRpc.Reflection.JsonRpcResponseEventArgs.JsonRpcResponseEventArgs(StreamJsonRpc.RequestId requestId, bool isSuccessfulResponse) -> void
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.MessageFormatterDuplexPipeTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy(System.Type enumeratedType, object handle) -> object
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle) -> System.Collections.Generic.IAsyncEnumerable<T>
-StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken(object enumerable) -> long
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CreateEnumerableProxy<T>(object handle, System.Collections.Generic.IReadOnlyList<T> prefetchedItems) -> System.Collections.Generic.IAsyncEnumerable<T>
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.GetToken<T>(System.Collections.Generic.IAsyncEnumerable<T> enumerable) -> long
 StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.MessageFormatterEnumerableTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.MessageFormatterProgressTracker(StreamJsonRpc.JsonRpc jsonRpc, StreamJsonRpc.Reflection.IJsonRpcFormatterState formatterState) -> void
@@ -69,6 +67,8 @@ StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageExce
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
+const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyName = "token" -> string
+const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -77,7 +77,10 @@ override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
+static StreamJsonRpc.JsonRpcExtensions.WithPrefetchAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Parametr readable i writable jsou null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Byla přijata žádost o provedení {0}, ale chybí objekt zpětného volání. Žádost se ruší.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Chyba při zápisu zprávy JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -7,10 +7,20 @@
         <target state="translated">"readable" und "writable" sind NULL.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Eine Anforderung zum Ausführen von "{0}" wurde ausgegeben, es ist aber kein Rückrufobjekt vorhanden. Die Anforderung wird gelöscht.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Fehler beim Schreiben der JSON-RPC-Nachricht: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -7,10 +7,20 @@
         <target state="translated">La lectura y escritura son NULL.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Recibió una solicitud para ejecutar '{0}', pero no hay ningún objeto de devolución de llamada. Anulando la solicitud.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Error al escribir el mensaje de JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -7,10 +7,20 @@
         <target state="translated">readable et writable sont tous les deux Null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">A reçu une demande pour exécuter '{0}' mais n’a aucun objet de rappel. Suppression de la demande.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Erreur lors de l'écriture du message RPC JSON : {0} : {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Readable e Writable sono entrambi Null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">È stata ricevuta una richiesta per l'esecuzione di '{0}' ma non sono presenti oggetti di callback. La richiesta verrà eliminata.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Si è verificato un errore durante la scrittura del messaggio della RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Readable と Writable の両方が null です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">'{0}' の実行の要求を受け取りましたが、コールバック オブジェクトがありません。要求を削除しています。</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC メッセージの書き込み時のエラー: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -7,10 +7,20 @@
         <target state="translated">읽고 쓸 수 있는 개체는 null입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">‘{0}’을(를) 실행하도록 요청을 받았지만 이 요청에 콜백 개체가 없습니다. 요청을 삭제합니다.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC 메시지를 쓰는 동안 오류 발생: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Elementy readable i writable mają wartość null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Otrzymano żądanie wykonania metody „{0}”, ale brakuje obiektu wywołania zwrotnego. Żądanie zostanie odrzucone.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Błąd zapisywania komunikatu JSON zdalnego wywołania procedury: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Legível e gravável são nulos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Recebeu uma solicitação para executar '{0}', mas não há nenhum objeto de retorno de chamada. Removendo a solicitação.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Erro ao gravar a Mensagem da RPC do JSON: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -7,10 +7,20 @@
         <target state="translated">И элементы, которые можно считать, и элементы, которые доступны для записи, имеют значение NULL.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">Получен запрос на выполнение "{0}", но отсутствует объект обратного вызова. Удаление запроса.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Произошла ошибка при записи сообщения RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Readable ve writable null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">'{0}' metodunu yürütme isteği alındı ancak geri çağırma nesnesi yok. İstek bırakılıyor.</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC İletisi yazılırken bir hata oluştu: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -7,10 +7,20 @@
         <target state="translated">可读内容和可写内容均为 null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">已获得执行“{0}”的请求，但没有回调对象。删除请求。</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">写入 JSON RPC 消息时出错: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -7,10 +7,20 @@
         <target state="translated">Readable 和 Writable 都是 Null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotBeCalledAfterGetAsyncEnumerator">
+        <source>This cannot be done after GetAsyncEnumerator has already been called.</source>
+        <target state="new">This cannot be done after GetAsyncEnumerator has already been called.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DroppingRequestDueToNoTargetObject" translate="yes" xml:space="preserve">
         <source>Got a request to execute '{0}' but have no callback object. Dropping the request.</source>
         <target state="translated">取得執行 '{0}' 的要求，但沒有回呼物件。正在卸除要求。</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the method name to execute.</note>
+      </trans-unit>
+      <trans-unit id="ElementsAlreadyPrefetched">
+        <source>This enumeration has already prefetched elements once.</source>
+        <target state="new">This enumeration has already prefetched elements once.</target>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
@@ -291,11 +301,6 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">寫入 JSON RPC 訊息時發生錯誤: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
-      </trans-unit>
-      <trans-unit id="UsableOnceOnly">
-        <source>This method may only be called once and already has been.</source>
-        <target state="new">This method may only be called once and already has been.</target>
-        <note />
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
In particular:

* Remove any need to dispose of an enumerable's handle if it was fully enumerated or if any error occurred.
* Allow for including values in the initial message that discloses the handle.

Also use RFC 2119 key words in protocol spec.

Closes #384