### PR TITLE
Add NewLineDelimitedMessageHandler

### DIFF
--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -47,6 +47,9 @@ StreamJsonRpc includes a few `IJsonRpcMessageHandler` implementations:
 1. `LengthHeaderMessageHandler` - This prepends a big endian 32-bit integer to each message to describe the length
    of the message. This handler works with .NET `Stream` and the new pipelines API. This handler is the fastest
    handler for those transports.
+1. `NewLineDelimitedMessageHandler` - This appends each JSON-RPC message with `\r\n` or `\n`.
+   It should only be used with UTF-8 text-based formatters that do not emit new line characters as part of the JSON.
+   This handler works with .NET `Stream` and the new pipelines API.
 1. `WebSocketMessageHandler` - This is designed specifically for `WebSocket`, which has implicit message boundaries
    as part of the web socket protocol. As such, no header is added. Each message is transmitted as a single web socket
    message.

--- a/src/StreamJsonRpc.Tests/NewLineDelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/NewLineDelimitedMessageHandlerTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class NewLineDelimitedMessageHandlerTests : TestBase
+{
+    private readonly IReadOnlyList<JsonRpcRequest> mockMessages = new JsonRpcRequest[]
+    {
+        new JsonRpcRequest { RequestId = new RequestId(1), Method = "a" },
+        new JsonRpcRequest { RequestId = new RequestId(2), Method = "b" },
+        new JsonRpcRequest { RequestId = new RequestId(3), Method = "c" },
+    };
+
+    public NewLineDelimitedMessageHandlerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void Ctor_Nulls()
+    {
+        Assert.Throws<ArgumentNullException>("pipe", () => new NewLineDelimitedMessageHandler(null!, new JsonMessageFormatter()));
+        Assert.Throws<ArgumentNullException>("formatter", () => new NewLineDelimitedMessageHandler(FullDuplexStream.CreatePipePair().Item1, null!));
+        Assert.Throws<ArgumentNullException>("formatter", () => new NewLineDelimitedMessageHandler(FullDuplexStream.CreatePipePair().Item1, null!));
+    }
+
+    [Fact]
+    public void UTF16_Formatter_NotSupported()
+    {
+        // Because the handler looks for UTF-8 encoded \n characters, it doesn't support anything else.
+        Assert.Throws<NotSupportedException>(() => new NewLineDelimitedMessageHandler(FullDuplexStream.CreatePipePair().Item1, new JsonMessageFormatter(Encoding.Unicode)));
+    }
+
+    [Fact]
+    public void NewLine()
+    {
+        var handler = new NewLineDelimitedMessageHandler(FullDuplexStream.CreatePipePair().Item1, new JsonMessageFormatter());
+
+        // Assert default value.
+        Assert.Equal(NewLineDelimitedMessageHandler.NewLineStyle.CrLf, handler.NewLine);
+
+        handler.NewLine = NewLineDelimitedMessageHandler.NewLineStyle.Lf;
+        Assert.Equal(NewLineDelimitedMessageHandler.NewLineStyle.Lf, handler.NewLine);
+    }
+
+    [Fact]
+    public async Task Reading_MixedLineEndings()
+    {
+        var pipe = new Pipe();
+        var handler = new NewLineDelimitedMessageHandler(null, pipe.Reader, new JsonMessageFormatter());
+
+        // Send messages with mixed line endings to the handler..
+        var testFormatter = new JsonMessageFormatter();
+        testFormatter.Serialize(pipe.Writer, this.mockMessages[0]);
+        pipe.Writer.Write(testFormatter.Encoding.GetBytes("\n"));
+        testFormatter.Serialize(pipe.Writer, this.mockMessages[1]);
+        pipe.Writer.Write(testFormatter.Encoding.GetBytes("\r\n"));
+        testFormatter.Serialize(pipe.Writer, this.mockMessages[2]);
+        pipe.Writer.Write(testFormatter.Encoding.GetBytes("\r\n"));
+        await pipe.Writer.FlushAsync(this.TimeoutToken);
+        pipe.Writer.Complete();
+
+        // Assert that the handler can read each one.
+        var readMessage1 = (JsonRpcRequest?)await handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(this.mockMessages[0].RequestId, readMessage1!.RequestId);
+        Assert.Equal(this.mockMessages[0].Method, readMessage1.Method);
+        var readMessage2 = (JsonRpcRequest?)await handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(this.mockMessages[1].RequestId, readMessage2!.RequestId);
+        Assert.Equal(this.mockMessages[1].Method, readMessage2.Method);
+        var readMessage3 = (JsonRpcRequest?)await handler.ReadAsync(this.TimeoutToken);
+        Assert.Equal(this.mockMessages[2].RequestId, readMessage3!.RequestId);
+        Assert.Equal(this.mockMessages[2].Method, readMessage3.Method);
+        Assert.Null(await handler.ReadAsync(this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task Reading_IncompleteLine()
+    {
+        var pipe = new Pipe();
+        var handler = new NewLineDelimitedMessageHandler(null, pipe.Reader, new JsonMessageFormatter());
+        var testFormatter = new JsonMessageFormatter();
+
+        // Send just the message, but no newline yet.
+        testFormatter.Serialize(pipe.Writer, this.mockMessages[0]);
+        await pipe.Writer.FlushAsync(this.TimeoutToken);
+
+        // Assert that the handler will wait for more bytes.
+        var readTask = handler.ReadAsync(this.TimeoutToken).AsTask();
+        await Assert.ThrowsAsync<TimeoutException>(() => readTask.WithTimeout(ExpectedTimeout));
+
+        // Now finish with a newline and assert that the message was read.
+        pipe.Writer.Write(testFormatter.Encoding.GetBytes("\r\n"));
+        await pipe.Writer.FlushAsync(this.TimeoutToken);
+        var msg = await readTask.WithCancellation(this.TimeoutToken);
+        Assert.True(msg is JsonRpcRequest);
+    }
+
+    [Fact]
+    public async Task Writing_MixedLineEndings()
+    {
+        var pipe = new Pipe();
+        var handler = new NewLineDelimitedMessageHandler(pipe.Writer, null, new JsonMessageFormatter());
+
+        // Use the handler to write out a couple messages with mixed line endings.
+        await handler.WriteAsync(this.mockMessages[0], this.TimeoutToken); // CRLF
+        handler.NewLine = NewLineDelimitedMessageHandler.NewLineStyle.Lf;
+        await handler.WriteAsync(this.mockMessages[1], this.TimeoutToken); // LF
+        await handler.DisposeAsync();
+
+        using var streamReader = new StreamReader(pipe.Reader.AsStream(), handler.Formatter.Encoding);
+        string allMessages = await streamReader.ReadToEndAsync();
+
+        // Use CR and LF counts to quickly figure whether our new line styles were honored.
+        Assert.Equal(3, allMessages.Split('\n').Length);
+        Assert.Equal(2, allMessages.Split('\r').Length);
+
+        // Now actually parse the messages.
+        var msgJson = allMessages.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(m => JToken.Parse(m.Trim())).ToArray();
+        Assert.Equal(2, msgJson.Length);
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Equal(this.mockMessages[i].RequestId.Number, msgJson[i]["id"].Value<int>());
+        }
+    }
+}

--- a/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.IO.Pipelines;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+    using StreamJsonRpc.Protocol;
+    using StreamJsonRpc.Reflection;
+
+    /// <summary>
+    /// A JSON-RPC message handler that delimits messages with new lines.
+    /// </summary>
+    /// <remarks>
+    /// When reading messages, either \n or \r\n character sequences are permitted for new lines.
+    /// When writing messages the <see cref="NewLine"/> property controls which character sequence is used to terminate each message.
+    /// </remarks>
+    public class NewLineDelimitedMessageHandler : PipeMessageHandler
+    {
+        /// <summary>
+        /// Backing field for the <see cref="NewLine"/> property.
+        /// </summary>
+        private NewLineStyle newLine = NewLineStyle.CrLf;
+
+        /// <summary>
+        /// The bytes to write out as the new line after each message.
+        /// </summary>
+        private ReadOnlyMemory<byte> newLineBytes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewLineDelimitedMessageHandler"/> class.
+        /// </summary>
+        /// <param name="pipe">The reader and writer to use for receiving/transmitting messages.</param>
+        /// <param name="formatter">The formatter used to serialize messages. Only UTF-8 formatters are supported.</param>
+        public NewLineDelimitedMessageHandler(IDuplexPipe pipe, IJsonRpcMessageTextFormatter formatter)
+            : base(pipe, formatter)
+        {
+            this.CommonConstructor();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewLineDelimitedMessageHandler"/> class.
+        /// </summary>
+        /// <param name="writer">The writer to use for transmitting messages.</param>
+        /// <param name="reader">The reader to use for receiving messages.</param>
+        /// <param name="formatter">The formatter used to serialize messages. Only UTF-8 formatters are supported.</param>
+        public NewLineDelimitedMessageHandler(PipeWriter? writer, PipeReader? reader, IJsonRpcMessageTextFormatter formatter)
+            : base(writer, reader, formatter)
+        {
+            this.CommonConstructor();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewLineDelimitedMessageHandler"/> class.
+        /// </summary>
+        /// <param name="writer">The stream to use for transmitting messages.</param>
+        /// <param name="reader">The stream to use for receiving messages.</param>
+        /// <param name="formatter">The formatter used to serialize messages. Only UTF-8 formatters are supported.</param>
+        public NewLineDelimitedMessageHandler(Stream writer, Stream reader, IJsonRpcMessageTextFormatter formatter)
+            : base(writer, reader, formatter)
+        {
+            this.CommonConstructor();
+        }
+
+        /// <summary>
+        /// Describes the supported styles of new lines that can be written.
+        /// </summary>
+        public enum NewLineStyle
+        {
+            /// <summary>
+            /// Newlines are represented as a single \n character.
+            /// </summary>
+            Lf,
+
+            /// <summary>
+            /// Newlines are represented by a \r\n character sequence.
+            /// </summary>
+            CrLf,
+        }
+
+        /// <summary>
+        /// Gets or sets the new line sequence to use to terminate a JSON-RPC message.
+        /// </summary>
+        public NewLineStyle NewLine
+        {
+            get => this.newLine;
+            set
+            {
+                if (this.newLine != value)
+                {
+                    this.newLineBytes = GetLineFeedSequence(this.Formatter.Encoding, value);
+                    this.newLine = value;
+                }
+            }
+        }
+
+        /// <inheritdoc cref="MessageHandlerBase.Formatter"/>
+        public new IJsonRpcMessageTextFormatter Formatter => (IJsonRpcMessageTextFormatter)base.Formatter;
+
+        /// <inheritdoc/>
+        protected override void Write(JsonRpcMessage content, CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(this.Writer);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            this.Formatter.Serialize(this.Writer, content);
+            this.Writer.Write(this.newLineBytes.Span);
+        }
+
+        /// <inheritdoc/>
+        protected override async ValueTask<JsonRpcMessage?> ReadCoreAsync(CancellationToken cancellationToken)
+        {
+            Assumes.NotNull(this.Reader);
+            while (true)
+            {
+                ReadResult readResult = await this.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                if (readResult.Buffer.Length == 0 && readResult.IsCompleted)
+                {
+                    return default; // remote end disconnected at a reasonable place.
+                }
+
+                SequencePosition? lf = readResult.Buffer.PositionOf((byte)'\n');
+                if (!lf.HasValue)
+                {
+                    if (readResult.IsCompleted)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    // Indicate that we can't find what we're looking for and read again.
+                    this.Reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+                    continue;
+                }
+
+                ReadOnlySequence<byte> line = readResult.Buffer.Slice(0, lf.Value);
+
+                // If the line ends with an \r (that precedes the \n we already found), trim that as well.
+                SequencePosition? cr = line.PositionOf((byte)'\r');
+                if (cr.HasValue && line.GetPosition(1, cr.Value).Equals(lf))
+                {
+                    line = line.Slice(0, line.Length - 1);
+                }
+
+                try
+                {
+                    // Skip over blank lines.
+                    if (line.Length > 0)
+                    {
+                        return this.Formatter.Deserialize(line);
+                    }
+                }
+                finally
+                {
+                    // Advance to the next line.
+                    this.Reader.AdvanceTo(readResult.Buffer.GetPosition(1, lf.Value));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the byte sequence for new lines.
+        /// </summary>
+        /// <param name="encoding">The encoding to use to convert the new line characters to bytes.</param>
+        /// <param name="style">The style of new line to produce.</param>
+        /// <returns>The bytes to emit for each new line.</returns>
+        private static ReadOnlyMemory<byte> GetLineFeedSequence(Encoding encoding, NewLineStyle style)
+        {
+            return style switch
+            {
+                NewLineStyle.Lf => encoding.GetBytes("\n"),
+                NewLineStyle.CrLf => encoding.GetBytes("\r\n"),
+                _ => throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.EnumValueNotRecognized, style), nameof(style)),
+            };
+        }
+
+        /// <summary>
+        /// Validates and initializes fields as they should be from every constructor.
+        /// </summary>
+        private void CommonConstructor()
+        {
+            if (this.Formatter is IJsonRpcFormatterTracingCallbacks)
+            {
+                // Such a formatter requires that we make their own written bytes available back to them for logging purposes.
+                // We haven't implemented support for such, and the JsonMessageFormatter doesn't need it, so no need to.
+                throw new NotSupportedException("Formatters that implement " + nameof(IJsonRpcFormatterTracingCallbacks) + " are not supported. Try using " + nameof(JsonMessageFormatter) + ".");
+            }
+
+            if (this.Formatter.Encoding.WebName != Encoding.UTF8.WebName)
+            {
+                throw new NotSupportedException("Only UTF-8 formatters are supported.");
+            }
+
+            this.newLineBytes = GetLineFeedSequence(this.Formatter.Encoding, this.NewLine);
+        }
+    }
+}

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value {0} is not among the recognized or supported members of the enum type..
+        /// </summary>
+        internal static string EnumValueNotRecognized {
+            get {
+                return ResourceManager.GetString("EnumValueNotRecognized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error writing JSON RPC Message: {0}: {1}.
         /// </summary>
         internal static string ErrorWritingJsonRpcMessage {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -150,6 +150,9 @@
   <data name="ElementsAlreadyPrefetched" xml:space="preserve">
     <value>This enumeration has already prefetched elements once.</value>
   </data>
+  <data name="EnumValueNotRecognized" xml:space="preserve">
+    <value>The value {0} is not among the recognized or supported members of the enum type.</value>
+  </data>
   <data name="ErrorWritingJsonRpcMessage" xml:space="preserve">
     <value>Error writing JSON RPC Message: {0}: {1}</value>
     <comment>{0} is the exception type, {1} is the exception message.</comment>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -22,6 +22,16 @@ StreamJsonRpc.MessagePackFormatter.MultiplexingStream.get -> Nerdbank.Streams.Mu
 StreamJsonRpc.MessagePackFormatter.MultiplexingStream.set -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler
+StreamJsonRpc.NewLineDelimitedMessageHandler.Formatter.get -> StreamJsonRpc.IJsonRpcMessageTextFormatter
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLine.get -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLine.set -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Stream writer, System.IO.Stream reader, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle.CrLf = 1 -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle.Lf = 0 -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
@@ -87,6 +97,8 @@ StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageExce
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyName = "token" -> string
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
+override StreamJsonRpc.NewLineDelimitedMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
+override StreamJsonRpc.NewLineDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -22,6 +22,16 @@ StreamJsonRpc.MessagePackFormatter.MultiplexingStream.get -> Nerdbank.Streams.Mu
 StreamJsonRpc.MessagePackFormatter.MultiplexingStream.set -> void
 StreamJsonRpc.MessagePackFormatter.Serialize(System.Buffers.IBufferWriter<byte> contentBuffer, StreamJsonRpc.Protocol.JsonRpcMessage message) -> void
 StreamJsonRpc.MessagePackFormatter.SetMessagePackSerializerOptions(MessagePack.MessagePackSerializerOptions options) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler
+StreamJsonRpc.NewLineDelimitedMessageHandler.Formatter.get -> StreamJsonRpc.IJsonRpcMessageTextFormatter
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLine.get -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLine.set -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Pipelines.IDuplexPipe pipe, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Pipelines.PipeWriter writer, System.IO.Pipelines.PipeReader reader, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineDelimitedMessageHandler(System.IO.Stream writer, System.IO.Stream reader, StreamJsonRpc.IJsonRpcMessageTextFormatter formatter) -> void
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle.CrLf = 1 -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
+StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle.Lf = 0 -> StreamJsonRpc.NewLineDelimitedMessageHandler.NewLineStyle
 StreamJsonRpc.Protocol.JsonRpcError.ErrorDetail.GetData<T>() -> T
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.JsonRpcError.RequestId.set -> void
@@ -87,6 +97,8 @@ StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageExce
 StreamJsonRpc.UnrecognizedJsonRpcMessageException.UnrecognizedJsonRpcMessageException(string message, System.Exception innerException) -> void
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.TokenPropertyName = "token" -> string
 const StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.ValuesPropertyName = "values" -> string
+override StreamJsonRpc.NewLineDelimitedMessageHandler.ReadCoreAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage>
+override StreamJsonRpc.NewLineDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
 override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Chyba při zápisu výsledku JSON RPC: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Fehler beim Schreiben des JSON-RPC-Ergebnisses: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Error al escribir el resultado de JSON RPC: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Erreur lors de l’écriture du résultat de JSON RPC : {0} : {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Si è verificato un errore durante la scrittura del risultato della RPC JSON. {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">JSON RPC 結果の書き込み時のエラー: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">JSON RPC 결과를 쓰는 동안 오류 발생: {0}:{1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Błąd zapisywania wyniku JSON RPC: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Erro ao gravar o resultado de RPC de JSON: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">Произошла ошибка при записи результата RPC JSON. {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">JSON RPC Sonucu yazılırken bir hata oluştu: {0}: {1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">写入 JSON RPC 结果 {0} 时出错：{1}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="new">This enumeration has already prefetched elements once.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValueNotRecognized">
+        <source>The value {0} is not among the recognized or supported members of the enum type.</source>
+        <target state="new">The value {0} is not among the recognized or supported members of the enum type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorWritingJsonRpcResult" translate="yes" xml:space="preserve">
         <source>Error writing JSON RPC Result: {0}: {1}</source>
         <target state="translated">寫入 JSON RPC 結果時發生錯誤: {0}: {1}</target>


### PR DESCRIPTION
This new handler delimites JSON-RPC messages simply by a new line character.
I've heard of a few such JSON-RPC protocol implementations, which makes sense because people can simply type or paste a JSON-RPC message into a terminal and press enter and it will be processed.