### PR TITLE
Fail gracefully if json-rpc 2.0 error or result is missing id

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -157,6 +157,39 @@ public class JsonMessageFormatterTests : TestBase
         Assert.True(error.RequestId.IsNull);
     }
 
+    [Fact]
+    public void DeserializingResultWithMissingIdFails()
+    {
+        var formatter = new JsonMessageFormatter();
+        var resultWithNoId = JObject.FromObject(new
+        {
+            jsonrpc = "2.0",
+            result = new
+            {
+                asdf = "abc",
+            },
+        });
+        var message = Assert.Throws<JsonSerializationException>(() => formatter.Deserialize(resultWithNoId)).InnerException?.Message;
+        Assert.Contains("\"id\" property missing.", message);
+    }
+
+    [Fact]
+    public void DeserializingErrorWithMissingIdFails()
+    {
+        var formatter = new JsonMessageFormatter();
+        var errorWithNoId = JObject.FromObject(new
+        {
+            jsonrpc = "2.0",
+            error = new
+            {
+                code = -1,
+                message = "Some message",
+            },
+        });
+        var message = Assert.Throws<JsonSerializationException>(() => formatter.Deserialize(errorWithNoId)).InnerException?.Message;
+        Assert.Contains("\"id\" property missing.", message);
+    }
+
     private static long MeasureLength(JsonRpcRequest msg, JsonMessageFormatter formatter)
     {
         var builder = new Sequence<byte>();

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -628,8 +628,7 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(json, nameof(json));
 
-            RequestId id = this.NormalizeId(json["id"].ToObject<RequestId>());
-
+            RequestId id = this.ExtractRequestId(json);
             JToken result = json["result"];
 
             return new JsonRpcResult(this.JsonSerializer)
@@ -643,7 +642,7 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(json, nameof(json));
 
-            RequestId id = this.NormalizeId(json["id"].ToObject<RequestId>());
+            RequestId id = this.ExtractRequestId(json);
             JToken error = json["error"];
 
             return new JsonRpcError
@@ -656,6 +655,17 @@ namespace StreamJsonRpc
                     Data = error["data"], // leave this as a JToken. We deserialize inside GetData<T>
                 },
             };
+        }
+
+        private RequestId ExtractRequestId(JToken json)
+        {
+            JToken idToken = json["id"];
+            if (idToken == null)
+            {
+                throw this.CreateProtocolNonComplianceException(json, "\"id\" property missing.");
+            }
+            RequestId id = this.NormalizeId(idToken.ToObject<RequestId>());
+            return id;
         }
 
         private RequestId NormalizeId(RequestId id)

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -664,6 +664,7 @@ namespace StreamJsonRpc
             {
                 throw this.CreateProtocolNonComplianceException(json, "\"id\" property missing.");
             }
+
             RequestId id = this.NormalizeId(idToken.ToObject<RequestId>());
             return id;
         }


### PR DESCRIPTION
Fix for issue #471 