### PR TITLE
Update Nerdbank.Streams to 2.4.57

### DIFF
--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="MessagePack" Version="2.1.80" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.0.299-rc" PrivateAssets="all" />
     <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" /> -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.16" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.45" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.45" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" PrivateAssets="compile" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.46" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.57" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="2.9.7" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />


### PR DESCRIPTION
This addresses a leak (https://github.com/AArnott/Nerdbank.Streams/issues/162) where PipeStream doesn't get disposed when `PipeReader` and `PipeWriter` are completed.

To avoid package restore warnings, I had to bump another dependency as well.