### PR TITLE
Add TransmissionCompletedSize ETW event

### DIFF
--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -263,6 +263,11 @@ namespace StreamJsonRpc
                 Memory<byte> contentMemory = this.Writer.GetMemory((int)contentSequence.Length);
                 contentSequence.CopyTo(contentMemory.Span);
                 this.Writer.Advance((int)contentSequence.Length);
+
+                if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+                {
+                    JsonRpcEventSource.Instance.TransmissionCompletedSize(contentSequence.Length);
+                }
             }
             finally
             {

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -242,7 +242,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Signal that a message has been transmitted with the size.
         /// </summary>
-        /// <param name="size">Size of the payload</param>.
+        /// <param name="size">Size of the payload.</param>.
         [Event(TransmisionCompletedSizeEvent, Task = Tasks.MessageTransmission, Opcode = EventOpcode.Stop, Level = EventLevel.Informational)]
         public void TransmissionCompletedSize(long size)
         {

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -89,7 +89,7 @@ namespace StreamJsonRpc
         private const int TransmissionCompletedEvent = 31;
 
         /// <summary>
-        /// The event ID for the <see cref="TransmissionCompletedSize"/>
+        /// The event ID for the <see cref="TransmissionCompletedSize"/>.
         /// </summary>
         private const int TransmisionCompletedSizeEvent = 32;
 
@@ -242,7 +242,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Signal that a message has been transmitted with the size.
         /// </summary>
-        /// <param name="size"></param>
+        /// <param name="size">Size of the payload</param>
         [Event(TransmisionCompletedSizeEvent, Task = Tasks.MessageTransmission, Opcode = EventOpcode.Stop, Level = EventLevel.Informational)]
         public void TransmissionCompletedSize(long size)
         {

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -89,6 +89,11 @@ namespace StreamJsonRpc
         private const int TransmissionCompletedEvent = 31;
 
         /// <summary>
+        /// The event ID for the <see cref="TransmissionCompletedSize"/>
+        /// </summary>
+        private const int TransmisionCompletedSizeEvent = 32;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonRpcEventSource"/> class.
         /// </summary>
         /// <remarks>
@@ -232,6 +237,16 @@ namespace StreamJsonRpc
         public void TransmissionCompleted()
         {
             this.WriteEvent(TransmissionCompletedEvent);
+        }
+
+        /// <summary>
+        /// Signal that a message has been transmitted with the size.
+        /// </summary>
+        /// <param name="size"></param>
+        [Event(TransmisionCompletedSizeEvent, Task = Tasks.MessageTransmission, Opcode = EventOpcode.Stop, Level = EventLevel.Informational)]
+        public void TransmissionCompletedSize(long size)
+        {
+            this.WriteEvent(TransmisionCompletedSizeEvent, size);
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -242,7 +242,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// Signal that a message has been transmitted with the size.
         /// </summary>
-        /// <param name="size">Size of the payload</param>
+        /// <param name="size">Size of the payload</param>.
         [Event(TransmisionCompletedSizeEvent, Task = Tasks.MessageTransmission, Opcode = EventOpcode.Stop, Level = EventLevel.Informational)]
         public void TransmissionCompletedSize(long size)
         {

--- a/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
+++ b/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
@@ -109,6 +109,11 @@ namespace StreamJsonRpc
                 Utilities.Write(this.Writer.GetSpan(sizeof(int)), checked((int)contentSequence.Length));
                 this.Writer.Advance(sizeof(int));
                 contentSequence.CopyTo(this.Writer);
+
+                if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+                {
+                    JsonRpcEventSource.Instance.TransmissionCompletedSize(contentSequence.Length);
+                }
             }
             finally
             {

--- a/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
@@ -113,11 +113,6 @@ namespace StreamJsonRpc
             cancellationToken.ThrowIfCancellationRequested();
             this.Formatter.Serialize(this.Writer, content);
             this.Writer.Write(this.newLineBytes.Span);
-
-            if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
-            {
-                JsonRpcEventSource.Instance.TransmissionCompletedSize(this.newLineBytes.Length);
-            }
         }
 
         /// <inheritdoc/>

--- a/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/NewLineDelimitedMessageHandler.cs
@@ -113,6 +113,11 @@ namespace StreamJsonRpc
             cancellationToken.ThrowIfCancellationRequested();
             this.Formatter.Serialize(this.Writer, content);
             this.Writer.Write(this.newLineBytes.Span);
+
+            if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+            {
+                JsonRpcEventSource.Instance.TransmissionCompletedSize(this.newLineBytes.Length);
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Updated implementations of IJsonRpcMessageHandler to emit a new event including the size of payload. 

These implementations include those of: 
1. HeaderDelimitedMessageHandler.cs
2. LengthHeaderMessageHandler.cs