### PR TITLE
Add support for MessagePack [Union] types as parameter and return types

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -23,7 +23,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
     {
     }
 
-    private interface IMessagePackServer
+    internal interface IMessagePackServer
     {
         Task<UnionBaseClass> ReturnUnionTypeAsync(CancellationToken cancellationToken);
 

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -116,6 +116,58 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
     /// Verifies that the type information associated with named parameters is used for proper serialization of union types.
     /// </summary>
     [Fact]
+    public async Task UnionType_NamedParameter_NoReturnValue_UntypedDictionary()
+    {
+        var server = new MessagePackServer();
+        this.serverRpc.AllowModificationWhileListening = true;
+        this.serverRpc.AddLocalRpcTarget(server);
+        await this.clientRpc.InvokeWithParameterObjectAsync(
+            nameof(MessagePackServer.AcceptUnionTypeAsync),
+            new Dictionary<string, object> { { "value", new UnionDerivedClass() } },
+            new Dictionary<string, Type> { { "value", typeof(UnionBaseClass) } },
+            this.TimeoutToken);
+        Assert.IsType<UnionDerivedClass>(server.ReceivedValue);
+
+        // Exercise the non-init path by repeating
+        await this.clientRpc.InvokeWithParameterObjectAsync(
+            nameof(MessagePackServer.AcceptUnionTypeAsync),
+            new Dictionary<string, object> { { "value", new UnionDerivedClass() } },
+            new Dictionary<string, Type> { { "value", typeof(UnionBaseClass) } },
+            this.TimeoutToken);
+        Assert.IsType<UnionDerivedClass>(server.ReceivedValue);
+    }
+
+    /// <summary>
+    /// Verifies that the type information associated with named parameters is used for proper serialization of union types.
+    /// </summary>
+    [Fact]
+    public async Task UnionType_NamedParameter_AndReturnValue_UntypedDictionary()
+    {
+        var server = new MessagePackServer();
+        this.serverRpc.AllowModificationWhileListening = true;
+        this.serverRpc.AddLocalRpcTarget(server);
+        string? result = await this.clientRpc.InvokeWithParameterObjectAsync<string?>(
+            nameof(MessagePackServer.AcceptUnionTypeAndReturnStringAsync),
+            new Dictionary<string, object> { { "value", new UnionDerivedClass() } },
+            new Dictionary<string, Type> { { "value", typeof(UnionBaseClass) } },
+            this.TimeoutToken);
+        Assert.Equal(typeof(UnionDerivedClass).Name, result);
+        Assert.IsType<UnionDerivedClass>(server.ReceivedValue);
+
+        // Exercise the non-init path by repeating
+        result = await this.clientRpc.InvokeWithParameterObjectAsync<string?>(
+            nameof(MessagePackServer.AcceptUnionTypeAndReturnStringAsync),
+            new Dictionary<string, object> { { "value", new UnionDerivedClass() } },
+            new Dictionary<string, Type> { { "value", typeof(UnionBaseClass) } },
+            this.TimeoutToken);
+        Assert.Equal(typeof(UnionDerivedClass).Name, result);
+        Assert.IsType<UnionDerivedClass>(server.ReceivedValue);
+    }
+
+    /// <summary>
+    /// Verifies that the type information associated with named parameters is used for proper serialization of union types.
+    /// </summary>
+    [Fact]
     public async Task UnionType_NamedParameter_NoReturnValue()
     {
         var server = new MessagePackServer();

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1016,9 +1016,37 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task InvokeWithParameterObjectAsync(string targetName, object? argument = null, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         {
             return this.InvokeWithParameterObjectAsync<object>(targetName, argument, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoke a method on the server.  The parameter is passed as an object.
+        /// </summary>
+        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
+        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argumentDeclaredTypes']"/></param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <returns>A task that completes when the server method executes and returns the result.</returns>
+        /// <exception cref="OperationCanceledException">
+        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
+        /// </exception>
+        /// <exception cref="RemoteInvocationException">
+        /// Result task fails with this exception if the server method throws an exception.
+        /// </exception>
+        /// <exception cref="RemoteMethodNotFoundException">
+        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0016 // Add public types and members to the declared API
+        public Task InvokeWithParameterObjectAsync(string targetName, object? argument, IReadOnlyDictionary<string, Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+        {
+            return this.InvokeWithParameterObjectAsync<object>(targetName, argument, argumentDeclaredTypes, cancellationToken);
         }
 
         /// <summary>
@@ -1040,11 +1068,43 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object? argument = null, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
+        {
+            return this.InvokeWithParameterObjectAsync<TResult>(targetName, argument, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoke a method on the server and get back the result.  The parameter is passed as an object.
+        /// </summary>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
+        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
+        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <param name="argumentDeclaredTypes">
+        /// A dictionary of <see cref="Type"/> objects that describe how each entry in the <see cref="IReadOnlyDictionary{TKey, TValue}"/> provided in <paramref name="argument"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same set of keys as <paramref name="argument"/> and contain no <c>null</c> values.
+        /// </param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <returns>A task that completes when the server method executes and returns the result.</returns>
+        /// <exception cref="OperationCanceledException">
+        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
+        /// </exception>
+        /// <exception cref="RemoteInvocationException">
+        /// Result task fails with this exception if the server method throws an exception.
+        /// </exception>
+        /// <exception cref="RemoteMethodNotFoundException">
+        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0016 // Add public types and members to the declared API
+        public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object? argument, IReadOnlyDictionary<string, Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
+#pragma warning restore RS0016 // Add public types and members to the declared API
         {
             // If argument is null, this indicates that the method does not take any parameters.
             object?[]? argumentToPass = argument == null ? null : new object?[] { argument };
-            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, argumentToPass, cancellationToken, isParameterObject: true);
+            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, argumentToPass, positionalArgumentDeclaredTypes: null, argumentDeclaredTypes, cancellationToken, isParameterObject: true);
         }
 
         /// <summary>
@@ -1157,7 +1217,7 @@ namespace StreamJsonRpc
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
         public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
         {
-            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, argumentDeclaredTypes, cancellationToken, isParameterObject: false);
+            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, argumentDeclaredTypes, namedArgumentDeclaredTypes: null, cancellationToken, isParameterObject: false);
         }
 
         /// <summary>
@@ -1359,10 +1419,10 @@ namespace StreamJsonRpc
             return this.InvokeCoreAsync<TResult>(id.HasValue ? new RequestId(id.Value) : default, targetName, arguments, cancellationToken, isParameterObject);
         }
 
-        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, CancellationToken, bool)"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)"/>
         protected Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken, bool isParameterObject)
         {
-            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, null, cancellationToken, isParameterObject);
+            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, null, null, cancellationToken, isParameterObject);
         }
 
         /// <summary>
