### PR TITLE
Avoid synchronous blocking in common case from JsonRpc.Dispose

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1880,18 +1880,37 @@ namespace StreamJsonRpc
                 // Dispose the stream and fault pending requests in the finally block
                 // So this is executed even if Disconnected event handler throws.
                 this.disconnectedSource.Cancel();
-                (this.MessageHandler as IDisposable)?.Dispose();
+
+                Task messageHandlerDisposal = Task.CompletedTask;
+                if (this.MessageHandler is MessageHandlerBase asyncDisposableMessageHandler)
+                {
+                    messageHandlerDisposal = asyncDisposableMessageHandler.DisposeAsync();
+                }
+                else if (this.MessageHandler is IDisposable disposableMessageHandler)
+                {
+                    disposableMessageHandler.Dispose();
+                }
+
                 this.FaultPendingRequests();
 
-                // Ensure the Task we may have returned from Completion is completed.
-                if (eventArgs.Exception != null)
-                {
-                    this.completionSource.TrySetException(eventArgs.Exception);
-                }
-                else
-                {
-                    this.completionSource.TrySetResult(true);
-                }
+                // Ensure the Task we may have returned from Completion is completed,
+                // but not before any asynchronous disposal of our message handler completes.
+                messageHandlerDisposal.ContinueWith(
+                    handlerDisposal =>
+                    {
+                        Exception fault = eventArgs.Exception ?? handlerDisposal.Exception;
+                        if (fault != null)
+                        {
+                            this.completionSource.TrySetException(fault);
+                        }
+                        else
+                        {
+                            this.completionSource.TrySetResult(true);
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default).Forget();
             }
         }
 

--- a/src/StreamJsonRpc/MessageHandlerBase.cs
+++ b/src/StreamJsonRpc/MessageHandlerBase.cs
@@ -274,7 +274,9 @@ namespace StreamJsonRpc
         /// <summary>
         /// Disposes this instance, and cancels any pending read or write operations.
         /// </summary>
-        private protected virtual async Task DisposeAsync()
+#pragma warning disable SA1202 // Elements should be ordered by access - keep change minimal for v2.2 servicing.
+        internal virtual async Task DisposeAsync()
+#pragma warning restore SA1202 // Elements should be ordered by access
         {
             if (!this.disposalTokenSource.IsCancellationRequested)
             {


### PR DESCRIPTION
Fixes #396

**Important**: after completing this PR, the commits should be merged into master right away and completely neutralized. That is, run a merge that effectively excludes these commits changes. The changes are already in master and are leading to merge conflicts now with this change.