### PR TITLE
Support streams as a return type

### DIFF
--- a/doc/oob_streams.md
+++ b/doc/oob_streams.md
@@ -47,14 +47,10 @@ The server may also reply with stream or pipe:
 ```cs
 public async Task<Stream> SendLargeFileAsync()
 {
-   var streamPair = FullDuplexPipe.CreatePair();
-   
-   // Use streamPair.Item1
+   // Open a stream on the server-side and forward it to the client.
+   var stream = new FileStream("pathToServerFile", FileMode.Open);
 
-   // Dispose of the stream to notify the client we are done sending data
-   streamPair.Item1.Dispose();
-
-   return streamPair.Item2;
+   return stream;
 }
 ```
 

--- a/doc/oob_streams.md
+++ b/doc/oob_streams.md
@@ -45,12 +45,9 @@ public async Task TakeLargeFileAsync(IDuplexPipe pipe)
 The server may also reply with stream or pipe:
 
 ```cs
-public async Task<Stream> SendLargeFileAsync()
-{
-   // Open a stream on the server-side and forward it to the client.
-   var stream = new FileStream("pathToServerFile", FileMode.Open);
-
-   return stream;
+public Stream GetFile(string path) {
+    // Validate that the client should be granted access to the requested file.
+    return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
 }
 ```
 

--- a/doc/oob_streams.md
+++ b/doc/oob_streams.md
@@ -2,7 +2,7 @@
 
 JSON-RPC is great for invoking methods and passing regular data types as arguments.
 When you want to pass binary data or stream a great deal of text without encoding as a very large JSON message,
