### PR TITLE
Fix deserialization of messages with null IDs

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Nerdbank.Streams;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
 using Xunit;
@@ -136,6 +137,24 @@ public class JsonMessageFormatterTests : TestBase
 
         formatter.MultiplexingStream = null;
         Assert.Null(formatter.MultiplexingStream);
+    }
+
+    [Fact]
+    public void ServerReturnsErrorWithNullId()
+    {
+        var formatter = new JsonMessageFormatter();
+        JsonRpcMessage? message = formatter.Deserialize(JObject.FromObject(new
+        {
+            jsonrpc = "2.0",
+            error = new
+            {
+                code = -1,
+                message = "Some message",
+            },
+            id = (object?)null,
+        }));
+        var error = Assert.IsAssignableFrom<JsonRpcError>(message);
+        Assert.True(error.RequestId.IsNull);
     }
 
     private static long MeasureLength(JsonRpcRequest msg, JsonMessageFormatter formatter)

--- a/src/StreamJsonRpc.Tests/JsonRpcRawStreamTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcRawStreamTests.cs
@@ -62,7 +62,9 @@ public class JsonRpcRawStreamTests : TestBase
             Assert.NotNull(args);
             Assert.NotNull(args.Description);
             Assert.Equal(DisconnectedReason.ParseError, args.Reason);
+#pragma warning disable CS0612 // Type or member is obsolete
             Assert.Null(args.LastMessage);
+#pragma warning restore CS0612 // Type or member is obsolete
             Assert.NotNull(args.Exception);
 
             // Server must dispose the stream now

--- a/src/StreamJsonRpc.Tests/RequestIdTests.cs
+++ b/src/StreamJsonRpc.Tests/RequestIdTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RequestIdTests : TestBase
+{
+    public RequestIdTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void StringValue()
+    {
+        Assert.Equal("s", new RequestId("s").String);
+        Assert.Null(new RequestId(null).String);
+        Assert.Null(new RequestId(3).String);
+    }
+
+    [Fact]
+    public void NumberValue()
+    {
+        Assert.Equal(3, new RequestId(3).Number);
+        Assert.Null(new RequestId(null).Number);
+        Assert.Null(new RequestId("3").Number);
+    }
+
+    [Fact]
+    public void IsNull()
+    {
+        Assert.True(RequestId.Null.IsNull);
+        Assert.False(RequestId.NotSpecified.IsNull);
+        Assert.False(default(RequestId).IsNull);
+        Assert.True(new RequestId(null).IsNull);
+        Assert.False(new RequestId("string").IsNull);
+        Assert.False(new RequestId(1).IsNull);
+    }
+
+    [Fact]
+    public void IsEmpty()
+    {
+        Assert.True(RequestId.NotSpecified.IsEmpty);
+        Assert.True(default(RequestId).IsEmpty);
+        Assert.False(RequestId.Null.IsEmpty);
+        Assert.False(new RequestId("string").IsEmpty);
+        Assert.False(new RequestId(null).IsEmpty);
+        Assert.False(new RequestId(1).IsEmpty);
+    }
+
+    [Fact]
+    public void Equals_Method()
+    {
+        Assert.True(RequestId.NotSpecified.Equals(RequestId.NotSpecified));
+        Assert.True(RequestId.Null.Equals(RequestId.Null));
+        Assert.False(RequestId.NotSpecified.Equals(RequestId.Null));
+        Assert.False(new RequestId("string").Equals(RequestId.NotSpecified));
+        Assert.False(new RequestId("string").Equals(RequestId.Null));
+        Assert.False(new RequestId(1).Equals(RequestId.NotSpecified));
+        Assert.False(new RequestId(1).Equals(RequestId.Null));
+    }
+
+    [Fact]
+    public void ToString_Method()
+    {
+        Assert.Equal("s", new RequestId("s").ToString());
+        Assert.Equal("1", new RequestId(1).ToString());
+        Assert.Equal("(null)", RequestId.Null.ToString());
+        Assert.Equal("(not specified)", RequestId.NotSpecified.ToString());
+    }
+}

--- a/src/StreamJsonRpc/EventArgs/DisconnectedReason.cs
+++ b/src/StreamJsonRpc/EventArgs/DisconnectedReason.cs
@@ -37,5 +37,10 @@ namespace StreamJsonRpc
         /// An extensibility point was leveraged locally and broke the contract.
         /// </summary>
         LocalContractViolation,
+
+        /// <summary>
+        /// The remote party violated the JSON-RPC protocol.
+        /// </summary>
+        RemoteProtocolViolation,
     }
 }

