### PR TITLE
Report abandoned JsonRpc proxies

### DIFF
--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
+StreamJsonRpc.JsonRpc.Abandoned -> System.EventHandler<StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs>
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs.OwnerStackTrace.get -> System.Diagnostics.StackTrace
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs.ProxyType.get -> System.Type
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, object target, StreamJsonRpc.JsonRpcMethodAttribute methodRpcSettings) -> void
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
+StreamJsonRpc.JsonRpc.Abandoned -> System.EventHandler<StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs>
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs.OwnerStackTrace.get -> System.Diagnostics.StackTrace
+StreamJsonRpc.JsonRpc.AbandonedConnectionEventArgs.ProxyType.get -> System.Type
 StreamJsonRpc.JsonRpc.AddLocalRpcMethod(System.Reflection.MethodInfo handler, object target, StreamJsonRpc.JsonRpcMethodAttribute methodRpcSettings) -> void
 StreamJsonRpc.JsonRpc.GetJsonRpcMethodAttribute(string methodName, System.ReadOnlySpan<System.Reflection.ParameterInfo> parameters) -> StreamJsonRpc.JsonRpcMethodAttribute
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>


### PR DESCRIPTION
This adds a `JsonRpc.Abandoned` event that owners can use to track if the instance or proxy that it shares with the rest of the application isn't properly disposed of.

* [ ] Add tests for and get this working when `IFoo` proxies include events.
* [ ] Determine whether this will be included in 2.4 or 2.5
