### PR TITLE
Allow roll-forward policy within the same feature band

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "3.1.100",
-    "rollForward": "latestPatch",
+    "rollForward": "feature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
I think an improved dev flow is to allow newer SDK versions 
within the same feature band, which is typically a quite safe 
way to guarantee backwards compatibility while gaining 
important patches and minor features automatically if the 
dev box happens to have a newer version (i.e. I have 3.1.301
but it currently cannot be used with the existing policy in 
this repo).