### PR TITLE
Fix verbose RPC message tracing

### DIFF
--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -17,9 +17,8 @@ namespace StreamJsonRpc
     using System.Threading.Tasks;
     using Microsoft;
     using Nerdbank.Streams;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using StreamJsonRpc.Protocol;
+    using StreamJsonRpc.Reflection;
 
     /// <summary>
     /// Adds headers before each text message transmitted over a stream.
@@ -209,6 +208,15 @@ namespace StreamJsonRpc
             {
                 this.Formatter.Serialize(this.contentSequenceBuilder, content);
                 ReadOnlySequence<byte> contentSequence = this.contentSequenceBuilder.AsReadOnlySequence;
+
+                // Some formatters (e.g. MessagePackFormatter) needs the encoded form in order to produce JSON for tracing.
+                // Other formatters (e.g. JsonMessageFormatter) would prefer to do its own tracing while it still has a JToken.
+                // We only help the formatters that need the byte-encoded form here. The rest can do it themselves.
+                if (this.Formatter is IJsonRpcFormatterTracingCallbacks tracer)
+                {
+                    tracer.OnSerializationComplete(content, this.contentSequenceBuilder);
+                }
+
                 Memory<byte> headerMemory = this.Writer.GetMemory(1024);
                 int bytesWritten = 0;
 

--- a/src/StreamJsonRpc/IJsonRpcMessageFormatter.cs
+++ b/src/StreamJsonRpc/IJsonRpcMessageFormatter.cs
@@ -3,8 +3,10 @@
 
 namespace StreamJsonRpc
 {
+    using System;
     using System.Buffers;
     using StreamJsonRpc.Protocol;
+    using StreamJsonRpc.Reflection;
 
     /// <summary>
     /// An interface that offers <see cref="JsonRpcMessage"/> serialization to and from a sequence of bytes.
@@ -30,6 +32,7 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="message">The message to be traced.</param>
         /// <returns>Any object whose <see cref="object.ToString()"/> method will produce a human-readable JSON string, suitable for tracing.</returns>
+        [Obsolete("Tracing is now done via the " + nameof(IJsonRpcTracingCallbacks) + " and " + nameof(IJsonRpcFormatterTracingCallbacks) + " interfaces. Formatters may throw NotSupportedException from this method.")]
         object GetJsonText(JsonRpcMessage message);
     }
 }

--- a/src/StreamJsonRpc/Reflection/IJsonRpcFormatterTracingCallbacks.cs
+++ b/src/StreamJsonRpc/Reflection/IJsonRpcFormatterTracingCallbacks.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System.Buffers;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// Optionally implemented by a <see cref="IJsonRpcMessageFormatter"/> when it needs the fully serialized sequence in order to trace the JSON representation of the message.
+    /// </summary>
+    public interface IJsonRpcFormatterTracingCallbacks
+    {
+        /// <summary>
+        /// Invites the formatter to call <see cref="IJsonRpcTracingCallbacks.OnMessageSerialized(JsonRpcMessage, object)"/> with the JSON representation of the message just serialized..
+        /// </summary>
+        /// <param name="message">The message that was just serialized.</param>
+        /// <param name="encodedMessage">The encoded copy of the message, as it recently came from the <see cref="IJsonRpcMessageFormatter.Serialize(IBufferWriter{byte}, JsonRpcMessage)"/> method.</param>
+        void OnSerializationComplete(JsonRpcMessage message, ReadOnlySequence<byte> encodedMessage);
+    }
+}

--- a/src/StreamJsonRpc/Reflection/IJsonRpcTracingCallbacks.cs
+++ b/src/StreamJsonRpc/Reflection/IJsonRpcTracingCallbacks.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An interface implemented by <see cref="JsonRpc"/> for <see cref="IJsonRpcMessageFormatter"/> implementations to use to facilitate message tracing.
+    /// </summary>
+    public interface IJsonRpcTracingCallbacks
+    {
+        /// <summary>
+        /// Occurs when the <see cref="IJsonRpcMessageFormatter"/> has serialized a message for transmission.
+        /// </summary>
+        /// <param name="message">The JSON-RPC message.</param>
+        /// <param name="encodedMessage">The encoded form of the message. Calling <see cref="object.ToString()"/> on this should produce the JSON-RPC text of the message.</param>
+        void OnMessageSerialized(JsonRpcMessage message, object encodedMessage);
+
+        /// <summary>
+        /// Occurs when the <see cref="IJsonRpcMessageFormatter"/> has deserialized an incoming message.
+        /// </summary>
+        /// <param name="message">The JSON-RPC message.</param>
+        /// <param name="encodedMessage">The encoded form of the message. Calling <see cref="object.ToString()"/> on this should produce the JSON-RPC text of the message.</param>
+        void OnMessageDeserialized(JsonRpcMessage message, object encodedMessage);
+    }
+}

--- a/src/StreamJsonRpc/Utilities.cs
+++ b/src/StreamJsonRpc/Utilities.cs
@@ -58,5 +58,21 @@ namespace StreamJsonRpc
             buffer[2] = (byte)(value >> 8);
             buffer[3] = (byte)value;
         }
