### PR TITLE
Fix mis-reported cancellation of message transmission

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -182,7 +182,7 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
     }
 
-    protected override void InitializeFormattersAndHandlers()
+    protected override void InitializeFormattersAndHandlers(bool controlledFlushingClient)
     {
         this.clientMessageFormatter = new JsonMessageFormatter
         {
@@ -208,7 +208,9 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
         };
 
         this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
-        this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+        this.clientMessageHandler = controlledFlushingClient
+            ? new DelayedFlushingHandler(this.clientStream, this.clientMessageFormatter)
+            : new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
     }
 
     [DataContract]
@@ -265,6 +267,25 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
             var stringValue = (string)value;
             var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(stringValue));
             writer.WriteValue(encoded);
+        }
+    }
+
+    private class DelayedFlushingHandler : HeaderDelimitedMessageHandler, IControlledFlushHandler
+    {
+        public DelayedFlushingHandler(Stream stream, IJsonRpcMessageFormatter formatter)
+            : base(stream, formatter)
+        {
+        }
+
+        public AsyncAutoResetEvent FlushEntered { get; } = new AsyncAutoResetEvent();
+
+        public AsyncAutoResetEvent AllowFlushAsyncExit { get; } = new AsyncAutoResetEvent();
+
+        protected override async ValueTask FlushAsync(CancellationToken cancellationToken)
+        {
+            this.FlushEntered.Set();
+            await this.AllowFlushAsyncExit.WaitAsync();
+            await base.FlushAsync(cancellationToken);
         }
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MessagePack;
 using MessagePack.Formatters;
@@ -53,7 +53,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
     }
 
-    protected override void InitializeFormattersAndHandlers()
+    protected override void InitializeFormattersAndHandlers(bool controlledFlushingClient)
     {
         this.serverMessageFormatter = new MessagePackFormatter();
         this.clientMessageFormatter = new MessagePackFormatter();
@@ -66,7 +66,9 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
         ((MessagePackFormatter)this.clientMessageFormatter).SetMessagePackSerializerOptions(options);
 
         this.serverMessageHandler = new LengthHeaderMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
-        this.clientMessageHandler = new LengthHeaderMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+        this.clientMessageHandler = controlledFlushingClient
+            ? new DelayedFlushingHandler(this.clientStream, this.clientMessageFormatter)
+            : new LengthHeaderMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
     }
 
     private class UnserializableTypeFormatter : IMessagePackFormatter<CustomSerializedType>
@@ -92,6 +94,25 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
         public void Serialize(ref MessagePackWriter writer, TypeThrowsWhenDeserialized value, MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(0);
+        }
+    }
+
+    private class DelayedFlushingHandler : LengthHeaderMessageHandler, IControlledFlushHandler
+    {
+        public DelayedFlushingHandler(Stream stream, IJsonRpcMessageFormatter formatter)
+            : base(stream, stream, formatter)
+        {
+        }
+
+        public AsyncAutoResetEvent FlushEntered { get; } = new AsyncAutoResetEvent();
+
+        public AsyncAutoResetEvent AllowFlushAsyncExit { get; } = new AsyncAutoResetEvent();
+
+        protected override async ValueTask FlushAsync(CancellationToken cancellationToken)
+        {
+            this.FlushEntered.Set();
+            await this.AllowFlushAsyncExit.WaitAsync();
+            await base.FlushAsync(cancellationToken);
         }
     }
 }

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -60,6 +60,19 @@ public abstract class JsonRpcTests : TestBase
         this.clientRpc.StartListening();
     }
 
+    protected interface IControlledFlushHandler : IJsonRpcMessageHandler
+    {
+        /// <summary>
+        /// Gets an event that is raised when <see cref="MessageHandlerBase.FlushAsync(CancellationToken)"/> is invoked.
+        /// </summary>
+        AsyncAutoResetEvent FlushEntered { get; }
+
+        /// <summary>
+        /// Gets an event that must be set before <see cref="MessageHandlerBase.FlushAsync(CancellationToken)"/> is allowed to return.
+        /// </summary>
+        AsyncAutoResetEvent AllowFlushAsyncExit { get; }
+    }
+
     private interface IServer
     {
         [JsonRpcMethod("AnotherName")]
@@ -760,6 +773,30 @@ public abstract class JsonRpcTests : TestBase
             this.server.AllowServerMethodToReturn.Set();
             await this.clientRpc.InvokeWithCancellationAsync(nameof(this.server.AsyncMethodWithCancellation), new[] { "a" }, cts.Token);
             cts.Cancel();
+        }
+    }
+
+    [Fact]
+    public async Task InvokeThenCancelToken_BetweenWriteAndFlush()
+    {
+        this.ReinitializeRpcWithoutListening(controlledFlushingClient: true);
+        var clientMessageHandler = (IControlledFlushHandler)this.clientMessageHandler;
+
+        this.clientRpc.StartListening();
+        this.serverRpc.StartListening();
+
+        using (var cts = new CancellationTokenSource())
+        {
+            this.server.AllowServerMethodToReturn.Set();
+            Task<string> invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(this.server.AsyncMethod), new[] { "a" }, cts.Token);
+            await clientMessageHandler.FlushEntered.WaitAsync(this.TimeoutToken);
+            cts.Cancel();
+            clientMessageHandler.AllowFlushAsyncExit.Set();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => invokeTask);
+
+            clientMessageHandler.AllowFlushAsyncExit.Set();
+            string result = await this.clientRpc.InvokeWithCancellationAsync<string>(nameof(this.server.AsyncMethod), new[] { "a" }, this.TimeoutToken);
+            Assert.Equal("a!", result);
         }
     }
 
@@ -1895,7 +1932,7 @@ public abstract class JsonRpcTests : TestBase
         base.Dispose(disposing);
     }
 
-    protected abstract void InitializeFormattersAndHandlers();
+    protected abstract void InitializeFormattersAndHandlers(bool controlledFlushingClient = false);
 
     protected override Task CheckGCPressureAsync(Func<Task> scenario, int maxBytesAllocated = -1, int iterations = 100, int allowedAttempts = 10)
     {
@@ -1926,13 +1963,13 @@ public abstract class JsonRpcTests : TestBase
         }
     }
 
-    private void ReinitializeRpcWithoutListening()
+    private void ReinitializeRpcWithoutListening(bool controlledFlushingClient = false)
     {
         var streams = Nerdbank.FullDuplexStream.CreateStreams();
         this.serverStream = streams.Item1;
         this.clientStream = streams.Item2;
 
-        this.InitializeFormattersAndHandlers();
+        this.InitializeFormattersAndHandlers(controlledFlushingClient);
 
         this.serverRpc = new JsonRpc(this.serverMessageHandler, this.server);
         this.clientRpc = new JsonRpc(this.clientMessageHandler);


### PR DESCRIPTION
When a message is written to the output stream but not flushed, and then cancellation is requested, although the flush was canceled, the message was eventually going to be sent even though the client was no longer tracking it. This led to an unexpected response from the server to eventually be received and in v2.5, `JsonRpc` terminates the connection when the server sends an unexpected response to a request it doesn't remember sending.

The fix is to stop honoring the `CancellationToken` after the message has been written. We still honor the *disposal* token during flush so as to not hold up shutdown, but after a message is written, we always wait for flush to complete if we're still running.

Fixes #489