@@ -1372,15 +1432,21 @@ namespace StreamJsonRpc
         /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>
         /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
-        /// <param name="argumentDeclaredTypes">
+        /// <param name="positionalArgumentDeclaredTypes">
         /// A list of <see cref="Type"/> objects that describe how each element in <paramref name="arguments"/> is expected by the server to be typed.
         /// If specified, this must have exactly the same length as <paramref name="arguments"/> and contain no <c>null</c> elements.
         /// This value is ignored when <paramref name="isParameterObject"/> is true.
         /// </param>
+        /// <param name="namedArgumentDeclaredTypes">
+        /// A dictionary of <see cref="Type"/> objects that describe how each entry in the <see cref="IReadOnlyDictionary{TKey, TValue}"/> provided in the only element of <paramref name="arguments"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same set of keys as the dictionary contained in the first element of <paramref name="arguments"/>, and contain no <c>null</c> values.
+        /// </param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
-        protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? argumentDeclaredTypes, CancellationToken cancellationToken, bool isParameterObject)
+#pragma warning disable RS0016 // Add public types and members to the declared API
+        protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? positionalArgumentDeclaredTypes, IReadOnlyDictionary<string, Type>? namedArgumentDeclaredTypes, CancellationToken cancellationToken, bool isParameterObject)
+#pragma warning restore RS0016 // Add public types and members to the declared API
         {
             Requires.NotNullOrEmpty(targetName, nameof(targetName));
 
@@ -1406,15 +1472,20 @@ namespace StreamJsonRpc
                 }
 
                 request.Arguments = argument;
