### PR TITLE
Report argument deserialization failures more precisely

### DIFF
--- a/src/StreamJsonRpc.Tests/Exceptions/RemoteInvocationExceptionTests.cs
+++ b/src/StreamJsonRpc.Tests/Exceptions/RemoteInvocationExceptionTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RemoteInvocationExceptionTests : TestBase
+{
+    private const string SomeMessage = "test message";
+    private static readonly Exception SomeInnerException = new Exception();
+
+    public RemoteInvocationExceptionTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void Ctor_Message_Code_Data()
+    {
+        var data = new CommonErrorData();
+        var ex = new RemoteInvocationException(SomeMessage, 123, data);
+        Assert.Equal(SomeMessage, ex.Message);
+        Assert.Equal(123, ex.ErrorCode);
+        Assert.Same(data, ex.ErrorData);
+        Assert.Null(ex.DeserializedErrorData);
+    }
+
+    [Fact]
+    public void Ctor_Message_Code_Data_DeserializedData()
+    {
+        var data = new CommonErrorData();
+        var deserializedData = new CommonErrorData();
+        var ex = new RemoteInvocationException(SomeMessage, 123, data, deserializedData);
+        Assert.Equal(SomeMessage, ex.Message);
+        Assert.Equal(123, ex.ErrorCode);
+        Assert.Same(data, ex.ErrorData);
+        Assert.Same(deserializedData, ex.DeserializedErrorData);
+    }
+
+    [Fact]
+    public void Serializable()
+    {
+        var data = new CommonErrorData();
+        var deserializedData = new CommonErrorData();
+        var original = new RemoteInvocationException(SomeMessage, 123, data, deserializedData);
+        var deserialized = BinaryFormatterRoundtrip(original);
+        Assert.Equal(original.Message, deserialized.Message);
+        Assert.Equal(original.ErrorCode, deserialized.ErrorCode);
+        Assert.Null(deserialized.ErrorData);
+        Assert.Null(deserialized.DeserializedErrorData);
+    }
+}

