### PR TITLE
Add the JsonRpcEnumerableSettings.Prefetch property

### DIFF
--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -66,6 +66,10 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
         Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeFirstItemWithPrefetchAsync(CancellationToken cancellationToken);
 
+        IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAsync(CancellationToken cancellationToken);
+
+        Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAndTaskWrapperAsync(CancellationToken cancellationToken);
+
         Task<CompoundEnumerableResult> GetNumbersAndMetadataAsync(CancellationToken cancellationToken);
 
         Task PassInNumbersAsync(IAsyncEnumerable<int> numbers, CancellationToken cancellationToken);
@@ -366,12 +370,23 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
     [Theory]
     [PairwiseData]
-    public async Task Cancellation_DuringLongRunningServerBeforeReturning(bool useProxy, bool prefetch)
+    public async Task Cancellation_DuringLongRunningServerBeforeReturning(bool useProxy, [CombinatorialValues(0, 1, 2, 3)] int prefetchStrategy)
     {
         var cts = new CancellationTokenSource();
+        string rpcMethodName =
+            prefetchStrategy == 0 ? nameof(Server.WaitTillCanceledBeforeReturningAsync) :
+            prefetchStrategy == 1 ? nameof(Server.WaitTillCanceledBeforeFirstItemWithPrefetchAsync) :
+            prefetchStrategy == 2 ? nameof(Server.WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAsync) :
+            prefetchStrategy == 3 ? nameof(Server.WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAndTaskWrapperAsync) :
+            throw new ArgumentOutOfRangeException(nameof(prefetchStrategy));
+
         Task<IAsyncEnumerable<int>> enumerable = useProxy
-            ? (prefetch ? this.clientProxy.Value.WaitTillCanceledBeforeFirstItemWithPrefetchAsync(cts.Token) : this.clientProxy.Value.WaitTillCanceledBeforeReturningAsync(cts.Token))
-            : this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(prefetch ? nameof(Server.WaitTillCanceledBeforeFirstItemWithPrefetchAsync) : nameof(Server.WaitTillCanceledBeforeReturningAsync), cancellationToken: cts.Token);
+            ? (prefetchStrategy == 0 ? this.clientProxy.Value.WaitTillCanceledBeforeReturningAsync(cts.Token) :
+               prefetchStrategy == 1 ? this.clientProxy.Value.WaitTillCanceledBeforeFirstItemWithPrefetchAsync(cts.Token) :
+               prefetchStrategy == 2 ? Task.FromResult(this.clientProxy.Value.WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAsync(cts.Token)) :
+               prefetchStrategy == 3 ? this.clientProxy.Value.WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAndTaskWrapperAsync(cts.Token) :
+               throw new ArgumentOutOfRangeException(nameof(prefetchStrategy)))
+            : this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(rpcMethodName, cancellationToken: cts.Token);
 
         // Make sure the method has been invoked first.
         await this.server.MethodEntered.WaitAsync(this.TimeoutToken);
@@ -380,7 +395,15 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
         cts.Cancel();
 
         // Verify that it does throw OCE. Or timeout and fail the test if it doesn't.
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerable).WithCancellation(this.TimeoutToken);
+        if (prefetchStrategy == 2 && useProxy)
+        {
+            // In this strategy, we just wrapped up the IAsyncEnumerable in a pre-completed task, so we won't observe cancellation until we start enumerating.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await (await enumerable).GetAsyncEnumerator().MoveNextAsync()).WithCancellation(this.TimeoutToken);
+        }
+        else
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerable).WithCancellation(this.TimeoutToken);
+        }
     }
 
     [Fact]
@@ -487,6 +510,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
         int enumerated = 0;
         await foreach (var item in proxy.GetNumbersParameterizedAsync(minBatchSize, maxReadAhead, prefetch, totalCount, this.TimeoutToken).WithCancellation(this.TimeoutToken))
         {
+            Assert.True(this.server.ActuallyGeneratedValueCount >= Math.Min(totalCount, prefetch), $"Prefetch: {prefetch}, ActuallyGeneratedValueCount: {this.server.ActuallyGeneratedValueCount}");
             Assert.Equal(++enumerated, item);
         }
 
