### PR TITLE
Rename TransmissionCompletedSize event and add received event

### DIFF
--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -186,7 +186,14 @@ namespace StreamJsonRpc
             }
 
             int contentLength = headers.Value.ContentLength.Value;
-            return await this.DeserializeMessageAsync(contentLength, headers.Value.ContentEncoding, DefaultContentEncoding, cancellationToken).ConfigureAwait(false);
+            JsonRpcMessage message = await this.DeserializeMessageAsync(contentLength, headers.Value.ContentEncoding, DefaultContentEncoding, cancellationToken).ConfigureAwait(false);
+
+            if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+            {
+                JsonRpcEventSource.Instance.HandlerReceived(contentLength);
+            }
+
+            return message;
         }
 
         /// <inheritdoc />
@@ -266,7 +273,7 @@ namespace StreamJsonRpc
 
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.TransmissionCompletedSize(contentSequence.Length);
+                    JsonRpcEventSource.Instance.HandlerTransmitted(contentSequence.Length);
                 }
             }
             finally

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -89,9 +89,14 @@ namespace StreamJsonRpc
         private const int TransmissionCompletedEvent = 31;
 
         /// <summary>
-        /// The event ID for the <see cref="TransmissionCompletedSize"/>.
+        /// The event ID for the <see cref="HandlerTransmitted"/>.
         /// </summary>
-        private const int TransmisionCompletedSizeEvent = 32;
+        private const int MessageHandlerTransmittedEvent = 32;
+
+        /// <summary>
+        /// The event ID for the <see cref="HandlerReceived"/>.
+        /// </summary>
+        private const int MessageHandlerReceivedEvent = 33;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonRpcEventSource"/> class.
@@ -240,13 +245,23 @@ namespace StreamJsonRpc
         }
 
         /// <summary>
-        /// Signal that a message has been transmitted with the size.
+        /// Signal that an <see cref="IJsonRpcMessageHandler"/> has transmitted a message.
         /// </summary>
         /// <param name="size">Size of the payload.</param>.
-        [Event(TransmisionCompletedSizeEvent, Task = Tasks.MessageTransmission, Opcode = EventOpcode.Stop, Level = EventLevel.Informational)]
-        public void TransmissionCompletedSize(long size)
+        [Event(MessageHandlerTransmittedEvent, Task = Tasks.MessageHandler, Opcode = EventOpcode.Send, Level = EventLevel.Informational)]
+        public void HandlerTransmitted(long size)
         {
-            this.WriteEvent(TransmisionCompletedSizeEvent, size);
+            this.WriteEvent(MessageHandlerTransmittedEvent, size);
+        }
+
+        /// <summary>
+        /// Signal that an <see cref="IJsonRpcMessageHandler"/> has received a message.
+        /// </summary>
+        /// <param name="size">Size of the payload.</param>.
+        [Event(MessageHandlerReceivedEvent, Task = Tasks.MessageHandler, Opcode = EventOpcode.Receive, Level = EventLevel.Informational)]
+        public void HandlerReceived(long size)
+        {
+            this.WriteEvent(MessageHandlerReceivedEvent, size);
         }
 
         /// <summary>
@@ -299,6 +314,7 @@ namespace StreamJsonRpc
             public const EventTask MessageTransmission = (EventTask)3;
             public const EventTask Cancellation = (EventTask)4;
             public const EventTask Notification = (EventTask)5;
+            public const EventTask MessageHandler = (EventTask)6;
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
+++ b/src/StreamJsonRpc/LengthHeaderMessageHandler.cs
@@ -83,7 +83,14 @@ namespace StreamJsonRpc
             int length = Utilities.ReadInt32BE(lengthBuffer);
             this.Reader.AdvanceTo(lengthBuffer.End);
 
-            return await this.DeserializeMessageAsync(length, cancellationToken).ConfigureAwait(false);
+            JsonRpcMessage message = await this.DeserializeMessageAsync(length, cancellationToken).ConfigureAwait(false);
+
+            if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+            {
+                JsonRpcEventSource.Instance.HandlerReceived(length);
+            }
+
+            return message;
         }
 
         /// <inheritdoc/>
@@ -112,7 +119,7 @@ namespace StreamJsonRpc
 
                 if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
                 {
-                    JsonRpcEventSource.Instance.TransmissionCompletedSize(contentSequence.Length);
+                    JsonRpcEventSource.Instance.HandlerTransmitted(contentSequence.Length);
                 }
             }
             finally


### PR DESCRIPTION
Previously we only reported on the size of messages *transmitted*. Now we report on the size of messages received as well.
I also give the events a different `Task` name to distinguish it from the `MessageTransmission` that is already used by `JsonRpc`.