--- a/src/StreamJsonRpc/EventArgs/JsonRpcDisconnectedEventArgs.cs
+++ b/src/StreamJsonRpc/EventArgs/JsonRpcDisconnectedEventArgs.cs
@@ -19,7 +19,7 @@ namespace StreamJsonRpc
         /// <param name="description">The description.</param>
         /// <param name="reason">The reason for disconnection.</param>
         public JsonRpcDisconnectedEventArgs(string description, DisconnectedReason reason)
-            : this(description, reason, lastMessage: null, exception: null)
+            : this(description, reason, (Exception?)null)
         {
         }
 
@@ -30,8 +30,12 @@ namespace StreamJsonRpc
         /// <param name="reason">The reason for disconnection.</param>
         /// <param name="exception">The exception.</param>
         public JsonRpcDisconnectedEventArgs(string description, DisconnectedReason reason, Exception? exception)
-            : this(description, reason, lastMessage: null, exception: exception)
         {
+            Requires.NotNullOrWhiteSpace(description, nameof(description));
+
+            this.Description = description;
+            this.Reason = reason;
+            this.Exception = exception;
         }
 
         /// <summary>
@@ -40,6 +44,7 @@ namespace StreamJsonRpc
         /// <param name="description">The description.</param>
         /// <param name="reason">The reason for disconnection.</param>
         /// <param name="lastMessage">The last message.</param>
+        [Obsolete]
         public JsonRpcDisconnectedEventArgs(string description, DisconnectedReason reason, JToken? lastMessage)
             : this(description, reason, lastMessage: lastMessage, exception: null)
         {
@@ -52,6 +57,7 @@ namespace StreamJsonRpc
         /// <param name="reason">The reason for disconnection.</param>
         /// <param name="lastMessage">The last message.</param>
         /// <param name="exception">The exception.</param>
+        [Obsolete]
         public JsonRpcDisconnectedEventArgs(string description, DisconnectedReason reason, JToken? lastMessage, Exception? exception)
         {
             Requires.NotNullOrWhiteSpace(description, nameof(description));
@@ -75,6 +81,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Gets the last message.
         /// </summary>
+        [Obsolete]
         public JToken? LastMessage { get; }
 
         /// <summary>

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2368,7 +2368,7 @@ namespace StreamJsonRpc
                         }
                     }
 