--- a/src/StreamJsonRpc.Tests/Exceptions/RpcArgumentDeserializationExceptionTests.cs
+++ b/src/StreamJsonRpc.Tests/Exceptions/RpcArgumentDeserializationExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RpcArgumentDeserializationExceptionTests : TestBase
+{
+    private const string SomeMessage = "test message";
+    private static readonly Exception SomeInnerException = new Exception();
+
+    public RpcArgumentDeserializationExceptionTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void Ctor_Message()
+    {
+        var ex = new RpcArgumentDeserializationException(SomeMessage);
+        Assert.Equal(SomeMessage, ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_Message_Exception()
+    {
+        var ex = new RpcArgumentDeserializationException(SomeMessage, SomeInnerException);
+        Assert.Equal(SomeMessage, ex.Message);
+        Assert.Same(SomeInnerException, ex.InnerException);
+    }
+
+    [Fact]
+    public void Ctor_WithDetails()
+    {
+        var ex = new RpcArgumentDeserializationException("argName", 67856, typeof(RpcArgumentDeserializationExceptionTests), SomeInnerException);
+        Assert.Equal("argName", ex.ArgumentName);
+        Assert.Equal(67856, ex.ArgumentPosition);
+        Assert.Equal(typeof(RpcArgumentDeserializationExceptionTests), ex.DeserializedType);
+        Assert.Same(SomeInnerException, ex.InnerException);
+    }
+
+    [Fact]
+    public void Serializable_WithPosition()
+    {
+        var original = new RpcArgumentDeserializationException("argName", 67856, typeof(RpcArgumentDeserializationExceptionTests), SomeInnerException);
+        var deserialized = BinaryFormatterRoundtrip(original);
+        Assert.Equal(original.Message, deserialized.Message);
+        Assert.Equal(original.ArgumentName, deserialized.ArgumentName);
+        Assert.Equal(original.ArgumentPosition, deserialized.ArgumentPosition);
+    }
+
+    [Fact]
+    public void Serializable_WithNoPosition()
+    {
+        var original = new RpcArgumentDeserializationException("argName", argumentPosition: null, typeof(RpcArgumentDeserializationExceptionTests), SomeInnerException);
+        var deserialized = BinaryFormatterRoundtrip(original);
+        Assert.Equal(original.Message, deserialized.Message);
+        Assert.Equal(original.ArgumentName, deserialized.ArgumentName);
+        Assert.Equal(original.ArgumentPosition, deserialized.ArgumentPosition);
+    }
+}

--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -240,7 +240,7 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
     {
         public override TypeThrowsWhenDeserialized ReadJson(JsonReader reader, Type objectType, TypeThrowsWhenDeserialized existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            throw new Exception("This exception is meant to be thrown.");
+            throw CreateExceptionToBeThrownByDeserializer();
         }
 
         public override void WriteJson(JsonWriter writer, TypeThrowsWhenDeserialized value, JsonSerializer serializer)

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -86,7 +86,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
     {
         public TypeThrowsWhenDeserialized Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            throw new Exception("This exception is meant to be thrown.");
+            throw CreateExceptionToBeThrownByDeserializer();
         }
 
         public void Serialize(ref MessagePackWriter writer, TypeThrowsWhenDeserialized value, MessagePackSerializerOptions options)

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1644,7 +1644,11 @@ public abstract class JsonRpcTests : TestBase
     [Fact]
     public async Task MethodArgThrowsOnDeserialization()
     {
-        await this.clientRpc.InvokeWithCancellationAsync(nameof(Server.MethodWithArgThatFailsToDeserialize), new object[] { new TypeThrowsWhenDeserialized() }, this.TimeoutToken).WithCancellation(this.TimeoutToken);
+        var ex = await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => this.clientRpc.InvokeWithCancellationAsync(nameof(Server.MethodWithArgThatFailsToDeserialize), new object[] { new TypeThrowsWhenDeserialized() }, this.TimeoutToken)).WithCancellation(this.TimeoutToken);
+        var expectedErrorMessage = CreateExceptionToBeThrownByDeserializer().Message;
+        Assert.Equal(JsonRpcErrorCode.InvalidParams, ex.ErrorCode);
+        var data = Assert.IsType<CommonErrorData>(ex.DeserializedErrorData);
+        Assert.Contains(FlattenCommonErrorData(data), d => d.Message?.Contains(expectedErrorMessage) ?? false);
     }
 
     [Fact]
@@ -1657,6 +1661,8 @@ public abstract class JsonRpcTests : TestBase
         Assert.NotNull(errorData.StackTrace);
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
     }
+
+    protected static Exception CreateExceptionToBeThrownByDeserializer() => new Exception("This exception is meant to be thrown.");
 
     protected override void Dispose(bool disposing)
     {
@@ -1696,6 +1702,15 @@ public abstract class JsonRpcTests : TestBase
         string header = $"Content-Length: {json.Length}\r\n\r\n";
         byte[] buffer = Encoding.ASCII.GetBytes(header + json);
         receivingStream.Write(buffer, 0, buffer.Length);
+    }
+
+    private static IEnumerable<CommonErrorData> FlattenCommonErrorData(CommonErrorData? errorData)
+    {
+        while (errorData is object)
+        {
+            yield return errorData;
+            errorData = errorData.Inner;
+        }
     }
 
     private void ReinitializeRpcWithoutListening()

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1642,6 +1642,12 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task MethodArgThrowsOnDeserialization()
+    {
+        await this.clientRpc.InvokeWithCancellationAsync(nameof(Server.MethodWithArgThatFailsToDeserialize), new object[] { new TypeThrowsWhenDeserialized() }, this.TimeoutToken).WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
     public async Task CanPassExceptionFromServer_DeserializedErrorData()
     {
         RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.MethodThatThrowsUnauthorizedAccessException)));
@@ -1885,6 +1891,10 @@ public abstract class JsonRpcTests : TestBase
         }
 
         public TypeThrowsWhenDeserialized GetTypeThrowsWhenDeserialized() => new TypeThrowsWhenDeserialized();
