### PR TITLE
Added UseSingleObjectParameterDeserialization option to JsonRpcTargetOptions

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1434,6 +1434,11 @@ namespace StreamJsonRpc
 
                     JsonRpcMethodAttribute? attribute = mapping.FindAttribute(method);
 
+                    if (attribute == null && options.UseSingleObjectParameterDeserialization)
+                    {
+                        attribute = new JsonRpcMethodAttribute(null) { UseSingleObjectParameterDeserialization = true };
+                    }
+
                     // Skip this method if its signature matches one from a derived type we have already scanned.
                     MethodSignatureAndTarget methodTarget = new MethodSignatureAndTarget(method, target, attribute);
                     if (methodTargetList.Contains(methodTarget))
@@ -1445,7 +1450,7 @@ namespace StreamJsonRpc
 
                     // If no explicit attribute has been applied, and the method ends with Async,
                     // register a request method name that does not include Async as well.
-                    if (attribute == null && method.Name.EndsWith(ImpliedMethodNameAsyncSuffix, StringComparison.Ordinal))
+                    if (attribute?.Name == null && method.Name.EndsWith(ImpliedMethodNameAsyncSuffix, StringComparison.Ordinal))
                     {
                         string nonAsyncMethodName = method.Name.Substring(0, method.Name.Length - ImpliedMethodNameAsyncSuffix.Length);
                         if (!candidateAliases.ContainsKey(nonAsyncMethodName))

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -40,6 +40,11 @@ namespace StreamJsonRpc
         public bool AllowNonPublicInvocation { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether JSON-RPC named arguments should all be deserialized into the RPC method's first parameter.
+        /// </summary>
+        public bool UseSingleObjectParameterDeserialization { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to dispose of the target object
         /// when the connection with the remote party is lost.
         /// </summary>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
+StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
+StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void


### PR DESCRIPTION
I added the the `UseSingleObjectParameterDeserialization` property to the target options. When the property is set to true, the `GetRequestMethodToClrMethodMap` method will add a `JsonRpcMethodAttribute` to the `MethodSignatureAndTarget`. I don't know if this is the correct approach because `GetJsonRpcMethodAttribute` will now return a attribute, that did not exist on the original method. But it seems like `AddLocalRpcMethod` is also creating fake attributes, so i think it should be ok.

resolves #444 