@@ -629,11 +653,10 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
             }
         }
 
-        public async ValueTask<IAsyncEnumerable<int>> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, CancellationToken cancellationToken)
+        public IAsyncEnumerable<int> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, CancellationToken cancellationToken)
         {
-            return await this.GetNumbersAsync(totalCount, cancellationToken)
-                .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize, MaxReadAhead = readAhead })
-                .WithPrefetchAsync(prefetch, cancellationToken);
+            return this.GetNumbersAsync(totalCount, cancellationToken)
+                .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize, MaxReadAhead = readAhead, Prefetch = prefetch });
         }
 
         public async IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemAsync([EnumeratorCancellation] CancellationToken cancellationToken)
@@ -648,6 +671,20 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
             this.MethodEntered.Set();
             return await this.WaitTillCanceledBeforeFirstItemAsync(cancellationToken)
                 .WithPrefetchAsync(1, cancellationToken);
+        }
+
+        public IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAsync(CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
+            return this.WaitTillCanceledBeforeFirstItemAsync(cancellationToken)
+                .WithJsonRpcSettings(new JsonRpcEnumerableSettings { Prefetch = 1 });
+        }
+
+        public Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeFirstItemUsingPrefetchSettingAndTaskWrapperAsync(CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
+            return Task.FromResult(this.WaitTillCanceledBeforeFirstItemAsync(cancellationToken)
+                .WithJsonRpcSettings(new JsonRpcEnumerableSettings { Prefetch = 1 }));
         }
 
         public Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken)

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -73,18 +73,6 @@ namespace StreamJsonRpc
         private readonly Action<object> cancelPendingOutboundRequestAction;
 
         /// <summary>
-        /// A delegate for the <see cref="HandleInvocationTaskOfTResult(JsonRpcRequest, Task)"/> method.
-        /// </summary>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Func<Task, object, JsonRpcMessage> handleInvocationTaskOfTResultDelegate;
-
-        /// <summary>
-        /// A delegate for the <see cref="HandleInvocationTaskResult(JsonRpcRequest, Task)"/> method.
-        /// </summary>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Func<Task, object, JsonRpcMessage> handleInvocationTaskResultDelegate;
-
-        /// <summary>
         /// A collection of target objects and their map of clr method to <see cref="JsonRpcMethodAttribute"/> values.
         /// </summary>
         private readonly Dictionary<string, List<MethodSignatureAndTarget>> targetRequestMethodToClrMethodMap = new Dictionary<string, List<MethodSignatureAndTarget>>(StringComparer.Ordinal);
@@ -216,8 +204,6 @@ namespace StreamJsonRpc
             }
 
             this.cancelPendingOutboundRequestAction = this.CancelPendingOutboundRequest;
-            this.handleInvocationTaskOfTResultDelegate = (t, request) => this.HandleInvocationTaskOfTResult((JsonRpcRequest)request, t);
-            this.handleInvocationTaskResultDelegate = (t, request) => this.HandleInvocationTaskResult((JsonRpcRequest)request, t);
 
             this.MessageHandler = messageHandler;
         }
