### PR TITLE
Add JsonRpc.DispatchCompletion property

### DIFF
--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
+StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
+StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool


### PR DESCRIPTION
This property returns a Task which completes whenever there are no local RPC methods currently running.
This allows shutdown code to not only wait for disconnection, but also for any trailing local RPC methods to finish running, if any.

Closes #466