### PR TITLE
Workaround issues on mono and get tests running

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -43,6 +43,10 @@ steps:
     testRunTitle: netcoreapp2.2-$(Agent.JobName)
     workingDirectory: src
 
+- powershell: mono $(NUGET_PACKAGES)/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/StreamJsonRpc.Tests/$(BuildConfiguration)/net472/StreamJsonRpc.Tests.dll -vsts -notrait "TestCategory=FailsInCloudTest" -noclass PerfTests
+  displayName: Run tests on mono
+  condition: ne(variables['Agent.OS'], 'Windows_NT') # The Windows Hosted agent doesn't include mono
+
 # We have to artifically run this script so that the extra .nupkg is produced for variables/InsertConfigValues.ps1 to notice.
 - powershell: azure-pipelines\artifacts\VSInsertion.ps1
   displayName: Prepare VSInsertion artifact

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.combinatorial" Version="1.2.7" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.12" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -126,7 +126,9 @@ namespace StreamJsonRpc
             }
 
             // When there is a CancellationToken parameter, we require that it always be the last parameter.
-            Span<ParameterInfo> methodParametersExcludingCancellationToken = method.Parameters.AsSpan(0, method.TotalParamCountExcludingCancellationToken);
+            Span<ParameterInfo> methodParametersExcludingCancellationToken = Utilities.IsRunningOnMono
+                ? method.Parameters.Take(method.TotalParamCountExcludingCancellationToken).ToArray()
+                : method.Parameters.AsSpan(0, method.TotalParamCountExcludingCancellationToken);
             Span<object> argumentsExcludingCancellationToken = arguments.Slice(0, method.TotalParamCountExcludingCancellationToken);
             if (method.HasCancellationTokenParameter)
             {

--- a/src/StreamJsonRpc/Utilities.cs
+++ b/src/StreamJsonRpc/Utilities.cs
@@ -10,6 +10,11 @@ namespace StreamJsonRpc
     internal static class Utilities
     {
         /// <summary>
+        /// Gets a value indicating whether the mono runtime is executing this code.
+        /// </summary>
+        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+
+        /// <summary>
         /// Reads an <see cref="int"/> value from a buffer using big endian.
         /// </summary>
         /// <param name="sequence">The sequence of bytes to read from. Must be at least 4 bytes long.</param>


### PR DESCRIPTION
Add a workaround to a mono bug so StreamJsonRpc can run on mono (and support VS 4 Mac).
This also gets all our unit tests running on mono on Azure Pipelines except for the `PerfTests` class, which causes mono to crash.

Fixes #387