### PR TITLE
Merge v2.2 to master

### DIFF
--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -5,7 +5,7 @@ schedules:
   displayName: Weekly OptProf run
   branches:
     include:
-    - v2.1
+    - v2.2
     - master
   always: true # we must keep data fresh since optimizationdata drops are purged after 30 days
 
@@ -25,6 +25,8 @@ variables:
   value: Release
 - name: BuildPlatform
   value: Any CPU
+- name: NUGET_PACKAGES
+  value: $(Agent.TempDirectory)/.nuget/packages
 - name: push_to_ci
   value: true
 - name: PublicRelease

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -43,7 +43,7 @@ steps:
     testRunTitle: netcoreapp2.2-$(Agent.JobName)
     workingDirectory: src
 
-- powershell: mono $(NUGET_PACKAGES)/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/StreamJsonRpc.Tests/$(BuildConfiguration)/net472/StreamJsonRpc.Tests.dll -vsts -notrait "TestCategory=FailsInCloudTest" -noclass PerfTests
+- powershell: mono $(NUGET_PACKAGES)/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/StreamJsonRpc.Tests/$(BuildConfiguration)/net472/StreamJsonRpc.Tests.dll -vsts -notrait "TestCategory=FailsInCloudTest" -notrait "FailsOnMono=true"
   displayName: Run tests on mono
   condition: ne(variables['Agent.OS'], 'Windows_NT') # The Windows Hosted agent doesn't include mono
 

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -43,6 +43,10 @@ steps:
     testRunTitle: netcoreapp2.2-$(Agent.JobName)
     workingDirectory: src
 
+- powershell: mono $(NUGET_PACKAGES)/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/StreamJsonRpc.Tests/$(BuildConfiguration)/net472/StreamJsonRpc.Tests.dll -vsts -notrait "TestCategory=FailsInCloudTest" -noclass PerfTests
+  displayName: Run tests on mono
+  condition: ne(variables['Agent.OS'], 'Windows_NT') # The Windows Hosted agent doesn't include mono
+
 # We have to artifically run this script so that the extra .nupkg is produced for variables/InsertConfigValues.ps1 to notice.
 - powershell: azure-pipelines\artifacts\VSInsertion.ps1
   displayName: Prepare VSInsertion artifact

--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -433,6 +433,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
     [SkippableFact]
     [Trait("GC", "")]
