### PR TITLE
Add test for async iterator method throwing an exception

### DIFF
--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -87,9 +87,8 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
         this.serverRpc = new JsonRpc(serverHandler, this.server);
         this.clientRpc = new JsonRpc(clientHandler);
 
-        // Don't use Verbose as it has nasty side-effects leading to test failures, which we need to fix!
-        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Information);
-        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Information);
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Verbose);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Verbose);
 
         this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
         this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));

--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -45,7 +45,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
     {
         IAsyncEnumerable<int> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken);
 
-        IAsyncEnumerable<int> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, CancellationToken cancellationToken);
+        IAsyncEnumerable<int> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, bool endWithException, CancellationToken cancellationToken);
     }
 
     protected interface IServer
@@ -484,12 +484,30 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
     {
         var proxy = this.clientRpc.Attach<IServer2>();
         int enumerated = 0;
-        await foreach (var item in proxy.GetNumbersParameterizedAsync(minBatchSize, maxReadAhead, prefetch, totalCount, this.TimeoutToken).WithCancellation(this.TimeoutToken))
+        await foreach (var item in proxy.GetNumbersParameterizedAsync(minBatchSize, maxReadAhead, prefetch, totalCount, endWithException: false, this.TimeoutToken).WithCancellation(this.TimeoutToken))
         {
             Assert.Equal(++enumerated, item);
         }
 
         Assert.Equal(totalCount, enumerated);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0, 2)] // no special features
+    [InlineData(1, 0, 3, 2)] // throw during prefetch
+    [InlineData(3, 0, 0, 2)] // throw during the first batch
+    [InlineData(2, 0, 0, 3)] // throw during the second batch
+    public async Task AsyncIteratorThrows(int minBatchSize, int maxReadAhead, int prefetch, int throwAfter)
+    {
+        var proxy = this.clientRpc.Attach<IServer2>();
+        var ex = await Assert.ThrowsAsync<RemoteInvocationException>(async delegate
+        {
+            await foreach (int i in proxy.GetNumbersParameterizedAsync(minBatchSize, maxReadAhead, prefetch, throwAfter, endWithException: true, this.TimeoutToken))
+            {
+                this.Logger.WriteLine("Observed item: " + i);
+            }
+        });
+        Assert.Equal(Server.FailByDesignExceptionMessage, ex.Message);
     }
 
     protected abstract void InitializeFormattersAndHandlers();
@@ -581,6 +599,8 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
         public const int MaxReadAhead = 4;
 
+        internal const string FailByDesignExceptionMessage = "Fail by design";
+
         public AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
 
         public AsyncManualResetEvent MethodExited { get; } = new AsyncManualResetEvent();
@@ -617,7 +637,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
         {
             try
             {
-                await foreach (var item in this.GetNumbersAsync(ValuesReturnedByEnumerables, cancellationToken))
+                await foreach (var item in this.GetNumbersAsync(ValuesReturnedByEnumerables, endWithException: false, cancellationToken))
                 {
                     yield return item;
                 }
@@ -628,9 +648,9 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
             }
         }
 
-        public async ValueTask<IAsyncEnumerable<int>> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, CancellationToken cancellationToken)
+        public async ValueTask<IAsyncEnumerable<int>> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, bool endWithException, CancellationToken cancellationToken)
         {
-            return await this.GetNumbersAsync(totalCount, cancellationToken)
+            return await this.GetNumbersAsync(totalCount, endWithException, cancellationToken)
                 .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize, MaxReadAhead = readAhead })
                 .WithPrefetchAsync(prefetch, cancellationToken);
         }
@@ -692,7 +712,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
             });
         }
 
-        private async IAsyncEnumerable<int> GetNumbersAsync(int totalCount, [EnumeratorCancellation] CancellationToken cancellationToken)
+        private async IAsyncEnumerable<int> GetNumbersAsync(int totalCount, bool endWithException, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             for (int i = 1; i <= totalCount; i++)
             {
@@ -701,6 +721,11 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
                 this.ActuallyGeneratedValueCount++;
                 this.ValueGenerated.PulseAll();
                 yield return i;
+            }
+
+            if (endWithException)
+            {
+                throw new InvalidOperationException(FailByDesignExceptionMessage);
             }
         }
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcEnumerableSettingsTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcEnumerableSettingsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using Xunit;
+
+public class JsonRpcEnumerableSettingsTests
+{
+    private JsonRpcEnumerableSettings settings = new JsonRpcEnumerableSettings();
+
+    [Fact]
+    public void MinBatchSize_Default()
+    {
+        Assert.Equal(1, this.settings.MinBatchSize);
+    }
+
+    [Fact]
+    public void MaxReadAhead_Default()
+    {
+        Assert.Equal(0, this.settings.MaxReadAhead);
+    }
+
+    [Fact]
+    public void MinBatchSize_AcceptsOnlyPositiveIntegers()
+    {
+        this.settings.MinBatchSize = 1;
+        this.settings.MinBatchSize = 10;
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.settings.MinBatchSize = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.settings.MinBatchSize = -1);
+    }
+
+    [Fact]
+    public void MaxReadAhead_AcceptsOnlyNonNegativeIntegers()
+    {
+        this.settings.MaxReadAhead = 10;
+        this.settings.MaxReadAhead = 0;
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.settings.MaxReadAhead = -1);
+    }
+}

