### PR TITLE
Trace message transmission failures

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -956,6 +956,18 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task NotifyAsync_LeavesTraceEvidenceOnFailure()
+    {
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.NotifyAsync("DoesNotMatter", new TypeThrowsWhenSerialized()));
+
+        // Verify that the trace explains what went wrong with the original exception message.
+        while (!this.clientTraces.Messages.Any(m => m.Contains("Can't touch this")))
+        {
+            await this.clientTraces.MessageReceived.WaitAsync(this.TimeoutToken);
+        }
+    }
+
+    [Fact]
     public async Task InvokeWithParameterObject_ProgressParameterAndFields()
     {
         int report = 0;

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -381,6 +381,11 @@ namespace StreamJsonRpc
             /// Thus a failure recorded in this event may be followed by a successful deserialization to another parameter type and invocation of a different overload.
             /// </remarks>
             MethodArgumentDeserializationFailure,
+
+            /// <summary>
+            /// An outgoing RPC message was not sent due to an exception, possibly a serialization failure.
+            /// </summary>
+            TransmissionFailed,
         }
 
         /// <summary>
@@ -1721,11 +1726,6 @@ namespace StreamJsonRpc
             {
                 throw new ConnectionLostException(Resources.ConnectionDropped, ex);
             }
-            catch (Exception)
-            {
-                this.OnRequestTransmissionAborted(request);
-                throw;
-            }
         }
 
         private JsonRpcError CreateError(JsonRpcRequest request, Exception exception)
@@ -2590,6 +2590,12 @@ namespace StreamJsonRpc
 
                     // Fatal error. Raise disconnected event.
                     this.OnJsonRpcDisconnected(e);
+                }
+
+                this.TraceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.TransmissionFailed, "Exception thrown while transmitting message: {0}", exception);
+                if (message is JsonRpcRequest request)
+                {
+                    this.OnRequestTransmissionAborted(request);
                 }
 
                 throw;

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
+StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
+StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool


### PR DESCRIPTION
We didn't trace these before, and while `NotifyAsync` and other methods will propagate the exception to the caller, if the NotifyAsync call was made by a dynamically generated proxy in response to raising an event, the exception would be swallowed without a trace.

This also fixes invocation of the virtual `JsonRpc.OnRequestTransmissionAborted` method so that we only invoke it on actual transmission failures and not on all errors in receiving a response too.