-StreamJsonRpc gives you an option to pass `Stream`, `IDuplexPipe`, `PipeReader` or `PipeWriter` as an argument to an RPC method.
+StreamJsonRpc gives you an option to pass `Stream`, `IDuplexPipe`, `PipeReader` or `PipeWriter` as an argument or as a return type for an RPC method.
 
 The content of the `Stream` or `IDuplexPipe` is transmitted out of band of the JSON-RPC channel so that no extra encoding is required. This out of band channel is provisioned from a [`MultiplexingStream`](https://github.com/AArnott/Nerdbank.Streams/blob/master/doc/MultiplexingStream.md) that can optionally be provided to the `JsonMessageFormatter` (or other formatters that support this feature). The `JsonRpc` connection itself is expected to be one of the channels in this `MultiplexingStream`.
 This can be configured like this (creation of the `MultiplexingStream` is out of scope of this topic):
@@ -42,14 +42,28 @@ public async Task TakeLargeFileAsync(IDuplexPipe pipe)
 }
 ```
 
+The server may also reply with stream or pipe:
+
+```cs
+public async Task<Stream> SendLargeFileAsync()
+{
+   var streamPair = FullDuplexPipe.CreatePair();
+   
+   // Use streamPair.Item1
+
+   // Dispose of the stream to notify the client we are done sending data
+   streamPair.Item1.Dispose();
+
+   return streamPair.Item2;
+}
+```
+
 ## Rules
 
 Passing out of band streams/pipes along JSON-RPC messages requires care be taken to avoid leaving
 abandoned `MultiplexingStream` channels active and consuming resources in corner cases.
 To facilitate this, the following rules apply:
-
-1. The `IDuplexPipe` always originates on the client and is passed as an argument to the server.
-   Servers are not allowed to return `IDuplexPipe` to clients because the server would have no feedback if the client dropped it, leaking resources.
+ 
 1. The client can only send an `IDuplexPipe` in a request (that expects a response).
    Notifications would not provide the client with feedback that the server dropped it, leaking resources.
 1. The client will immediately terminate the `IDuplexPipe` if the server returns ANY error in response to the request, since the server may not be aware of the `IDuplexPipe`.

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -348,7 +348,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task ServerThrowsOnStreamRequestFromNotification()
     {
-        
+        await this.clientRpc.NotifyAsync(nameof(Server.ServerMethodThatReturnsTwoWayStream));
     }
 
     /// <summary>

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -301,16 +301,10 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     }
 
     [Fact]
-    public async Task ServerMethodThatReturnsPipeAsObjectFailsOnReturn()
-    {
-        await Assert.ThrowsAnyAsync<RemoteRpcException>(() => this.clientRpc.InvokeWithCancellationAsync(nameof(Server.ReturnPipeAsObject), new object[0], this.TimeoutToken));
-    }
-
-    [Fact]
     public async Task ServerMethodThatReturnsAStream()
     {
-        byte[] buffer = new byte[1200];
-        Stream result = await this.clientRpc.InvokeAsync<Stream>(nameof(Server.ServerMethodThatReturnsAStream));
+        byte[] buffer = new byte[16];
+        Stream result = await this.clientRpc.InvokeAsync<Stream>(nameof(Server.ServerMethodThatReturnsTwoWayStream));
 
         int s = await result.ReadAsync(buffer, 0, buffer.Length);
         string returnedContent = Encoding.UTF8.GetString(buffer, 0, s);
@@ -325,19 +319,19 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     public async Task ServerMethodThatReturnsCustomTypeWithStream()
     {
         byte[] buffer = new byte[1200];
-        Stream result = await this.clientRpc.InvokeAsync<OneWayStreamWrapper>(nameof(Server.ServerMethodThatReturnsCustomTypeWithStream));
+        StreamContainingClass result = await this.clientRpc.InvokeAsync<StreamContainingClass>(nameof(Server.ServerMethodThatReturnsCustomTypeWithStream));
 
-        int s = await result.ReadAsync(buffer, 0, buffer.Length);
+        int s = await result.InnerStream.ReadAsync(buffer, 0, buffer.Length);
         string returnedContent = Encoding.UTF8.GetString(buffer);
 
-        Assert.Equal("Streamed bits!", returnedContent);
+        Assert.Equal("More streamed bits!", returnedContent);
     }
 
     [Fact]
     public async Task ServerMethodThatReturnsStreamCanBeClosed()
     {
         byte[] buffer = new byte[1200];
-        Stream result = await this.clientRpc.InvokeAsync<Stream>(nameof(Server.ServerMethodThatReturnsCustomTypeWithStream));
+        Stream result = await this.clientRpc.InvokeAsync<Stream>(nameof(Server.ServerMethodThatReturnsTwoWayStream));
 
         result.Dispose();
 
@@ -347,22 +341,14 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task ClientCanRequestStreamAndDropIt()
     {
-        // client can request a stream and not consume it, leading to a leaked resource if not handled properly.
-
-        //await this.clientRpc.InvokeAsync(nameof(Server.));
-        // check that the stream is disposed.
-    }
-
-    [Fact]
-    public async Task ClientCanRequestStreamAndDropItAndGetsDisposed()
-    {
-        //await this.clientRpc.InvokeAsync(nameof(Server.));
+        byte[] buffer = new byte[1200];
+        await this.clientRpc.InvokeAsync(nameof(Server.ServerMethodThatReturnsTwoWayStream));
     }
 
     [Fact]
     public async Task ServerThrowsOnStreamRequestFromNotification()
     {
-        //await this.clientRpc.InvokeAsync<Stream>(nameof(Server.));
+        
     }
 
     /// <summary>
@@ -847,7 +833,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 
         public object ReturnPipeAsObject() => FullDuplexStream.CreatePipePair().Item1;
 
-        public Stream ServerMethodThatReturnsAStream()
+        public Stream ServerMethodThatReturnsTwoWayStream()
         {
             var streamPair = FullDuplexStream.CreatePair();
             var bytes = Encoding.UTF8.GetBytes("Streamed bits!");
@@ -858,24 +844,17 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
             return streamPair.Item2;
         }
 
-        public Stream ServerMethodThatReturnsCustomTypeWithStream()
+        public StreamContainingClass ServerMethodThatReturnsCustomTypeWithStream()
         {
-            var innerStream = new SimplexStream();
-            var stream = new OneWayStreamWrapper(innerStream, true, true);
+            var streamPair = FullDuplexStream.CreatePair();
+            var stream = new StreamContainingClass(streamPair.Item2);
 
-            innerStream.Write(Encoding.UTF8.GetBytes("Streamed bits!"));
+            var bytes = Encoding.UTF8.GetBytes("More streamed bits!");
+
+            streamPair.Item1.Write(bytes, 0, bytes.Length);
+            streamPair.Item1.Flush();
 
             return stream;
-        }
-
-        public async Task<Stream> ServerMethodThatReturnsTwoWayStream(CancellationToken cancellationToken)
-        {
-            (Stream, Stream) streamPair = FullDuplexStream.CreatePair();
-
-            Task twoWayCom = TwoWayTalkAsync(streamPair.Item1, writeOnOdd: true, cancellationToken);
-            await twoWayCom.WithCancellation(cancellationToken); // rethrow any exceptions.
-
-            return streamPair.Item2;
         }
     }
 
@@ -986,5 +965,17 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
                 this.innerStream.Dispose();
             }
         }
+    }
+
+    protected class StreamContainingClass
+    {
+        private Stream innerStream;
+
+        public StreamContainingClass(Stream inner)
+        {
+            this.innerStream = inner;
+        }
+
+        public Stream InnerStream => this.innerStream;
     }
 }

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -381,7 +381,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 
         if (this.clientMx != null)
         {
-            this.clientMx.ChannelOffered += (sender, args) =>
+            this.clientMx.ChannelOffered += (object? sender, MultiplexingStream.ChannelOfferEventArgs args) =>
             {
                 channelCreatedTask.SetException(new TaskCanceledException());
             };
@@ -932,6 +932,10 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
             var streamPair = FullDuplexStream.CreatePair();
 
             this.StreamToDispose = new WrappedStream(streamPair.Item1);
+
+            byte[] buffer = Encoding.UTF8.GetBytes("Bytes!");
+
+            this.StreamToDispose.WriteAsync(buffer, 0, buffer.Length);
 
             return streamPair.Item2;
         }

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -381,7 +381,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 
         if (this.clientMx != null)
         {
-            this.clientMx.ChannelOffered += delegate(object sender, MultiplexingStream.ChannelOfferEventArgs args)
+            this.clientMx.ChannelOffered += (sender, args) =>
             {
                 channelCreatedTask.SetException(new TaskCanceledException());
             };

--- a/src/StreamJsonRpc.Tests/JsonRpcRawStreamTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcRawStreamTests.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1870,6 +1870,17 @@ namespace StreamJsonRpc
                             return CreateCancellationResponse(request);
                         }
 
+                        // Dispose of the result if it was requested via a notification and is a stream.
+                        if (!request.IsResponseExpected && result is Stream stream)
+                        {
+                            stream.Dispose();
+
+                            this.TraceSource.TraceEvent(TraceEventType.Warning,
+                                                        (int)TraceEvents.RequestReceived,
+                                                        "Received notification for method \"{0}\", which returned a stream. Streams are not supported for notifications and has been automatically disposed.",
+                                                        request.Method);
+                        }
+
                         return new JsonRpcResult
                         {
                             RequestId = request.RequestId,

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -12,7 +12,6 @@ namespace StreamJsonRpc
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.IO;
-    using System.IO.Pipelines;
     using System.Linq;
     using System.Reflection;
     using System.Threading;
@@ -1869,30 +1868,6 @@ namespace StreamJsonRpc
                         catch (OperationCanceledException)
                         {
                             return CreateCancellationResponse(request);
-                        }
-
-                        // Dispose of the result if it was requested via a notification.
-                        if (!request.IsResponseExpected && result is Stream stream)
-                        {
-                            stream.Dispose();
-
-                            this.TraceSource.TraceEvent(
-                                TraceEventType.Warning,
-                                (int)TraceEvents.RequestReceived,
-                                "Received notification for method \"{0}\", which returned a stream. Streams are not supported for notifications and has been automatically disposed.",
-                                request.Method);
-                        }
-
-                        if (!request.IsResponseExpected && result is IDuplexPipe pipe)
-                        {
-                            await pipe.Output.CompleteAsync().ConfigureAwait(false);
-                            await pipe.Input.CompleteAsync().ConfigureAwait(false);
-
-                            this.TraceSource.TraceEvent(
-                                TraceEventType.Warning,
-                                (int)TraceEvents.RequestReceived,
-                                "Received notification for method \"{0}\", which returned a pipe. Pipes are not supported for notifications and has been automatically disposed.",
-                                request.Method);
                         }
 
                         return new JsonRpcResult

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -13,7 +13,6 @@ namespace StreamJsonRpc.Reflection
     using Microsoft;
     using Microsoft.VisualStudio.Threading;
     using Nerdbank.Streams;
-    using StreamJsonRpc.Protocol;
 
     /// <summary>
     /// Assists <see cref="IJsonRpcMessageFormatter"/> implementations with supporting marshaling <see cref="IDuplexPipe"/> over JSON-RPC.

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -7,6 +7,7 @@ namespace StreamJsonRpc.Reflection
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics.CodeAnalysis;
+    using System.IO;
     using System.IO.Pipelines;
     using System.Threading;
     using System.Threading.Tasks;
@@ -112,6 +113,9 @@ namespace StreamJsonRpc.Reflection
             MultiplexingStream mxstream = this.GetMultiplexingStreamOrThrow();
             if (this.formatterState.SerializingMessageWithId.IsEmpty)
             {
+                duplexPipe?.Output.Complete();
+                duplexPipe?.Input.Complete();
+
                 throw new NotSupportedException(Resources.MarshaledObjectInNotificationError);
             }
 

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -112,7 +112,7 @@ namespace StreamJsonRpc.Reflection
             MultiplexingStream mxstream = this.GetMultiplexingStreamOrThrow();
             if (this.formatterState.SerializingMessageWithId.IsEmpty)
             {
-                throw new NotSupportedException(Resources.MarshaledObjectInNotificationError); // MarshaledObjectInNotificationError
+                throw new NotSupportedException(Resources.MarshaledObjectInNotificationError);
             }
 
             if (duplexPipe is null)

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.6.13" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" PrivateAssets="compile" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.5.58" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.5.70" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.0-beta1.final" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />


### PR DESCRIPTION
This PR enables the ability to return a stream as a server method to the client. 
The following corner cases have been added as tests:
- Support returning a stream from a server method
- Verify that a stream can be disposed after the client drops it
- Verify that custom return types with an inner stream also get a multiplexing channel
- Requesting a stream from a notification logs a warning and disposes of such stream immediately 

Closes #424 