+                if (namedArgumentDeclaredTypes is object)
+                {
+                    Requires.Argument(namedArgumentDeclaredTypes.Count == request.ArgumentCount, nameof(namedArgumentDeclaredTypes), Resources.TypedArgumentsLengthMismatch);
+                    request.NamedArgumentDeclaredTypes = namedArgumentDeclaredTypes;
+                }
             }
             else
             {
                 request.Arguments = arguments ?? EmptyObjectArray;
 
-                if (argumentDeclaredTypes is object)
+                if (positionalArgumentDeclaredTypes is object)
                 {
-                    Requires.Argument(argumentDeclaredTypes.Count == arguments?.Count, nameof(argumentDeclaredTypes), Resources.TypedArgumentsLengthMismatch);
-                    request.ArgumentListDeclaredTypes = argumentDeclaredTypes;
+                    Requires.Argument(positionalArgumentDeclaredTypes.Count == request.ArgumentCount, nameof(positionalArgumentDeclaredTypes), Resources.TypedArgumentsLengthMismatch);
+                    request.ArgumentListDeclaredTypes = positionalArgumentDeclaredTypes;
                 }
             }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1039,9 +1039,39 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task InvokeWithCancellationAsync(string targetName, IReadOnlyList<object?>? arguments = null, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         {
             return this.InvokeWithCancellationAsync<object>(targetName, arguments, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoke a method on the server.
+        /// </summary>
+        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
+        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
+        /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeWithCancellationAsync{TResult}(string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, CancellationToken)" path="/param[@name='argumentDeclaredTypes']"/></param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <returns>A task that completes when the server method executes.</returns>
+        /// <exception cref="OperationCanceledException">
+        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
+        /// or in response to the <paramref name="cancellationToken"/> being canceled.
+        /// </exception>
+        /// <exception cref="RemoteInvocationException">
+        /// Result task fails with this exception if the server method throws an exception,
+        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
+        /// </exception>
+        /// <exception cref="RemoteMethodNotFoundException">
+        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
+        public Task InvokeWithCancellationAsync(string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type> argumentDeclaredTypes, CancellationToken cancellationToken)
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
+        {
+            return this.InvokeWithCancellationAsync<object>(targetName, arguments, argumentDeclaredTypes, cancellationToken);
         }
 
         /// <summary>
@@ -1065,9 +1095,41 @@ namespace StreamJsonRpc
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+#pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object?>? arguments = null, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         {
             return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoke a method on the server and get back the result.
+        /// </summary>
+        /// <typeparam name="TResult">Type of the method result.</typeparam>
+        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
+        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
+        /// <param name="argumentDeclaredTypes">
+        /// A list of <see cref="Type"/> objects that describe how each element in <paramref name="arguments"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same length as <paramref name="arguments"/> and contain no <c>null</c> elements.
+        /// </param>
+        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <returns>A task that completes when the server method executes and returns the result.</returns>
+        /// <exception cref="OperationCanceledException">
+        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
+        /// or in response to the <paramref name="cancellationToken"/> being canceled.
+        /// </exception>
+        /// <exception cref="RemoteInvocationException">
+        /// Result task fails with this exception if the server method throws an exception,
+        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
+        /// </exception>
+        /// <exception cref="RemoteMethodNotFoundException">
+        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
+        {
+            return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, argumentDeclaredTypes, cancellationToken, isParameterObject: false);
         }
 
         /// <summary>
@@ -1269,6 +1331,12 @@ namespace StreamJsonRpc
             return this.InvokeCoreAsync<TResult>(id.HasValue ? new RequestId(id.Value) : default, targetName, arguments, cancellationToken, isParameterObject);
         }
 
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, CancellationToken, bool)"/>
+        protected Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken, bool isParameterObject)
+        {
+            return this.InvokeCoreAsync<TResult>(id, targetName, arguments, null, cancellationToken, isParameterObject);
+        }
+
         /// <summary>
         /// Invokes the specified RPC method.
         /// </summary>
@@ -1276,10 +1344,15 @@ namespace StreamJsonRpc
         /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
         /// <param name="targetName">Name of the method to invoke.</param>
         /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
+        /// <param name="argumentDeclaredTypes">
+        /// A list of <see cref="Type"/> objects that describe how each element in <paramref name="arguments"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same length as <paramref name="arguments"/> and contain no <c>null</c> elements.
+        /// This value is ignored when <paramref name="isParameterObject"/> is true.
+        /// </param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
         /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
-        protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken, bool isParameterObject)
+        protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? argumentDeclaredTypes, CancellationToken cancellationToken, bool isParameterObject)
         {
             Requires.NotNullOrEmpty(targetName, nameof(targetName));
 

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -45,6 +45,14 @@ namespace StreamJsonRpc
         private const string ErrorPropertyName = "error";
 
         /// <summary>
+        /// A cache of property names to declared property types, indexed by their containing parameter object type.
+        /// </summary>
+        /// <remarks>
+        /// All access to this field should be while holding a lock on this member's value.
+        /// </remarks>
+        private static readonly Dictionary<Type, IReadOnlyDictionary<string, Type>> ParameterObjectPropertyTypes = new Dictionary<Type, IReadOnlyDictionary<string, Type>>();
+
+        /// <summary>
         /// The options to use for serializing top-level RPC messages.
         /// </summary>
         private readonly MessagePackSerializerOptions messageSerializationOptions;
@@ -238,7 +246,11 @@ namespace StreamJsonRpc
             {
                 // This request contains named arguments, but not using a standard dictionary. Convert it to a dictionary so that
                 // the parameters can be matched to the method we're invoking.
-                request.Arguments = GetParamsObjectDictionary(request.Arguments);
+                if (GetParamsObjectDictionary(request.Arguments) is { } namedArgs)
+                {
+                    request.Arguments = namedArgs.ArgumentValues;
+                    request.NamedArgumentDeclaredTypes = namedArgs.ArgumentTypes;
+                }
             }
 
             var writer = new MessagePackWriter(contentBuffer);
@@ -265,17 +277,28 @@ namespace StreamJsonRpc
         /// Extracts a dictionary of property names and values from the specified params object.
         /// </summary>
         /// <param name="paramsObject">The params object.</param>
-        /// <returns>A dictionary, or <c>null</c> if <paramref name="paramsObject"/> is null.</returns>
+        /// <returns>A dictionary of argument values and another of declared argument types, or <c>null</c> if <paramref name="paramsObject"/> is null.</returns>
         /// <remarks>
         /// This method supports DataContractSerializer-compliant types. This includes C# anonymous types.
         /// </remarks>
         [return: NotNullIfNotNull("paramsObject")]
-        private static IReadOnlyDictionary<string, object?>? GetParamsObjectDictionary(object? paramsObject)
+        private static (IReadOnlyDictionary<string, object?> ArgumentValues, IReadOnlyDictionary<string, Type> ArgumentTypes)? GetParamsObjectDictionary(object? paramsObject)
         {
             if (paramsObject == null)
             {
-                return null;
+                return default;
             }
+
+            // Look up the argument types dictionary if we saved it before.
+            Type paramsObjectType = paramsObject.GetType();
+            IReadOnlyDictionary<string, Type>? argumentTypes;
+            lock (ParameterObjectPropertyTypes)
+            {
+                ParameterObjectPropertyTypes.TryGetValue(paramsObjectType, out argumentTypes);
+            }
+
+            // If we couldn't find a previously created argument types dictionary, create a mutable one that we'll build this time.
+            Dictionary<string, Type>? mutableArgumentTypes = argumentTypes is null ? new Dictionary<string, Type>() : null;
 
             var result = new Dictionary<string, object?>(StringComparer.Ordinal);
 
@@ -320,6 +343,10 @@ namespace StreamJsonRpc
                     if (TryGetSerializationInfo(property, out string key))
                     {
                         result[key] = property.GetValue(paramsObject);
+                        if (mutableArgumentTypes is object)
+                        {
+                            mutableArgumentTypes[key] = property.PropertyType;
+                        }
                     }
                 }
             }
