### PR TITLE
Clear reserved buffer on reader disposal

### DIFF
--- a/src/StreamJsonRpc/PipeMessageHandler.cs
+++ b/src/StreamJsonRpc/PipeMessageHandler.cs
@@ -144,6 +144,7 @@ namespace StreamJsonRpc
         /// <inheritdoc />
         protected override void DisposeReader()
         {
+            this.deserializationReservedBuffer = default;
             this.Reader?.Complete();
 
             base.DisposeReader();


### PR DESCRIPTION
This prevents an exception being thrown (or worse: data corruption) as a connection is being torn down when the buffer is released by DisposeReader() followed by a later call to IJsonRpcMessageBufferManager.DeserializationComplete in the same class.