### PR TITLE
Prevent JSON deserializer from scrambling dates

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -163,6 +163,7 @@ namespace StreamJsonRpc
             {
                 NullValueHandling = NullValueHandling.Ignore,
                 ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+                DateParseHandling = DateParseHandling.None,
                 Converters =
                 {
                     new JsonProgressServerConverter(this),


### PR DESCRIPTION
Newtonsoft.Json recognizes and reformats strings that look like dates by default. This is absolutely crazy, and has screwed up countless people, including our own users. Turn it off by default, and verify that folks can turn it back on if they really wanted it.

Fixes #487