@@ -1508,7 +1494,9 @@ namespace StreamJsonRpc
             TypeInfo? taskTypeInfoLocal = taskTypeInfo;
             while (taskTypeInfoLocal != null)
             {
-                if (IsTaskOfTOrValueTaskOfT(taskTypeInfoLocal))
+                bool isTaskOfTOrValueTaskOfT = taskTypeInfoLocal.IsGenericType &&
+                    (taskTypeInfoLocal.GetGenericTypeDefinition() == typeof(Task<>) || taskTypeInfoLocal.GetGenericTypeDefinition() == typeof(ValueTask<>));
+                if (isTaskOfTOrValueTaskOfT)
                 {
                     taskOfTTypeInfo = taskTypeInfoLocal;
                     return true;
@@ -1519,10 +1507,6 @@ namespace StreamJsonRpc
 
             taskOfTTypeInfo = null;
             return false;
-
-#pragma warning disable CS8762 // https://github.com/dotnet/roslyn/issues/41673
-            bool IsTaskOfTOrValueTaskOfT(TypeInfo typeInfo) => typeInfo.IsGenericType && (typeInfo.GetGenericTypeDefinition() == typeof(Task<>) || typeInfo.GetGenericTypeDefinition() == typeof(ValueTask<>));
-#pragma warning restore CS8762 // https://github.com/dotnet/roslyn/issues/41673
         }
 
         /// <summary>
@@ -1821,6 +1805,7 @@ namespace StreamJsonRpc
                         return CreateCancellationResponse(request);
                     }
 
+                    // Convert ValueTask to Task or ValueTask<T> to Task<T>
                     if (TryGetTaskFromValueTask(result, out Task? resultTask))
                     {
                         result = resultTask;
@@ -1833,6 +1818,15 @@ namespace StreamJsonRpc
                             JsonRpcEventSource.Instance.SendingResult(request.RequestId.NumberIfPossibleForEvent);
                         }
 
+                        try
+                        {
+                            await this.ProcessResultBeforeSerializingAsync(result, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            return CreateCancellationResponse(request);
+                        }
+
                         return new JsonRpcResult
                         {
                             RequestId = request.RequestId,
@@ -1840,20 +1834,16 @@ namespace StreamJsonRpc
                         };
                     }
 
+                    // Avoid another first chance exception from re-throwing here. We'll handle faults in our HandleInvocationTask* methods below.
+                    await resultingTask.NoThrowAwaitable(false);
+
                     // Pick continuation delegate based on whether a Task.Result exists based on method declaration.
                     // Checking on the runtime result object itself is problematic because .NET / C# implements
                     // async Task methods to return a Task<VoidTaskResult> instance, and we shouldn't consider
                     // the VoidTaskResult internal struct as a meaningful result.
-                    Func<Task, object, JsonRpcMessage> continuationDelegate = TryGetTaskOfTOrValueTaskOfTType(targetMethod.ReturnType!.GetTypeInfo(), out _)
-                        ? this.handleInvocationTaskOfTResultDelegate
-                        : this.handleInvocationTaskResultDelegate;
-
-                    return await resultingTask.ContinueWith(
-                        continuationDelegate!,
-                        request,
-                        CancellationToken.None,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default).ConfigureAwait(false);
+                    return TryGetTaskOfTOrValueTaskOfTType(targetMethod.ReturnType!.GetTypeInfo(), out _)
+                        ? await this.HandleInvocationTaskOfTResultAsync(request, resultingTask, cancellationToken).ConfigureAwait(false)
+                        : this.HandleInvocationTaskResult(request, resultingTask);
                 }
                 else
                 {
@@ -2039,15 +2029,14 @@ namespace StreamJsonRpc
             return result;
         }
 