@@ -329,10 +356,31 @@ namespace StreamJsonRpc
                 if (TryGetSerializationInfo(field, out string key))
                 {
                     result[key] = field.GetValue(paramsObject);
+                    if (mutableArgumentTypes is object)
+                    {
+                        mutableArgumentTypes[key] = field.FieldType;
+                    }
                 }
             }
 
-            return result;
+            // If we assembled the argument types dictionary this time, save it for next time.
+            if (mutableArgumentTypes is object)
+            {
+                lock (ParameterObjectPropertyTypes)
+                {
+                    if (ParameterObjectPropertyTypes.TryGetValue(paramsObjectType, out IReadOnlyDictionary<string, Type>? lostRace))
+                    {
+                        // Of the two, pick the winner to use ourselves so we consolidate on one and allow the GC to collect the loser sooner.
+                        argumentTypes = lostRace;
+                    }
+                    else
+                    {
+                        ParameterObjectPropertyTypes.Add(paramsObjectType, argumentTypes = mutableArgumentTypes);
+                    }
+                }
+            }
+
+            return (result, argumentTypes!);
         }
 
         private static ReadOnlySequence<byte> GetSliceForNextToken(ref MessagePackReader reader)
@@ -1118,9 +1166,17 @@ namespace StreamJsonRpc
                 if (value.ArgumentsList != null)
                 {
                     writer.WriteArrayHeader(value.ArgumentsList.Count);
-                    foreach (var arg in value.ArgumentsList)
+                    for (int i = 0; i < value.ArgumentsList.Count; i++)
                     {
-                        DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, arg, this.formatter.userDataSerializationOptions);
+                        object? arg = value.ArgumentsList[i];
+                        if (value.ArgumentListDeclaredTypes is object)
+                        {
+                            MessagePackSerializer.Serialize(value.ArgumentListDeclaredTypes[i], ref writer, arg, this.formatter.userDataSerializationOptions);
+                        }
+                        else
+                        {
+                            DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, arg, this.formatter.userDataSerializationOptions);
+                        }
                     }
                 }
                 else if (value.NamedArguments != null)
@@ -1129,7 +1185,14 @@ namespace StreamJsonRpc
                     foreach (KeyValuePair<string, object?> entry in value.NamedArguments)
                     {
                         writer.Write(entry.Key);
-                        DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, entry.Value, this.formatter.userDataSerializationOptions);
+                        if (value.NamedArgumentDeclaredTypes?[entry.Key] is Type argType)
+                        {
+                            MessagePackSerializer.Serialize(argType, ref writer, entry.Value, this.formatter.userDataSerializationOptions);
+                        }
+                        else
+                        {
+                            DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, entry.Value, this.formatter.userDataSerializationOptions);
+                        }
                     }
                 }
                 else
@@ -1188,7 +1251,14 @@ namespace StreamJsonRpc
                 options.Resolver.GetFormatterWithVerify<RequestId>().Serialize(ref writer, value.RequestId, options);
 
                 writer.Write(ResultPropertyName);
-                DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, value.Result, this.formatter.userDataSerializationOptions);
+                if (value.ResultDeclaredType is object && value.ResultDeclaredType != typeof(void))
+                {
+                    MessagePackSerializer.Serialize(value.ResultDeclaredType, ref writer, value.Result, this.formatter.userDataSerializationOptions);
+                }
+                else
+                {
+                    DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, value.Result, this.formatter.userDataSerializationOptions);
+                }
             }
         }
 

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -110,6 +110,19 @@ namespace StreamJsonRpc.Protocol
         }
 
         /// <summary>
+        /// Gets or sets a dictionary of <see cref="Type"/> objects indexed by the property name that describe how each element in <see cref="NamedArguments"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same size as <see cref="NamedArguments"/> and contain no <c>null</c> values.
+        /// </summary>
+        /// <remarks>
+        /// This property is *not* serialized into the JSON-RPC message.
+        /// On the client-side of an RPC call it comes from the declared property types in the parameter object.
+        /// On the server-side of the RPC call it comes from the types of each parameter on the invoked RPC method.
+        /// This list is used for purposes of aiding the <see cref="IJsonRpcMessageFormatter"/> in serialization.
+        /// </remarks>
+        [IgnoreDataMember]
+        public IReadOnlyDictionary<string, Type>? NamedArgumentDeclaredTypes { get; set; }
+
+        /// <summary>
         /// Gets or sets an array of arguments, if applicable.
         /// </summary>
         [IgnoreDataMember]