+
+        public void MethodWithArgThatFailsToDeserialize(TypeThrowsWhenDeserialized arg1)
+        {
+        }
 
         public int? MethodReturnsNullableInt(int a) => a > 0 ? (int?)a : null;
 

--- a/src/StreamJsonRpc.Tests/TestBase.cs
+++ b/src/StreamJsonRpc.Tests/TestBase.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
@@ -64,6 +66,15 @@ public abstract class TestBase : IDisposable
         }
 
         return resultTcs.Task;
+    }
+
+    protected static T BinaryFormatterRoundtrip<T>(T original)
+    {
+        var bf = new BinaryFormatter();
+        var ms = new MemoryStream();
+        bf.Serialize(ms, original);
+        ms.Position = 0;
+        return (T)bf.Deserialize(ms);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -5,6 +5,7 @@ namespace StreamJsonRpc
 {
     using System;
     using System.IO;
+    using System.Runtime.Serialization;
     using System.Text;
     using Newtonsoft.Json.Linq;
     using StreamJsonRpc.Protocol;
@@ -15,7 +16,7 @@ namespace StreamJsonRpc
     /// <remarks>
     /// The details of the target method exception can be found on the <see cref="ErrorCode"/> and <see cref="ErrorData"/> properties.
     /// </remarks>
-    [System.Serializable]
+    [Serializable]
     public class RemoteInvocationException : RemoteRpcException
     {
         /// <summary>
@@ -51,11 +52,10 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="info">Serialization info.</param>
         /// <param name="context">Streaming context.</param>
-        protected RemoteInvocationException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
+        protected RemoteInvocationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            this.ErrorCode = info.GetInt32(nameof(this.ErrorCode));
         }
 
         /// <summary>
@@ -108,6 +108,13 @@ namespace StreamJsonRpc
             }
 
             return result;
+        }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(this.ErrorCode), this.ErrorCode);
         }
 
         private static void ContributeInnerExceptionDetails(StringBuilder builder, CommonErrorData errorData)

--- a/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
@@ -6,6 +6,8 @@ namespace StreamJsonRpc
     using System;
     using System.Runtime.Serialization;
     using Microsoft;
+    using Newtonsoft.Json.Linq;
+    using StreamJsonRpc.Protocol;
 
     /// <summary>
     /// Remote RPC exception that indicates that the requested target method was not found on the server.
@@ -24,11 +26,17 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="message">Exception message describing why the method was not found.</param>
         /// <param name="targetMethod">Target method that was not found.</param>
-        internal RemoteMethodNotFoundException(string? message, string targetMethod)
+        /// <param name="errorCode">The value of the error.code field in the response.</param>
+        /// <param name="errorData">The value of the error.data field in the response.</param>
+        /// <param name="deserializedErrorData">The value of the error.data field in the response, deserialized according to <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.</param>
+        internal RemoteMethodNotFoundException(string? message, string targetMethod, JsonRpcErrorCode errorCode, object? errorData, object? deserializedErrorData)
             : base(message)
         {
             Requires.NotNullOrEmpty(targetMethod, nameof(targetMethod));
+            this.ErrorCode = errorCode;
             this.TargetMethod = targetMethod;
+            this.ErrorData = errorData;
+            this.DeserializedErrorData = deserializedErrorData;
         }
 
         /// <summary>
@@ -46,6 +54,34 @@ namespace StreamJsonRpc
         /// Gets the name of the target method that was not found.
         /// </summary>
         public string TargetMethod { get; }