+    [Trait("FailsOnMono", "true")]
     public async Task ArgumentEnumerable_ReleasedOnErrorInSubsequentArgumentSerialization()
     {
         WeakReference enumerable = await this.ArgumentEnumerable_ReleasedOnErrorInSubsequentArgumentSerialization_Helper();
@@ -441,6 +442,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
     [SkippableFact]
     [Trait("GC", "")]
+    [Trait("FailsOnMono", "true")]
     public async Task ArgumentEnumerable_ReleasedWhenIgnoredBySuccessfulRpcCall()
     {
         WeakReference enumerable = await this.ArgumentEnumerable_ReleasedWhenIgnoredBySuccessfulRpcCall_Helper();
@@ -449,6 +451,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
     [SkippableFact]
     [Trait("GC", "")]
+    [Trait("FailsOnMono", "true")]
     public async Task ArgumentEnumerable_ForciblyDisposedAndReleasedWhenNotDisposedWithinRpcCall()
     {
         WeakReference enumerable = await this.ArgumentEnumerable_ForciblyDisposedAndReleasedWhenNotDisposedWithinRpcCall_Helper();

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -290,6 +290,7 @@ public abstract class JsonRpcTests : TestBase
     [SkippableFact]
     [Trait("GC", "")]
     [Trait("TestCategory", "FailsInCloudTest")] // Test showing unstability on Azure Pipelines, but always succeeds locally.
+    [Trait("FailsOnMono", "true")]
     public async Task InvokeWithProgressParameter_NoMemoryLeakConfirm()
     {
         Skip.If(IsRunningUnderLiveUnitTest);
@@ -299,6 +300,7 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    [Trait("FailsOnMono", "true")]
     public async Task NotifyWithProgressParameter_NoMemoryLeakConfirm()
     {
         WeakReference weakRef = await this.NotifyAsyncWithProgressParameter_NoMemoryLeakConfirm_Helper();

--- a/src/StreamJsonRpc.Tests/PerfTests.cs
+++ b/src/StreamJsonRpc.Tests/PerfTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 [Trait("Category", "SkipWhenLiveUnitTesting")] // very slow test
+[Trait("FailsOnMono", "true")]
 public class PerfTests
 {
     private readonly ITestOutputHelper logger;

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.combinatorial" Version="1.2.7" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.12" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Helper methods for dynamically generated proxies to invoke.
+    /// This type is only public because mono does not support IgnoresAccessChecksToAttribute. Do not call directly.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This class is only for invoking from dynamically generated code.")]
+    public static class CodeGenHelpers
+    {
+        /// <inheritdoc cref="ProxyGeneration.AsyncEnumerableProxy{T}"/>
+        public static IAsyncEnumerable<T> CreateAsyncEnumerableProxy<T>(Task<IAsyncEnumerable<T>> enumerableTask, CancellationToken defaultCancellationToken) => new ProxyGeneration.AsyncEnumerableProxy<T>(enumerableTask, defaultCancellationToken);
+    }
+}

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -127,7 +127,9 @@ namespace StreamJsonRpc
             }
 
             // When there is a CancellationToken parameter, we require that it always be the last parameter.
-            Span<ParameterInfo> methodParametersExcludingCancellationToken = method.Parameters.AsSpan(0, method.TotalParamCountExcludingCancellationToken);
+            Span<ParameterInfo> methodParametersExcludingCancellationToken = Utilities.IsRunningOnMono
+                ? method.Parameters.Take(method.TotalParamCountExcludingCancellationToken).ToArray()
+                : method.Parameters.AsSpan(0, method.TotalParamCountExcludingCancellationToken);
             Span<object?> argumentsExcludingCancellationToken = arguments.Slice(0, method.TotalParamCountExcludingCancellationToken);
             if (method.HasCancellationTokenParameter)
             {

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <Description>A cross-platform .NET portable library that implements the JSON-RPC wire protocol and can use System.IO.Stream or WebSocket so you can use it with any transport.</Description>
+    <Description>A cross-platform .NETStandard library that implements the JSON-RPC wire protocol and can use System.IO.Stream, System.IO.Pipelines or WebSocket so you can use it with any transport.</Description>
     <PackageTags>visualstudio stream json rpc jsonrpc</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/StreamJsonRpc/Utilities.cs
+++ b/src/StreamJsonRpc/Utilities.cs
@@ -10,6 +10,11 @@ namespace StreamJsonRpc
     internal static class Utilities
     {
         /// <summary>
+        /// Gets a value indicating whether the mono runtime is executing this code.
+        /// </summary>
+        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+
+        /// <summary>
         /// Reads an <see cref="int"/> value from a buffer using big endian.
         /// </summary>
         /// <param name="sequence">The sequence of bytes to read from. Must be at least 4 bytes long.</param>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -29,6 +29,7 @@ StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.set -> void
+StreamJsonRpc.Reflection.CodeGenHelpers
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcMessageEventArgs>
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
@@ -81,6 +82,7 @@ static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collecti
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithPrefetchAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>
+static StreamJsonRpc.Reflection.CodeGenHelpers.CreateAsyncEnumerableProxy<T>(System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>> enumerableTask, System.Threading.CancellationToken defaultCancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -29,6 +29,7 @@ StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcRequest.RequestId.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcResult.RequestId.set -> void
+StreamJsonRpc.Reflection.CodeGenHelpers
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.RequestTransmissionAborted -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcMessageEventArgs>
 StreamJsonRpc.Reflection.IJsonRpcFormatterCallbacks.ResponseReceived -> System.EventHandler<StreamJsonRpc.Reflection.JsonRpcResponseEventArgs>
@@ -81,6 +82,7 @@ static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collecti
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithJsonRpcSettings<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.WithPrefetchAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T> enumerable, int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>
+static StreamJsonRpc.Reflection.CodeGenHelpers.CreateAsyncEnumerableProxy<T>(System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>> enumerableTask, System.Threading.CancellationToken defaultCancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanDeserialize(System.Type objectType) -> bool
 static StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.CanSerialize(System.Type objectType) -> bool
 static StreamJsonRpc.RequestId.NotSpecified.get -> StreamJsonRpc.RequestId


### PR DESCRIPTION
More than a merge... this required some fixes to run on mono, which v2.2 brought in and collided with other changes unique to master that broke mono further than v2.2 had fixed up for.