@@ -129,6 +142,21 @@ namespace StreamJsonRpc.Protocol
             get => this.Arguments as IReadOnlyList<object>;
             set => this.Arguments = value;
         }
+
+        /// <summary>
+        /// Gets or sets a list of <see cref="Type"/> objects that describe how each element in <see cref="ArgumentsList"/> is expected by the server to be typed.
+        /// If specified, this must have exactly the same length as <see cref="ArgumentsList"/> and contain no <c>null</c> elements.
+        /// </summary>
+        /// <remarks>
+        /// This property is *not* serialized into the JSON-RPC message.
+        /// On the client-side of an RPC call it comes from the typed arguments supplied to the
+        /// <see cref="JsonRpc.InvokeWithCancellationAsync{TResult}(string, IReadOnlyList{object?}, IReadOnlyList{Type}, System.Threading.CancellationToken)"/>
+        /// method.
+        /// On the server-side of the RPC call it comes from the types of each parameter on the invoked RPC method.
+        /// This list is used for purposes of aiding the <see cref="IJsonRpcMessageFormatter"/> in serialization.
+        /// </remarks>
+        [IgnoreDataMember]
+        public IReadOnlyList<Type>? ArgumentListDeclaredTypes { get; set; }
 
         /// <summary>
         /// Gets the string to display in the debugger for this instance.

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -23,6 +23,15 @@ namespace StreamJsonRpc.Protocol
         public object? Result { get; set; }
 
         /// <summary>
+        /// Gets or sets the declared type of the return value.
+        /// </summary>
+        /// <remarks>
+        /// This value is not serialized, but is used by the RPC server to assist in serialization where necessary.
+        /// </remarks>
+        [IgnoreDataMember]
+        public Type? ResultDeclaredType { get; set; }
+
+        /// <summary>
         /// Gets or sets an identifier established by the client if a response to the request is expected.
         /// </summary>
         /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <c>null</c>.</value>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -209,8 +209,8 @@ namespace StreamJsonRpc
                 MethodInfo invokeAsyncOfTaskOfTMethodInfo = invokeAsyncMethodInfos.Single(m => m.IsGenericMethod);
 
                 IEnumerable<MethodInfo> invokeWithCancellationAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithCancellationAsync));
-                MethodInfo invokeWithCancellationAsyncOfTaskMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => !m.IsGenericMethod);
-                MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod);
+                MethodInfo invokeWithCancellationAsyncOfTaskMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters().Length == 3);
+                MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 3);
 
                 IEnumerable<MethodInfo> invokeWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithParameterObjectAsync));
                 MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod);

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -210,8 +210,8 @@ namespace StreamJsonRpc
                 MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 4);
 
                 IEnumerable<MethodInfo> invokeWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithParameterObjectAsync));
