### PR TITLE
point richnav to prod instead of int

### DIFF
--- a/azure-pipelines/richnav.yml
+++ b/azure-pipelines/richnav.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: RichCodeNavUpload
-  displayName: Rich Code Navigation Upload to Staging
+  displayName: Rich Code Navigation Upload to Production
   pool: Hosted Windows 2019 with VS2019
   steps:
   - template: install-dependencies.yml
@@ -8,6 +8,6 @@ jobs:
     displayName: RichCodeNav Upload
     inputs:
       languages: 'csharp'
-      environment: staging
+      environment: production
       isPrivateFeed: false
     continueOnError: true


### PR DESCRIPTION
This will make the repo available with rich nav at this prod endpoint: https://online.visualstudio.com/github/microsoft/vs-streamjsonrpc