### PR TITLE
Fixes a few test issues

### DIFF
--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -316,11 +316,11 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         Assert.Equal("Streamed bits!", serverReply);
 
         // Verify server received client response
-        await writeOnlyStream.WriteLineAsync("Returned bits").ConfigureAwait(false);
+        await writeOnlyStream.WriteLineAsync("Returned bytes").ConfigureAwait(false);
+        await writeOnlyStream.FlushAsync().WithCancellation(this.TimeoutToken);
 
         Assumes.NotNull(this.server.ChatLaterTask);
-        this.server.ChatLaterTask.RunSynchronously();
-        await WhenAllSucceedOrAnyFault(this.server.ChatLaterTask!);
+        await this.server.ChatLaterTask.WithCancellation(this.TimeoutToken);
 
         remoteStream.Dispose();
     }
@@ -915,7 +915,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
             await writeOnlyStream.WriteLineAsync("Streamed bits!").ConfigureAwait(false);
             await writeOnlyStream.FlushAsync().ConfigureAwait(false);
 
-            this.ChatLaterTask = new Task(async () =>
+            this.ChatLaterTask = Task.Run(async () =>
             {
                 var reply = await reader.ReadLineAsync();
 

--- a/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -244,9 +244,9 @@ public class JsonRpcClient20InteropTests : InteropTestBase
     }
 
     [Fact]
-    public void NotifyWithParameterPassedAsObjectAsync_ThrowsExceptions()
+    public async Task NotifyWithParameterPassedAsObjectAsync_ThrowsExceptions()
     {
-        Assert.ThrowsAsync<ArgumentException>(() => this.clientRpc.NotifyWithParameterObjectAsync("test", new int[] { 1, 2 }));
+        await Assert.ThrowsAsync<ArgumentException>(() => this.clientRpc.NotifyWithParameterObjectAsync("test", new int[] { 1, 2 }));
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2623,7 +2623,7 @@ public abstract class JsonRpcTests : TestBase
                 {
                     this.runningInContext.Value--;
                 }
-            });
+            }).Forget();
         }
     }
 

--- a/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/src/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.5.31" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/tests.ruleset
+++ b/src/tests.ruleset
@@ -25,5 +25,9 @@
     <Rule Id="VSTHRD200" Action="Hidden" />
     <Rule Id="VSTHRD002" Action="Hidden" />
     <Rule Id="VSTHRD103" Action="Hidden" />
+    <Rule Id="VSTHRD003" Action="None" />
+    <Rule Id="VSTHRD111" Action="None" />
+    <Rule Id="VSTHRD012" Action="None" />
+    <Rule Id="VSTHRD001" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
All of these were found by adding the vs-threading analyzers to the tests.
One of them was causing an unstable test that failed while an unrelated PR was being validated in Azure Pipelines.
We're seeing a lot of mono-mac crashes too, which are almost certainly attributing to the `async void` and associated test defect that this PR fixes.

Fixes #493