+
+        /// <summary>
+        /// Gets the value of the <c>error.code</c> field in the response.
+        /// </summary>
+        /// <value>
+        /// The value is typically either <see cref="JsonRpcErrorCode.InvalidParams"/> or <see cref="JsonRpcErrorCode.MethodNotFound"/>.
+        /// </value>
+        public JsonRpcErrorCode ErrorCode { get; }
+
+        /// <summary>
+        /// Gets the <c>error.data</c> value in the error response, if one was provided.
+        /// </summary>
+        /// <remarks>
+        /// Depending on the <see cref="IJsonRpcMessageFormatter"/> used, the value of this property, if any,
+        /// may be a <see cref="JToken"/> or a deserialized object.
+        /// If a deserialized object, the type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
+        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
+        /// </remarks>
+        public object? ErrorData { get; }
+
+        /// <summary>
+        /// Gets the <c>error.data</c> value in the error response, if one was provided.
+        /// </summary>
+        /// <remarks>
+        /// The type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
+        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
+        /// </remarks>
+        public object? DeserializedErrorData { get; }
 
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/StreamJsonRpc/Exceptions/RpcArgumentDeserializationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RpcArgumentDeserializationException.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Globalization;
+    using System.Runtime.Serialization;
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An exception thrown from <see cref="JsonRpcRequest.TryGetArgumentByNameOrIndex(string?, int, Type?, out object?)"/>
+    /// when the argument cannot be deserialized to the requested type, typically due to an incompatibility or exception thrown from the deserializer.
+    /// </summary>
+    [Serializable]
+    public class RpcArgumentDeserializationException : RemoteRpcException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcArgumentDeserializationException"/> class.
+        /// </summary>
+        /// <param name="argumentName">The name of the argument from the JSON-RPC request that failed to deserialize, if available.</param>
+        /// <param name="argumentPosition">The 0-based index of the argument from the JSON-RPC request that failed to deserialize, if available.</param>
+        /// <param name="deserializedType">The <see cref="Type"/> to which deserialization of the argument was attempted.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public RpcArgumentDeserializationException(string? argumentName, int? argumentPosition, Type? deserializedType, Exception? innerException)
+            : this(string.Format(CultureInfo.CurrentCulture, Resources.FailureDeserializingRpcArgument, argumentName, argumentPosition, deserializedType, innerException?.Message), innerException)
+        {
+            this.ArgumentName = argumentName;
+            this.ArgumentPosition = argumentPosition;
+            this.DeserializedType = deserializedType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcArgumentDeserializationException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="RpcArgumentDeserializationException(string, Exception)"/>
+        public RpcArgumentDeserializationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcArgumentDeserializationException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="RemoteRpcException(string, Exception)"/>
+        public RpcArgumentDeserializationException(string message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcArgumentDeserializationException"/> class.
+        /// </summary>
+        /// <param name="info">Serialization info.</param>
+        /// <param name="context">Serialization context.</param>
+        protected RpcArgumentDeserializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            this.ArgumentName = info.GetString(nameof(this.ArgumentName));
+            this.ArgumentPosition = info.GetInt32(nameof(this.ArgumentPosition));
+            if (this.ArgumentPosition == -1)
+            {
+                this.ArgumentPosition = null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the argument from the JSON-RPC request that failed to deserialize, if available.
+        /// </summary>
+        /// <remarks>
+        /// This value will be <c>null</c> when the JSON-RPC request uses positional arguments.
+        /// </remarks>
+        public string? ArgumentName { get; private set; }
+
+        /// <summary>
+        /// Gets the 0-based index of the argument from the JSON-RPC request that failed to deserialize, if available.
+        /// </summary>
+        /// <remarks>
+        /// This value will be <c>null</c> when the JSON-RPC request uses named arguments.
+        /// </remarks>
+        public int? ArgumentPosition { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="Type"/> to which deserialization of the argument was attempted.
+        /// </summary>
+        public Type? DeserializedType { get; private set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(this.ArgumentName), this.ArgumentName);
+            info.AddValue(nameof(this.ArgumentPosition), this.ArgumentPosition ?? -1);
+        }
+    }
+}

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -745,7 +745,7 @@ namespace StreamJsonRpc
                             this.formatter.rpc.TraceSource.TraceEvent(TraceEventType.Warning, (int)JsonRpc.TraceEvents.MethodArgumentDeserializationFailure, Resources.FailureDeserializingRpcArgument, name, position, typeHint, ex);
                         }
 
