### PR TITLE
Include RPC server stack trace in RemoteInvocationException.ToString()

### DIFF
--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -72,6 +72,7 @@ const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyNa
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
+override StreamJsonRpc.RemoteInvocationException.ToString() -> string
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -72,6 +72,7 @@ const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyNa
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
+override StreamJsonRpc.RemoteInvocationException.ToString() -> string
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int


### PR DESCRIPTION
It isn't always possible to do, but when the server provides a `CommonErrorData` object, we certainly can do it.
I endeavored to copy the string format that .NET uses for its own exception formatting, including for inner exceptions.

Closes #369