+
+        /// <summary>
+        /// Copies a <see cref="ReadOnlySequence{T}"/> to an <see cref="IBufferWriter{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of element to copy.</typeparam>
+        /// <param name="sequence">The sequence to read from.</param>
+        /// <param name="writer">The target to write to.</param>
+        internal static void CopyTo<T>(this in ReadOnlySequence<T> sequence, IBufferWriter<T> writer)
+        {
+            Requires.NotNull(writer, nameof(writer));
+
+            foreach (ReadOnlyMemory<T> segment in sequence)
+            {
+                writer.Write(segment.Span);
+            }
+        }
     }
 }

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -38,8 +38,13 @@ StreamJsonRpc.Reflection.IJsonRpcFormatterState
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingRequest.get -> bool
+StreamJsonRpc.Reflection.IJsonRpcFormatterTracingCallbacks
+StreamJsonRpc.Reflection.IJsonRpcFormatterTracingCallbacks.OnSerializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message, System.Buffers.ReadOnlySequence<byte> encodedMessage) -> void
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks.OnMessageDeserialized(StreamJsonRpc.Protocol.JsonRpcMessage message, object encodedMessage) -> void
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks.OnMessageSerialized(StreamJsonRpc.Protocol.JsonRpcMessage message, object encodedMessage) -> void
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.JsonRpcMessageEventArgs(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.RequestId.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -38,8 +38,13 @@ StreamJsonRpc.Reflection.IJsonRpcFormatterState
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Reflection.IJsonRpcFormatterState.SerializingRequest.get -> bool
+StreamJsonRpc.Reflection.IJsonRpcFormatterTracingCallbacks
+StreamJsonRpc.Reflection.IJsonRpcFormatterTracingCallbacks.OnSerializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message, System.Buffers.ReadOnlySequence<byte> encodedMessage) -> void
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager
 StreamJsonRpc.Reflection.IJsonRpcMessageBufferManager.DeserializationComplete(StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks.OnMessageDeserialized(StreamJsonRpc.Protocol.JsonRpcMessage message, object encodedMessage) -> void
+StreamJsonRpc.Reflection.IJsonRpcTracingCallbacks.OnMessageSerialized(StreamJsonRpc.Protocol.JsonRpcMessage message, object encodedMessage) -> void
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.JsonRpcMessageEventArgs(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.Reflection.JsonRpcMessageEventArgs.RequestId.get -> StreamJsonRpc.RequestId


### PR DESCRIPTION
We have JsonConverter and IMessagePackFormatter<T> types that have side effects in order to support marshaling of special objects. This makes tracing the full JSON-RPC message hazardous if it means we run these custom serializers multiple times per message, and this is in fact happening lately.

The fix is to be sure we only serialize/deserialize a message *once*. This means that the result of the serialization must be retained long enough to trace (if tracing is turned on). It also means we need to retain the text that was *de*serialized long enough to be traced. We also don't want to allocate a string for the entire message unless tracing requires it.

The approach varies between formatters, as follows:

For the `JsonMessageFormatter` we have a super-convenient `JToken` instance that represents the entire message either after serialization or before deserialization. This type knows how to render a string representation of itself. So for this formatter we simply raise the trace events with the `JToken` as a parameter, which the string formatter will call `ToString` on if a trace listener wants it as a string.

For the `MessagePackFormatter` it's a little more complicated. There is no native JSON text representation at all (since msgpack is a binary encoding). But we still want to trace a JSON text representation for logging/diagnostics purposes. MessagePack has a converter that translates msgpack binary to JSON text, but this requires that we have the entire msgpack byte sequence. When deserializing this is easy enough: we have the sequence to deserialize from anyway. But when serializing, we're writing to an `IBufferWriter<T>` which doesn't give us access to access the serialized binary later. So seeing the full msgpack that was serialized in order to convert to JSON and trace it is something the formatter needs help with. The message handlers have access to the full msgpack to be written, so we arrange for the handlers to "call back" into the formatter after the formatter is done serializing in order to say "by the way, here's the full sequence you just wrote out" which the formatter can then use to raise the trace event with an object that will convert it to JSON text if/when the object's ToString() method is called. This call back from the handler into the formatter is through an optional interface that only the `MessagePackFormatter` needs to implement.

As part of this 'callback' from handler to formatter, the `LengthHeaderMessageHandler` needed a slightly revision: it didn't have a way to collect the entire serialized sequence written by the formatter because the `PrefixingBufferWriter<T>` doesn't expose a `ReadOnlySequence<T>` for all the written bytes like `Sequence<T>` does. So I had to switch to `Sequence<T>` in this handler. This means that small messages will have their buffer copied (even when not tracing) once before being transmitted where they weren't being copied before. But these are small messages so the impact is likely very small. Large messages were already getting copied anyway, so no difference there.

So with this change we now have safe and complete tracing of JSON-RPC messages for all handlers and formatters, and without nasty doubling of side-effects.

Fixes #386