-                        return false;
+                        throw new RpcArgumentDeserializationException(name, position, typeHint, ex);
                     }
                 }
 

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -738,8 +738,13 @@ namespace StreamJsonRpc
 
                         return true;
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        if (this.formatter.rpc?.TraceSource.Switch.ShouldTrace(TraceEventType.Warning) ?? false)
+                        {
+                            this.formatter.rpc.TraceSource.TraceEvent(TraceEventType.Warning, (int)JsonRpc.TraceEvents.MethodArgumentDeserializationFailure, Resources.FailureDeserializingRpcArgument, name, position, typeHint, ex);
+                        }
+
                         return false;
                     }
                 }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1543,15 +1543,15 @@ namespace StreamJsonRpc
             Requires.NotNull(response, nameof(response));
 
             Assumes.NotNull(response.Error);
+            Type? dataType = this.GetErrorDetailsDataType(response);
+            object? deserializedData = dataType != null ? response.Error.GetData(dataType) : response.Error.Data;
             switch (response.Error.Code)
             {
                 case JsonRpcErrorCode.InvalidParams:
                 case JsonRpcErrorCode.MethodNotFound:
-                    return new RemoteMethodNotFoundException(response.Error.Message, targetName);
+                    return new RemoteMethodNotFoundException(response.Error.Message, targetName, response.Error.Code, response.Error.Data, deserializedData);
 
                 default:
-                    Type? dataType = this.GetErrorDetailsDataType(response);
-                    object? deserializedData = dataType != null ? response.Error.GetData(dataType) : response.Error.Data;
                     return new RemoteInvocationException(response.Error.Message, (int)response.Error.Code, response.Error.Data, deserializedData);
             }
         }
@@ -1928,6 +1928,7 @@ namespace StreamJsonRpc
                             {
                                 Code = JsonRpcErrorCode.InvalidParams,
                                 Message = targetMethod.LookupErrorMessage,
+                                Data = targetMethod.ArgumentDeserializationFailures is object ? new CommonErrorData(targetMethod.ArgumentDeserializationFailures) : null,
                             },
                         };
                     }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -373,6 +373,16 @@ namespace StreamJsonRpc
             /// An exception occurred when reading the $/progress notification.
             /// </summary>
             ProgressNotificationError,
+
+            /// <summary>
+            /// An incoming RPC call included an argument that failed to deserialize to the type on a candidate target method's proposed matching parameter.
+            /// </summary>
+            /// <remarks>
+            /// This may not represent a fatal error. When there are multiple overloads to choose from,
+            /// choosing the overload to invoke involves attempts to deserialize arguments to the types dictated by each overload's parameters.
+            /// Thus a failure recorded in this event may be followed by a successful deserialization to another parameter type and invocation of a different overload.
+            /// </remarks>
+            MethodArgumentDeserializationFailure,
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1329,11 +1329,6 @@ namespace StreamJsonRpc
                             typedArguments[0] = MessagePackSerializer.Deserialize(parameters[0].ParameterType, ref reader, this.formatter.userDataSerializationOptions);
                             return ArgumentMatchResult.Success;
                         }
-                        catch (NotSupportedException)
-                        {
-                            // This block can be removed after https://github.com/neuecc/MessagePack-CSharp/pull/633 is applied.
-                            return ArgumentMatchResult.ParameterArgumentTypeMismatch;
-                        }
                         catch (MessagePackSerializationException)
                         {
                             return ArgumentMatchResult.ParameterArgumentTypeMismatch;
@@ -1375,8 +1370,13 @@ namespace StreamJsonRpc
                     value = MessagePackSerializer.Deserialize(typeHint ?? typeof(object), ref reader, this.formatter.userDataSerializationOptions);
                     return true;
                 }
-                catch (MessagePackSerializationException)
+                catch (MessagePackSerializationException ex)
                 {
+                    if (this.formatter.rpc?.TraceSource.Switch.ShouldTrace(TraceEventType.Warning) ?? false)
+                    {
+                        this.formatter.rpc.TraceSource.TraceEvent(TraceEventType.Warning, (int)JsonRpc.TraceEvents.MethodArgumentDeserializationFailure, Resources.FailureDeserializingRpcArgument, name, position, typeHint, ex);
+                    }
+
                     value = null;
                     return false;
                 }

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1377,8 +1377,7 @@ namespace StreamJsonRpc
                         this.formatter.rpc.TraceSource.TraceEvent(TraceEventType.Warning, (int)JsonRpc.TraceEvents.MethodArgumentDeserializationFailure, Resources.FailureDeserializingRpcArgument, name, position, typeHint, ex);
                     }
 
