### PR TITLE
Avoid completing reader or writer except after they are done

### DIFF
--- a/src/StreamJsonRpc/PipeMessageHandler.cs
+++ b/src/StreamJsonRpc/PipeMessageHandler.cs
@@ -142,18 +142,6 @@ namespace StreamJsonRpc
         protected abstract void Write(JsonRpcMessage content, CancellationToken cancellationToken);
 
         /// <inheritdoc />
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                this.Reader?.Complete();
-                this.Writer?.Complete();
-
-                base.Dispose(disposing);
-            }
-        }
-
-        /// <inheritdoc />
         protected override void DisposeReader()
         {
             this.Reader?.Complete();

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -271,7 +271,6 @@ override StreamJsonRpc.LengthHeaderMessageHandler.ReadCoreAsync(System.Threading
 override StreamJsonRpc.LengthHeaderMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanWrite.get -> bool
-override StreamJsonRpc.PipeMessageHandler.Dispose(bool disposing) -> void
 override StreamJsonRpc.PipeMessageHandler.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override StreamJsonRpc.Protocol.JsonRpcError.ToString() -> string
 override StreamJsonRpc.Protocol.JsonRpcRequest.ToString() -> string

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -271,7 +271,6 @@ override StreamJsonRpc.LengthHeaderMessageHandler.ReadCoreAsync(System.Threading
 override StreamJsonRpc.LengthHeaderMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.CanRead.get -> bool
 override StreamJsonRpc.PipeMessageHandler.CanWrite.get -> bool
-override StreamJsonRpc.PipeMessageHandler.Dispose(bool disposing) -> void
 override StreamJsonRpc.PipeMessageHandler.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override StreamJsonRpc.Protocol.JsonRpcError.ToString() -> string
 override StreamJsonRpc.Protocol.JsonRpcRequest.ToString() -> string


### PR DESCRIPTION
This is a follow-up to #350 which was evidently incompletely fixed. In the earlier fix, we arranged to Complete the reader and writer after they were done, which might be sometime after Dispose is called. This was all done in the base type. In the derived type, a Dispose override method Complete()'d the reader and writer anyway, defeating the very thing we were trying to fix. 

The fix is to remove these calls to Complete, leaving the base class to schedule these calls as it already does:

https://github.com/microsoft/vs-streamjsonrpc/blob/d7135f8e40898a0bce6a689a568aa9a65c0b13fc/src/StreamJsonRpc/MessageHandlerBase.cs#L64-L66

Fixes #413