-        private JsonRpcMessage HandleInvocationTaskOfTResult(JsonRpcRequest request, Task t)
+        private async ValueTask<JsonRpcMessage> HandleInvocationTaskOfTResultAsync(JsonRpcRequest request, Task t, CancellationToken cancellationToken)
         {
-            JsonRpcMessage message = this.HandleInvocationTaskResult(request, t);
+            // This method should only be called for methods that declare to return Task<T> (or a derived type), or ValueTask<T>.
+            Assumes.True(TryGetTaskOfTOrValueTaskOfTType(t.GetType().GetTypeInfo(), out TypeInfo? taskOfTTypeInfo));
 
-            if (message is JsonRpcResult resultMessage)
+            object? result = null;
+            if (t.Status == TaskStatus.RanToCompletion)
             {
-                // This method should only be called for methods that declare to return Task<T> (or a derived type), or ValueTask<T>.
-                Assumes.True(TryGetTaskOfTOrValueTaskOfTType(t.GetType().GetTypeInfo(), out TypeInfo? taskOfTTypeInfo));
-
                 // If t is a Task<SomeType>, it will have Result property.
                 // If t is just a Task, there is no Result property on it.
                 // We can't really write direct code to deal with Task<T>, since we have no idea of T in this context, so we simply use reflection to
@@ -2060,10 +2049,32 @@ namespace StreamJsonRpc
 
                 PropertyInfo? resultProperty = taskOfTTypeInfo.GetDeclaredProperty(ResultPropertyName);
                 Assumes.NotNull(resultProperty);
-                resultMessage.Result = resultProperty.GetValue(t);
+                result = resultProperty.GetValue(t);
+
+                // Transfer the ultimate success/failure result of the operation from the original successful method to the post-processing step.
+                t = this.ProcessResultBeforeSerializingAsync(result, cancellationToken);
+                await t.NoThrowAwaitable(false);
+            }
+
+            JsonRpcMessage message = this.HandleInvocationTaskResult(request, t);
+            if (message is JsonRpcResult resultMessage)
+            {
+                resultMessage.Result = result;
             }
 
             return message;
+        }
+
+        /// <summary>
+        /// Perform any special processing on the result of an RPC method before serializing it for transmission to the RPC client.
+        /// </summary>
+        /// <param name="result">The result from the RPC method.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that completes when processing the result is complete. The returned Task *may* transition to a <see cref="TaskStatus.Faulted"/> state.</returns>
+        private Task ProcessResultBeforeSerializingAsync(object? result, CancellationToken cancellationToken)
+        {
+            // If result is a prefetching IAsyncEnumerable<T>, prefetch now.
+            return JsonRpcExtensions.PrefetchIfApplicableAsync(result, cancellationToken);
         }
 
         private void OnJsonRpcDisconnected(JsonRpcDisconnectedEventArgs eventArgs)

--- a/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
+++ b/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
@@ -27,5 +27,17 @@ namespace StreamJsonRpc
         /// Gets or sets the minimum number of elements to obtain from the generator before sending a batch of values to the consumer.
         /// </summary>
         public int MinBatchSize { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the number of elements that should be precomputed and provided in the initial JSON-RPC message
+        /// so the receiving party does not neet to request the initial few elements.
+        /// </summary>
+        /// <remarks>
+        /// <para>This should only be used for <see cref="IAsyncEnumerable{T}"/> objects returned directly from an RPC method.</para>
+        /// <para>To prefetch items for <see cref="IAsyncEnumerable{T}"/> objects used as arguments to an RPC method
+        /// or within an object graph of a returned value, use the <see cref="JsonRpcExtensions.WithPrefetchAsync{T}(IAsyncEnumerable{T}, int, System.Threading.CancellationToken)"/> extension method
+        /// instead and leave this value at 0.</para>
+        /// </remarks>
+        public int Prefetch { get; set; }
     }
 }

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.set -> void
 StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.set -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcExtensions
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.MaxReadAhead.set -> void
 StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.MinBatchSize.set -> void
+StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
+StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcExtensions
 StreamJsonRpc.JsonRpcMethodAttribute.JsonRpcMethodAttribute() -> void
 StreamJsonRpc.JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization.get -> bool


### PR DESCRIPTION
This allows RPC server methods to return IAsyncEnumerable<T> with a prefetch setting without requiring them to call an async method and thus have to return a `Task<IAsyncEnumerable<T>>` instead of the more preferable `IAsyncEnumerable<T>` directly.

The trick here is that the `JsonRpc` class must itself perform the asynchronous `PrefetchAsync` operation after the RPC method returns but before sending the result for transmission to the formatter.

Closes #430