-                MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod);
-                MethodInfo invokeWithParameterObjectAsyncOfTaskOfTMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => m.IsGenericMethod);
+                MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters().Length == 3);
+                MethodInfo invokeWithParameterObjectAsyncOfTaskOfTMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 3);
 
                 foreach (MethodInfo method in FindAllOnThisAndOtherInterfaces(serviceInterface, i => i.DeclaredMethods).Where(m => !m.IsSpecialName))
                 {
@@ -338,10 +338,7 @@ namespace StreamJsonRpc
                         }
                         else
                         {
-                            LocalBuilder ct = il.DeclareLocal(typeof(CancellationToken));
-                            il.Emit(OpCodes.Ldloca_S, ct);
-                            il.Emit(OpCodes.Initobj, typeof(CancellationToken));
-                            il.Emit(OpCodes.Ldloc_S, ct);
+                            il.Emit(OpCodes.Call, CancellationTokenNonePropertyGetter);
                         }
 
                         // Construct the InvokeAsync<T> method with the T argument supplied if we have a return type.

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -308,20 +308,28 @@ namespace StreamJsonRpc
                     // The second argument is an array of arguments for the RPC method.
                     il.MarkLabel(positionalArgsLabel);
                     {
-                        il.Emit(OpCodes.Ldc_I4, argumentCountExcludingCancellationToken);
-                        il.Emit(OpCodes.Newarr, typeof(object));
-
-                        for (int i = 0; i < argumentCountExcludingCancellationToken; i++)
+                        if (argumentCountExcludingCancellationToken == 0)
                         {
-                            il.Emit(OpCodes.Dup); // duplicate the array on the stack
-                            il.Emit(OpCodes.Ldc_I4, i); // push the index of the array to be initialized.
-                            il.Emit(OpCodes.Ldarg, i + 1); // push the associated argument
-                            if (methodParameters[i].ParameterType.GetTypeInfo().IsValueType)
-                            {
-                                il.Emit(OpCodes.Box, methodParameters[i].ParameterType); // box if the argument is a value type
-                            }
+                            // No args, so avoid creating an array.
+                            il.Emit(OpCodes.Ldnull);
+                        }
+                        else
+                        {
+                            il.Emit(OpCodes.Ldc_I4, argumentCountExcludingCancellationToken);
+                            il.Emit(OpCodes.Newarr, typeof(object));
 
-                            il.Emit(OpCodes.Stelem_Ref); // set the array element.
+                            for (int i = 0; i < argumentCountExcludingCancellationToken; i++)
+                            {
+                                il.Emit(OpCodes.Dup); // duplicate the array on the stack
+                                il.Emit(OpCodes.Ldc_I4, i); // push the index of the array to be initialized.
+                                il.Emit(OpCodes.Ldarg, i + 1); // push the associated argument
+                                if (methodParameters[i].ParameterType.GetTypeInfo().IsValueType)
+                                {
+                                    il.Emit(OpCodes.Box, methodParameters[i].ParameterType); // box if the argument is a value type
+                                }
+
+                                il.Emit(OpCodes.Stelem_Ref); // set the array element.
+                            }
                         }
 
                         MethodInfo invokingMethod;

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -32,6 +32,7 @@ namespace StreamJsonRpc
         private static readonly MethodInfo DelegateRemoveMethod = typeof(Delegate).GetRuntimeMethod(nameof(Delegate.Remove), new Type[] { typeof(Delegate), typeof(Delegate) })!;
         private static readonly MethodInfo CancellationTokenNonePropertyGetter = typeof(CancellationToken).GetRuntimeProperty(nameof(CancellationToken.None))!.GetMethod!;
         private static readonly ConstructorInfo ObjectCtor = typeof(object).GetTypeInfo().DeclaredConstructors.Single();
+        private static readonly MethodInfo GetTypeFromHandleMethod = typeof(Type).GetRuntimeMethod(nameof(Type.GetTypeFromHandle), new Type[] { typeof(RuntimeTypeHandle) });
         private static readonly Dictionary<TypeInfo, TypeInfo> GeneratedProxiesByInterface = new Dictionary<TypeInfo, TypeInfo>();
         private static readonly MethodInfo CompareExchangeMethod = (from method in typeof(Interlocked).GetRuntimeMethods()
                                                                     where method.Name == nameof(Interlocked.CompareExchange)
@@ -204,13 +205,9 @@ namespace StreamJsonRpc
                     jsonRpcProperty.SetGetMethod(jsonRpcPropertyGetter);
                 }
 
-                MethodInfo[] invokeAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeAsync) && m.GetParameters()[1].ParameterType == typeof(object[])).ToArray();
-                MethodInfo invokeAsyncOfTaskMethodInfo = invokeAsyncMethodInfos.Single(m => !m.IsGenericMethod);
-                MethodInfo invokeAsyncOfTaskOfTMethodInfo = invokeAsyncMethodInfos.Single(m => m.IsGenericMethod);
-
                 IEnumerable<MethodInfo> invokeWithCancellationAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithCancellationAsync));
-                MethodInfo invokeWithCancellationAsyncOfTaskMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters().Length == 3);
-                MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 3);
+                MethodInfo invokeWithCancellationAsyncOfTaskMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters().Length == 4);
+                MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 4);
 
                 IEnumerable<MethodInfo> invokeWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithParameterObjectAsync));
                 MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod);
@@ -332,23 +329,25 @@ namespace StreamJsonRpc
                             }
                         }
 
-                        MethodInfo invokingMethod;
+                        // The third argument is a Type[] describing each parameter type.
+                        LoadParameterTypeArrayField(proxyTypeBuilder, methodParameters.Take(argumentCountExcludingCancellationToken).ToArray(), il);
+
                         if (cancellationTokenParameter != null)
                         {
                             il.Emit(OpCodes.Ldarg, cancellationTokenParameter.Position + 1);
-                            invokingMethod = hasReturnValue ? invokeWithCancellationAsyncOfTaskOfTMethodInfo : invokeWithCancellationAsyncOfTaskMethodInfo;
                         }
                         else
                         {
-                            invokingMethod = hasReturnValue ? invokeAsyncOfTaskOfTMethodInfo : invokeAsyncOfTaskMethodInfo;
+                            LocalBuilder ct = il.DeclareLocal(typeof(CancellationToken));
+                            il.Emit(OpCodes.Ldloca_S, ct);
+                            il.Emit(OpCodes.Initobj, typeof(CancellationToken));
+                            il.Emit(OpCodes.Ldloc_S, ct);
                         }
 
                         // Construct the InvokeAsync<T> method with the T argument supplied if we have a return type.
-                        if (invokeResultTypeArgument != null)
-                        {
-                            invokingMethod = invokingMethod.MakeGenericMethod(invokeResultTypeArgument);
-                        }
-
+                        MethodInfo invokingMethod = invokeResultTypeArgument is object
+                            ? invokeWithCancellationAsyncOfTaskOfTMethodInfo.MakeGenericMethod(invokeResultTypeArgument)
+                            : invokeWithCancellationAsyncOfTaskMethodInfo;
                         il.EmitCall(OpCodes.Callvirt, invokingMethod, null);
 
                         AdaptReturnType(method, returnTypeIsValueTask, returnTypeIsIAsyncEnumerable, il, invokingMethod, cancellationTokenParameter);