-                    if (data != null)
+                    if (data is object)
                     {
                         if (data.ExpectedResultType != null && rpc is JsonRpcResult resultMessage)
                         {
@@ -2387,6 +2387,13 @@ namespace StreamJsonRpc
                         await TaskScheduler.Default.SwitchTo(alwaysYield: true);
                         data.CompletionHandler(rpc);
                         data = null; // avoid invoking again if we throw later
+                    }
+                    else
+                    {
+                        // Unexpected "response" to no request we have a record of. Raise disconnected event.
+                        this.OnJsonRpcDisconnected(new JsonRpcDisconnectedEventArgs(
+                            Resources.UnexpectedResponseWithNoMatchingRequest,
+                            DisconnectedReason.RemoteProtocolViolation));
                     }
                 }
                 else

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1102,13 +1102,16 @@ namespace StreamJsonRpc
 
             public void Serialize(ref MessagePackWriter writer, Protocol.JsonRpcRequest value, MessagePackSerializerOptions options)
             {
-                writer.WriteMapHeader(4);
+                writer.WriteMapHeader(value.RequestId.IsEmpty ? 3 : 4);
 
                 writer.Write(VersionPropertyName);
                 writer.Write(value.Version);
 
-                writer.Write(IdPropertyName);
-                options.Resolver.GetFormatterWithVerify<RequestId>().Serialize(ref writer, value.RequestId, options);
+                if (!value.RequestId.IsEmpty)
+                {
+                    writer.Write(IdPropertyName);
+                    options.Resolver.GetFormatterWithVerify<RequestId>().Serialize(ref writer, value.RequestId, options);
+                }
 
                 writer.Write(MethodPropertyName);
                 writer.Write(value.Method);

--- a/src/StreamJsonRpc/RequestIdJsonConverter.cs
+++ b/src/StreamJsonRpc/RequestIdJsonConverter.cs
@@ -16,6 +16,7 @@ namespace StreamJsonRpc
             {
                 case JsonToken.Integer: return new RequestId(reader.Value is int i ? i : (long)reader.Value);
                 case JsonToken.String: return new RequestId((string)reader.Value);
+                case JsonToken.Null: return RequestId.Null;
                 default: throw new JsonSerializationException("Unexpected token type for request ID: " + reader.TokenType);
             }
         }

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -538,6 +538,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A response was received without a request having been sent..
+        /// </summary>
+        internal static string UnexpectedResponseWithNoMatchingRequest {
+            get {
+                return ResourceManager.GetString("UnexpectedResponseWithNoMatchingRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unexpected token &apos;{0}&apos; while parsing header..
         /// </summary>
         internal static string UnexpectedTokenReadingHeader {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -296,6 +296,9 @@
     <value>Unexpected error processing JSON-RPC message: {0}</value>
     <comment>{0} is the exception message.</comment>
   </data>
+  <data name="UnexpectedResponseWithNoMatchingRequest" xml:space="preserve">
+    <value>A response was received without a request having been sent.</value>
+  </data>
   <data name="UnexpectedTokenReadingHeader" xml:space="preserve">
     <value>Unexpected token '{0}' while parsing header.</value>
     <comment>{0} is the token, which is typically a single character.</comment>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -417,7 +417,7 @@ StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
 StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
-StreamJsonRpc.RequestId.RequestId(string! id) -> void
+StreamJsonRpc.RequestId.RequestId(string? id) -> void
 StreamJsonRpc.RequestId.String.get -> string?
 StreamJsonRpc.RpcArgumentDeserializationException
 StreamJsonRpc.RpcArgumentDeserializationException.ArgumentName.get -> string?

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
+StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.RequestId.IsNull.get -> bool
+static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -417,7 +417,7 @@ StreamJsonRpc.RequestId.Equals(StreamJsonRpc.RequestId other) -> bool
 StreamJsonRpc.RequestId.IsEmpty.get -> bool
 StreamJsonRpc.RequestId.Number.get -> long?
 StreamJsonRpc.RequestId.RequestId(long id) -> void
-StreamJsonRpc.RequestId.RequestId(string! id) -> void
+StreamJsonRpc.RequestId.RequestId(string? id) -> void
 StreamJsonRpc.RequestId.String.get -> string?
 StreamJsonRpc.RpcArgumentDeserializationException
 StreamJsonRpc.RpcArgumentDeserializationException.ArgumentName.get -> string?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
+StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.RequestId.IsNull.get -> bool
+static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Neočekávaná chyba při zpracování zprávy JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Tento vzdálený objekt neexistuje.</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Unerwarteter Fehler beim Verarbeiten der JSON-RPC-Nachricht: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Dieses Remoteobjekt ist nicht mehr vorhanden.</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Mensaje de error inesperado al procesar JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Este objeto remoto ya no existe.</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Erreur inattendue durant le traitement du message JSON-RPC : {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Cet objet distant n'existe plus.</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Errore imprevisto durante l'elaborazione del messaggio JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Questo oggetto remoto non esiste più.</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -137,6 +137,11 @@
         <target state="translated">JSON-RPC メッセージの処理で予期しないエラーが発生しました: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">このリモート オブジェクトは存在しません。</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -137,6 +137,11 @@
         <target state="translated">JSON-RPC 메시지를 처리하는 동안 예기치 않은 오류 발생: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">이 원격 개체는 더 이상 없습니다.</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Nieoczekiwany błąd podczas przetwarzania komunikatu JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Ten obiekt zdalny już nie istnieje.</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Erro inesperado ao processar a mensagem JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Este objeto remoto não existe mais.</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Непредвиденная ошибка при обработке сообщения JSON-RPC: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Этот удаленный объект больше не существует.</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">JSON-RPC iletisi işlenirken beklenmeyen hata oluştu: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">Bu uzak nesne artık yok.</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="translated">处理 JSON-RPC 消息时出现意外错误: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">此远程对象已不复存在。</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="translated">處理 JSON-RPC 訊息時發生未預期的錯誤: {0}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception message.</note>
       </trans-unit>
+      <trans-unit id="UnexpectedResponseWithNoMatchingRequest">
+        <source>A response was received without a request having been sent.</source>
+        <target state="new">A response was received without a request having been sent.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnknownTokenToMarshaledObject">
         <source>This remote object no longer exists.</source>
         <target state="translated">這個遠端物件已不存在。</target>


### PR DESCRIPTION
JSON-RPC *allows* `null` as a request id value (bizarrely enough). And while we might not care to support interop with folks who use `null` as a value, it can legitimately come in response to a request where the server failed to parse in our request. I can't imagine a situation where that would happen, but there are pretty strange JSON-RPC servers out there, and I've heard from one user of this library that this came up.

The goal of this change is to update the code to acknowledge the validity of the `null` value at the schema level so that instead of a rather bizarre error when the situation is encountered, the oddity gets further in our pipeline where a more helpful error can be produced.

I add several tests including mocked up interop tests to demonstrate the intended behavior.