-                    value = null;
-                    return false;
+                    throw new RpcArgumentDeserializationException(name, position, typeHint, ex);
                 }
                 finally
                 {

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -144,6 +144,7 @@ namespace StreamJsonRpc.Protocol
         /// The length of this span must equal the length of <paramref name="parameters"/>.
         /// </param>
         /// <returns><c>true</c> if all the arguments can conform to the types of the <paramref name="parameters"/> and <paramref name="typedArguments"/> is initialized; <c>false</c> otherwise.</returns>
+        /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
         public virtual ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
         {
             Requires.Argument(parameters.Length == typedArguments.Length, nameof(typedArguments), "Length of spans do not match.");
@@ -205,6 +206,7 @@ namespace StreamJsonRpc.Protocol
         /// A derived-type may override this method in order to consider the <paramref name="typeHint"/>
         /// and deserialize the required argument on-demand such that it can satisfy the type requirement.
         /// </remarks>
+        /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
         public virtual bool TryGetArgumentByNameOrIndex(string? name, int position, Type? typeHint, out object? value)
         {
             if (this.NamedArguments != null && name != null)

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deserializing JSON-RPC argument with name &quot;{0}&quot; and position {1} to type &quot;{2}&quot; failed: {3}.
+        /// </summary>
+        internal static string FailureDeserializingRpcArgument {
+            get {
+                return ResourceManager.GetString("FailureDeserializingRpcArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A fatal exception was thrown from the server method {0}: {1}.
         /// </summary>
         internal static string FatalExceptionWasThrown {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -162,6 +162,10 @@
     <value>Failure deserializing incoming JSON RPC '{0}': {1}</value>
     <comment>{0} is the JSON RPC, {1} is the exception message.</comment>
   </data>
+  <data name="FailureDeserializingRpcArgument" xml:space="preserve">
+    <value>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</value>
+    <comment>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</comment>
+  </data>
   <data name="FatalExceptionWasThrown" xml:space="preserve">
     <value>A fatal exception was thrown from the server method {0}: {1}</value>
     <comment>{0} is the exception type, {1} is the exception message</comment>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, ob
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.TraceEvents.MethodArgumentDeserializationFailure = 17 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings
 StreamJsonRpc.JsonRpcEnumerableSettings.JsonRpcEnumerableSettings() -> void
 StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -62,6 +62,9 @@ StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformatio
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
+StreamJsonRpc.RemoteMethodNotFoundException.DeserializedErrorData.get -> object
+StreamJsonRpc.RemoteMethodNotFoundException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode
+StreamJsonRpc.RemoteMethodNotFoundException.ErrorData.get -> object
 StreamJsonRpc.RequestId
 StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
@@ -69,6 +72,14 @@ StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
 StreamJsonRpc.RequestId.RequestId(string id) -> void
 StreamJsonRpc.RequestId.String.get -> string
+StreamJsonRpc.RpcArgumentDeserializationException
+StreamJsonRpc.RpcArgumentDeserializationException.ArgumentName.get -> string
+StreamJsonRpc.RpcArgumentDeserializationException.ArgumentPosition.get -> int?
+StreamJsonRpc.RpcArgumentDeserializationException.DeserializedType.get -> System.Type
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string argumentName, int? argumentPosition, System.Type deserializedType, System.Exception innerException) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string message) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string message, System.Exception innerException) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException() -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -78,11 +89,13 @@ const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyNa
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
+override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RemoteInvocationException.ToString() -> string
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
+override StreamJsonRpc.RpcArgumentDeserializationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, ob
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.TraceEvents.MethodArgumentDeserializationFailure = 17 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings
 StreamJsonRpc.JsonRpcEnumerableSettings.JsonRpcEnumerableSettings() -> void
 StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -62,6 +62,9 @@ StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformatio
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.TryGetProgressObject(long progressId, out StreamJsonRpc.Reflection.MessageFormatterProgressTracker.ProgressParamInformation valueType) -> bool
 StreamJsonRpc.RemoteInvocationException.DeserializedErrorData.get -> object
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string message, int errorCode, object errorData, object deserializedErrorData) -> void
+StreamJsonRpc.RemoteMethodNotFoundException.DeserializedErrorData.get -> object
+StreamJsonRpc.RemoteMethodNotFoundException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode
+StreamJsonRpc.RemoteMethodNotFoundException.ErrorData.get -> object
 StreamJsonRpc.RequestId
 StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
@@ -69,6 +72,14 @@ StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
 StreamJsonRpc.RequestId.RequestId(string id) -> void
 StreamJsonRpc.RequestId.String.get -> string
+StreamJsonRpc.RpcArgumentDeserializationException
+StreamJsonRpc.RpcArgumentDeserializationException.ArgumentName.get -> string
+StreamJsonRpc.RpcArgumentDeserializationException.ArgumentPosition.get -> int?
+StreamJsonRpc.RpcArgumentDeserializationException.DeserializedType.get -> System.Type
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string argumentName, int? argumentPosition, System.Type deserializedType, System.Exception innerException) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string message) -> void
+StreamJsonRpc.RpcArgumentDeserializationException.RpcArgumentDeserializationException(string message, System.Exception innerException) -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException() -> void
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -78,11 +89,13 @@ const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyNa
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
+override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RemoteInvocationException.ToString() -> string
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object obj) -> bool
 override StreamJsonRpc.RequestId.GetHashCode() -> int
 override StreamJsonRpc.RequestId.ToString() -> string