@@ -364,11 +363,57 @@ namespace StreamJsonRpc
 
 #if SaveAssembly
                 ((AssemblyBuilder)proxyModuleBuilder.Assembly).Save(proxyModuleBuilder.ScopeName);
+                System.IO.File.Delete(proxyModuleBuilder.ScopeName + ".dll");
                 System.IO.File.Move(proxyModuleBuilder.ScopeName, proxyModuleBuilder.ScopeName + ".dll");
 #endif
             }
 
             return generatedType;
+        }
+
+        private static void LoadParameterTypeArrayField(TypeBuilder proxyTypeBuilder, ParameterInfo[] parameterInfos, ILGenerator il)
+        {
+            if (parameterInfos.Length == 0)
+            {
+                // No need for a field when the array would be empty.
+                il.Emit(OpCodes.Ldnull);
+                return;
+            }
+
+            // Create a reusable Type[] with each of the parameters in the RPC method (excluding the cancellation token)
+            string fieldName = Guid.NewGuid().ToString("n");
+            FieldBuilder field = proxyTypeBuilder.DefineField(
+                fieldName,
+                typeof(Type[]),
+                FieldAttributes.Static | FieldAttributes.Private);
+
+            Label skipInitLabel = il.DefineLabel();
+
+            // Load the Type[] field, and skip initializing it if it's non-null.
+            il.Emit(OpCodes.Ldsfld, field);
+            il.Emit(OpCodes.Dup); // keep a copy on the stack after the test in case it's non-null.
+            il.Emit(OpCodes.Brtrue_S, skipInitLabel);
+
+            // Initialize the field.
+            il.Emit(OpCodes.Pop); // pop off the extra null.
+            il.Emit(OpCodes.Ldc_I4, parameterInfos.Length);
+            il.Emit(OpCodes.Newarr, typeof(Type));
+
+            // Populate the array.
+            for (int i = 0; i < parameterInfos.Length; i++)
+            {
+                il.Emit(OpCodes.Dup); // Keep the array on the stack after we use it.
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldtoken, parameterInfos[i].ParameterType);
+                il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
+                il.Emit(OpCodes.Stelem_Ref);
+            }
+
+            // Store the array in the field, while keeping a copy on the stack for the argument.
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Stsfld, field);
+
+            il.MarkLabel(skipInitLabel);
         }
 
         private static void ImplementDisposeMethod(TypeBuilder proxyTypeBuilder, FieldBuilder jsonRpcField)

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -520,6 +520,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The length of this list must equal the length of the arguments list..
+        /// </summary>
+        internal static string TypedArgumentsLengthMismatch {
+            get {
+                return ResourceManager.GetString("TypedArgumentsLengthMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find method &apos;{0}/{1}&apos; on {2} for the following reasons: {3}.
         /// </summary>
         internal static string UnableToFindMethod {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -288,6 +288,9 @@
     <value>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</value>
     <comment>{0} and {1} are CLR type names.</comment>
   </data>
+  <data name="TypedArgumentsLengthMismatch" xml:space="preserve">
+    <value>The length of this list must equal the length of the arguments list.</value>
+  </data>
   <data name="UnableToFindMethod" xml:space="preserve">
     <value>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</value>
     <comment>{0} is the method name, {1} is arity, {2} is target class full name, {3} is the error list.</comment>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
-StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,13 @@
+StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type>
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
+StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Type>
+StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
+StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type
+StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.DisconnectedReason
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
-StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,13 @@
+StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>
+StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string targetName, System.Collections.Generic.IReadOnlyList<object> arguments, System.Collections.Generic.IReadOnlyList<System.Type> argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.UseSingleObjectParameterDeserialization.set -> void
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type>
+StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
+StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Type>
+StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
+StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type
+StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Úloha byla zrušena.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Nebyla nalezena metoda {0}/{1} v {2} z následujících důvodů: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Der Task wurde abgebrochen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Die Methode "{0}/{1}" für "{2}" wurde aus den folgenden Gründen nicht gefunden: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -127,6 +127,11 @@
         <target state="translated">La tarea se canceló.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">No se puede encontrar el método '{0}/{1}' en {2} por las siguientes razones: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">La tâche a été annulée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Impossible de trouver la méthode '{0}/{1}' sur {2} pour les raisons suivantes : {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -127,6 +127,11 @@
         <target state="translated">L'attività è stata annullata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Il metodo '{0}/{1}' in {2} non è stato trovato per i motivi seguenti: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -127,6 +127,11 @@
         <target state="translated">タスクはキャンセルされました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">次の理由により、{2} でメソッド '{0}/{1}' が見つかりません: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -127,6 +127,11 @@
         <target state="translated">작업이 취소되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">{2}에서 '{0}/{1}' 메서드를 다음과 같은 이유로 찾을 수 없음:{3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Zadanie zostało anulowane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Nie można odnaleźć metody „{0}/{1}” w klasie {2}. Przyczyny: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -127,6 +127,11 @@
         <target state="translated">A tarefa foi cancelada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Não é possível encontrar o método '{0}/{1}' em {2} pelos seguintes motivos: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Задача отменена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">Не удалось найти метод "{0}/{1}" в {2} по следующим причинам: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Bu görev iptal edildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">'{0}/{1}' metodu {2} üzerinde şu nedenlerle bulunamadı: {3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -127,6 +127,11 @@
         <target state="translated">任务已取消。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">找不到 {2} 上的方法“{0}/{1}”，原因如下：{3}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -127,6 +127,11 @@
         <target state="translated">工作已取消。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TypedArgumentsLengthMismatch">
+        <source>The length of this list must equal the length of the arguments list.</source>
+        <target state="new">The length of this list must equal the length of the arguments list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindMethod" translate="yes" xml:space="preserve">
         <source>Unable to find method '{0}/{1}' on {2} for the following reasons: {3}</source>
         <target state="translated">在 {2} 上找不到方法 '{0}/{1}'，原因如下: {3}</target>


### PR DESCRIPTION
- Add several tests to demonstrate the expected use cases.
- Update the library to take declared argument types, and propagate these and return types to the formatter.
- Update the `MessagePackFormatter` to use this type info to serialize using the declared type so that union data wraps the msgpack data when appropriate.
- Optimize proxies to never allocate 0-length arrays.

## Original problem

MessagePack requires knowing the declared type as well as the object to actually serialize/deserialize. The declared type might be `BaseType` while the value itself might be an instance of `DerivedType`. When the declared type equals the value's actual runtime type, MessagePack simply serializes the value. But when the declared type is a base type of the value's type, MessagePack looks for a `[Union]` attribute on the declared type so it knows how to annotate the serialized value so that the runtime type can be recovered on the deserialized side.

It is very important that the serializing and deserializing sides agree on the _declared_ type so that they agree on what the type annotation (if any) should be, otherwise there is a deserialization failure.
The *deserializing* side always knows the declared type, as this is required to deserialize it in the first place. But while the *serializing* side always knows the runtime type (since it has the value and can call `GetType()` on it), the serializer does _not_ always know the *declared* type. Thus, our MessagePack serialization code does not annotate values with the sometimes necessary Union type data, leading to a failure on the deserializing side.

## Design

We can divide the problem into two parts: parameters and return types.
Parameters are sent from the RPC client to the RPC server while return values go the opposite direction.
Because the problem is always on the *serializing* side, that means on the RPC server side we only need to worry about the declared type of the return value and on the RPC client side we only need to worry about the declared type of the arguments.

### Return types

`JsonRpc` can already discover the declared return types of RPC methods on the server side because `JsonRpc` invoked the server method after all, so it has direct access to `MethodInfo.ReturnType`.
`JsonRpc` needs to pass this declared return type to the formatter and will do this by way of a new property set on `JsonRpcResult`. This property will *not* itself be serialized, and will only be set on the server.

### Parameter types

Parameter handling breaks down into two groups: positional and named.

#### Positional arguments

On the client side where arguments are serialized, `JsonRpc` only has an `IReadOnlyList<object?>` of arguments. So we have runtime types, but no *declared* types, where the declared type for a given argument would be the parameter type on the RPC method on the server.  `JsonRpc.Invoke*` methods will need to take a new `IReadOnlyList<Type>` parameter so the client can list the declared types of each argument as the server expects it.
`JsonRpc` needs to pass this `IReadOnlyList<Type>` to the formatter so it can use it while serializing arguments. It does this via a new property on `JsonRpcRequest`. This property is not serialized, but the formatter will be able to use it on the client side and correlate each declared parameter type with the actual argument value.

Dynamically generated proxies will lazily create a static array for each RPC method with the declared parameter types and pass it to `JsonRpc`.

#### Named arguments

Named arguments are provided by a single object. Typically this object has properties to represent each parameter on the RPC method. In this case each argument is provided in its own property. When reflecting over this type and its properties to get the values, we have the `PropertyInfo` for each and can get the declared type from the `PropertyInfo.PropertyType` property. We therefore don't need the client to provide any additional type information regarding these arguments.
The `MessagePackFormatter` captures these property types just before serializing the single parameter object and uses them as necessary.

In another scenario, the named arguments are passed as a name=value dictionary instead of a specialized type with a property for each named parameter.
In this case the `MessagePackFormatter` has no way to obtain the declared parameter types.
`JsonRpc` needs to collect this data from the caller and pass it along to the formatter.
Unlike positional arguments that will use `IReadOnlyList<Type>` to represent each parameter type, named parameters will require an `IReadOnlyDictionary<string, Type>` so each parameter's type can be looked up by name.
It does this through a new property on `JsonRpcRequest`. This property is not serialized, but the formatter will be able to use it on the client side and correlate each declared parameter type with the actual argument value.

Dynamically generated proxies support passing named arguments, but always with a specially generated parameter type, so they do not need to create a dictionary of property types, as the `MessagePackFormatter` will do it while reflecting over the special parameters type the proxy created.

Closes #460
