### PR TITLE
Document the exotic types

### DIFF
--- a/doc/exotic_types.md
+++ b/doc/exotic_types.md
@@ -1,0 +1,12 @@
+# Exotic Types
+
+Some types are not serializable but are specially recognized and marshaled by StreamJsonRpc when used in arguments or return values.
+
+* [`CancellationToken`](sendrequest.md#cancellation)
+* [`IProgress<T>`](progresssupport.md)
+* [`Stream`, `IDuplexPipe`, `PipeReader`, `PipeWriter`](oob_streams.md)
+* [`IAsyncEnumerable<T>`](asyncenumerable.md)
+
+The `CancellationToken` support is built into the `JsonRpc` class itself so that it works in any configuration, provided the remote side also supports it.
+
+The rest of the types listed above require support by the `IJsonRpcMessageFormatter` in use. All formatters that ship within the StreamJsonRpc library come with built-in support for all of these.

--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -88,6 +88,10 @@ StreamJsonRpc includes the following `IJsonRpcMessageFormatter` implementations:
     You can contribute your own via `MessagePackFormatter.SetOptions(MessagePackSerializationOptions)`.
     See alternative formatters below.
 
+When authoring a custom `IJsonRpcMessageFormatter` implementation, consider supporting the [exotic types](exotic_types.md) that require formatter participation.
+We have helper classes to make this straightforward.
+Refer to the source code from our built-in formatters to see how to use these helper classes.
+
 ### Alternative formatters
 
 For performance reasons when both parties can agree, it may be appropriate to switch out the textual JSON

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,10 +12,7 @@ The rest of our documentation are organized around use case.
 1. [Test your code](testing.md)
 1. [Write resilient code](resiliency.md)
 1. [Remote Targets](remotetargets.md)
-1. Passing around
-   1. [`Stream`/`IDuplexPipe`](oob_streams.md)
-   1. [`IProgress<T>`](progresssupport.md)
-   1. [`IAsyncEnumerable<T>`](asyncenumerable.md)
+1. [Pass certain special types in arguments or return values](exotic_types.md)
 1. [Troubleshoot](troubleshooting.md)
 
 See [full samples](https://github.com/AArnott/StreamJsonRpc.Sample) demonstrating two processes


### PR DESCRIPTION
While each exotic type had its own documentation, we didn't have a great place to send folks where a complete list was available. This fills that doc hole.