### PR TITLE
Update Mac OS hosted version after AzDo warning

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -31,7 +31,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS 10.15
   steps:
   - checkout: self
     clean: true

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -31,7 +31,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS 10.15
+    vmImage: macOS-10.15
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
The image version we're using for Mac OS is going to be deprecated on March 23rd 2020. This updates to the newest hosted version of that image.