--- a/src/StreamJsonRpc/Exceptions/UnexpectedEmptyEnumerableResponseException.cs
+++ b/src/StreamJsonRpc/Exceptions/UnexpectedEmptyEnumerableResponseException.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+
+    internal class UnexpectedEmptyEnumerableResponseException : RemoteRpcException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnexpectedEmptyEnumerableResponseException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="RemoteRpcException(string)"/>
+        public UnexpectedEmptyEnumerableResponseException(string? message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnexpectedEmptyEnumerableResponseException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="RemoteRpcException(string, Exception)"/>
+        public UnexpectedEmptyEnumerableResponseException(string? message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
+++ b/src/StreamJsonRpc/JsonRpcEnumerableSettings.cs
@@ -4,6 +4,7 @@
 namespace StreamJsonRpc
 {
     using System.Collections.Generic;
+    using Microsoft;
 
     /// <summary>
     /// Provides customizations on performance characteristics of an <see cref="IAsyncEnumerable{T}"/> that is passed over JSON-RPC.
@@ -19,13 +20,41 @@ namespace StreamJsonRpc
         internal static readonly JsonRpcEnumerableSettings DefaultSettings = new JsonRpcEnumerableSettings();
 
         /// <summary>
+        /// Backing field for the <see cref="MinBatchSize"/> property.
+        /// </summary>
+        private int minBatchSize = 1;
+
+        /// <summary>
+        /// Backing field for the <see cref="MaxReadAhead"/> property.
+        /// </summary>
+        private int maxReadAhead;
+
+        /// <summary>
         /// Gets or sets the maximum number of elements to read ahead and cache from the generator in anticipation of the consumer requesting those values.
         /// </summary>
-        public int MaxReadAhead { get; set; }
+        /// <value>This value must be a non-negative number.</value>
+        public int MaxReadAhead
+        {
+            get => this.maxReadAhead;
+            set
+            {
+                Requires.Range(value >= 0, nameof(value), Resources.NonNegativeIntegerRequired);
+                this.maxReadAhead = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the minimum number of elements to obtain from the generator before sending a batch of values to the consumer.
         /// </summary>
-        public int MinBatchSize { get; set; } = 1;
+        /// <value>This must be a positive integer.</value>
+        public int MinBatchSize
+        {
+            get => this.minBatchSize;
+            set
+            {
+                Requires.Range(value > 0, nameof(value), Resources.PositiveIntegerRequired);
+                this.minBatchSize = value;
+            }
+        }
     }
 }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -458,9 +458,17 @@ namespace StreamJsonRpc.Reflection
 
                             this.generatorReportsFinished = results.Finished;
                         }
-                        catch (RemoteInvocationException ex) when (ex.ErrorCode == (int)JsonRpcErrorCode.NoMarshaledObjectFound)
+                        catch (RemoteInvocationException ex)
                         {
-                            throw new InvalidOperationException(ex.Message, ex);
+                            // Avoid spending a message asking the server to dispose of the marshalled enumerator since they threw an exception at us.
+                            this.generatorReportsFinished = true;
+
+                            if (ex.ErrorCode == (int)JsonRpcErrorCode.NoMarshaledObjectFound)
+                            {
+                                throw new InvalidOperationException(ex.Message, ex);
+                            }
+
+                            throw;
                         }
                     }
 

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -446,6 +446,11 @@ namespace StreamJsonRpc.Reflection
                         try
                         {
                             EnumeratorResults<T> results = await this.owner.jsonRpc.InvokeWithCancellationAsync<EnumeratorResults<T>>(NextMethodName, this.nextOrDisposeArguments, this.cancellationToken).ConfigureAwait(false);
+                            if (!results.Finished && results.Values?.Count == 0)
+                            {
+                                throw new UnexpectedEmptyEnumerableResponseException("The RPC server responded with an empty list of additional values for an incomplete list.");
+                            }
+
                             if (results.Values != null)
                             {
                                 Write(this.localCachedValues, results.Values);


### PR DESCRIPTION
- 3653f3c Add test for throwing from the async iterator method
- 7dbc96a Avoid disposing of faulted RPC iterator
- 0a78bb9 Add `JsonRpcEnumerableSettings` range checks
- 31f332d Recognize and reject nonsensical responses from RPC servers
- 080aba4 Enable verbose tracing of `IAsyncEnumerable<T>`

Closes #445