+override StreamJsonRpc.RpcArgumentDeserializationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings) -> System.Collections.Generic.IAsyncEnumerable<T>
 static StreamJsonRpc.JsonRpcExtensions.AsAsyncEnumerable<T>(this System.Collections.Generic.IEnumerable<T> enumerable, StreamJsonRpc.JsonRpcEnumerableSettings settings, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<T>

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Selhání při deserializaci příchozího JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Daný typ nejde přetypovat na IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Fehler beim Deserialisieren des eingehenden JSON-RPC "{0}": {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Der angegebene Typ kann nicht in IProgress&lt;T&gt; umgewandelt werden.</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Error al deserializar '{0}' de JSON RPC entrante: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">No se puede convertir el tipo dado en IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Échec de la désérialisation du protocole JSON RPC entrant '{0}' : {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Impossible de caster le type donné en IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Si è verificato un errore durante la deserializzazione della RPC JSON in arrivo '{0}': {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Non è possibile eseguire il cast del tipo specificato in IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">JSON RPC '{0}' の逆シリアル化の失敗: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">指定された型は IProgress&lt;T&gt; にキャストできません</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">들어오는 JSON RPC '{0}'을(를) 역직렬화하는 데 실패:{1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">지정된 형식을 IProgress로 캐스팅할 수 없음&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Błąd deserializacji przychodzącego wywołania JSON RPC „{0}”: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Nie można rzutować danego typu na typ IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Falha ao desserializar o RPC de JSON de entrada '{0}': {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Não é possível converter o Tipo fornecido em IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Ошибка при десериализации входящих данных RPC JSON "{0}": {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Не удалось привести указанный тип к IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Gelen JSON RPC '{0}' seri durumdan çıkarılamadı: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Verilen Tür IProgress&lt;T&gt; olarak atanamıyor</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">反序列化传入 JSON RPC“{0}”时失败：{1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">无法将给定类型强制转换为 IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">將傳入的 JSON RPC '{0}' 還原序列化失敗: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the JSON RPC, {1} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcArgument">
+        <source>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</source>
+        <target state="new">Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</target>
+        <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">無法將指定的類型轉換為 IProgress&lt;T&gt;</target>


### PR DESCRIPTION
Instead of responding with a general exception that claims the client didn't send an argument for a given parameter, we now report that an argument deserialization failed, and include all inner exception details.

**BEFORE**
> Unable to find method 'SynchronizeTextAsync/3' on {no object} for the following reasons: An argument was not supplied for a required parameter.

**AFTER**
> Unable to find method 'MethodWithArgThatFailsToDeserialize/1' on {no object} for the following reasons: Deserializing JSON-RPC argument with name \"arg1\" and position 0 to type \"JsonRpcTests+TypeThrowsWhenDeserialized\" failed: This exception is meant to be thrown.

In addition to the improved message, the `RemoteMethodNotFoundException` type now contains extra data with all the type, message and callstack info for all inner exceptions similar to how it would if the exception had been thrown from the RPC server method itself. The full JSON-RPC error message sent to the client and accessible through this exception is:

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "error": {
    "code": -32602,
    "message": "Unable to find method 'MethodWithArgThatFailsToDeserialize/1' on {no object} for the following reasons: Deserializing JSON-RPC argument with name \"arg1\" and position 0 to type \"JsonRpcTests+TypeThrowsWhenDeserialized\" failed: This exception is meant to be thrown.",
    "data": {
      "type": "System.AggregateException",
      "message": "One or more errors occurred.",
      "stack": null,
      "code": -2146233088,
      "inner": {
        "type": "StreamJsonRpc.RpcArgumentDeserializationException",
        "message": "Deserializing JSON-RPC argument with name \"arg1\" and position 0 to type \"JsonRpcTests+TypeThrowsWhenDeserialized\" failed: This exception is meant to be thrown.",
        "stack": "   at StreamJsonRpc.JsonMessageFormatter.JsonRpcRequest.TryGetArgumentByNameOrIndex(String name, Int32 position, Type typeHint, Object& value) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\JsonMessageFormatter.cs:line 748\r\n   at StreamJsonRpc.Protocol.JsonRpcRequest.TryGetTypedArguments(ReadOnlySpan`1 parameters, Span`1 typedArguments) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\Protocol\\JsonRpcRequest.cs:line 166\r\n   at StreamJsonRpc.JsonMessageFormatter.JsonRpcRequest.TryGetTypedArguments(ReadOnlySpan`1 parameters, Span`1 typedArguments) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\JsonMessageFormatter.cs:line 717\r\n   at StreamJsonRpc.TargetMethod.TryGetArguments(JsonRpcRequest request, MethodSignature method, Span`1 arguments) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\Reflection\\TargetMethod.cs:line 156\r\n   at StreamJsonRpc.TargetMethod..ctor(JsonRpcRequest request, List`1 candidateMethodTargets) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\Reflection\\TargetMethod.cs:line 48",
        "code": -2146233088,
        "inner": {
          "type": "System.Exception",
          "message": "This exception is meant to be thrown.",
          "stack": "   at JsonRpcJsonHeadersTests.TypeThrowsWhenDeserializedConverter.ReadJson(JsonReader reader, Type objectType, TypeThrowsWhenDeserialized existingValue, Boolean hasExistingValue, JsonSerializer serializer) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc.Tests\\JsonRpcJsonHeadersTests.cs:line 243\r\n   at Newtonsoft.Json.JsonConverter`1.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)\r\n   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)\r\n   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)\r\n   at StreamJsonRpc.JsonMessageFormatter.JsonRpcRequest.TryGetArgumentByNameOrIndex(String name, Int32 position, Type typeHint, Object& value) in D:\\git\\streamjsonrpc\\src\\StreamJsonRpc\\JsonMessageFormatter.cs:line 732",
          "code": -2146233088,
          "inner": null
        }
      }
    }
  }
}
```

When there are multiple overloads and all of them fail, an exception for each overload that failed will be included so the investigation can consider why each overload was a mismatch.

When one overload fails but another overload succeeds, the succeeding overload is invoked as before. But even in that case, we now trace a warning message regarding the conversion failure as it occurs.

Fixes #400