### PR TITLE
Add support for serializing exceptions

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -386,6 +386,11 @@ namespace StreamJsonRpc
             /// An outgoing RPC message was not sent due to an exception, possibly a serialization failure.
             /// </summary>
             TransmissionFailed,
+
+            /// <summary>
+            /// An incoming <see cref="Exception"/> cannot be deserialized to its original type because the type could not be loaded.
+            /// </summary>
+            ExceptionTypeNotFound,
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -101,7 +101,7 @@ namespace StreamJsonRpc
         /// <summary>
         /// The options to use for serializing user data (e.g. arguments, return values and errors).
         /// </summary>
-        private MessagePackSerializerOptions userDataSerializationOptions = MessagePackSerializerOptions.Standard.WithSecurity(MessagePackSecurity.UntrustedData);
+        private MessagePackSerializerOptions userDataSerializationOptions;
 
         /// <summary>
         /// Backing field for the <see cref="IJsonRpcInstanceContainer.Rpc"/> property.
@@ -124,7 +124,7 @@ namespace StreamJsonRpc
             this.pipeFormatterResolver = new PipeFormatterResolver(this);
 
             // Set up default user data resolver.
-            this.userDataSerializationOptions = this.MassageUserDataOptions(StandardResolverAllowPrivate.Options);
+            this.userDataSerializationOptions = this.MassageUserDataOptions(DefaultUserDataSerializationOptions);
         }
 
         private interface IJsonRpcMessagePackRetention
@@ -137,6 +137,17 @@ namespace StreamJsonRpc
             /// </remarks>
             ReadOnlySequence<byte> OriginalMessagePack { get; }
         }
+
+        /// <summary>
+        /// Gets the default <see cref="MessagePackSerializerOptions"/> used for user data (arguments, return values and errors) in RPC calls
+        /// prior to any call to <see cref="SetMessagePackSerializerOptions(MessagePackSerializerOptions)"/>.
+        /// </summary>
+        /// <value>
+        /// This is <see cref="StandardResolverAllowPrivate.Options"/>
+        /// modified to use the <see cref="MessagePackSecurity.UntrustedData"/> security setting.
+        /// </value>
+        public static MessagePackSerializerOptions DefaultUserDataSerializationOptions { get; } = StandardResolverAllowPrivate.Options
+            .WithSecurity(MessagePackSecurity.UntrustedData);
 
         /// <inheritdoc/>
         JsonRpc IJsonRpcInstanceContainer.Rpc
@@ -218,8 +229,7 @@ namespace StreamJsonRpc
         /// Sets the <see cref="MessagePackSerializerOptions"/> to use for serialization of user data.
         /// </summary>
         /// <param name="options">
-        /// The options to use. Before this call, the options used come from <see cref="MessagePackSerializerOptions.Standard"/>
-        /// modified to use the <see cref="MessagePackSecurity.UntrustedData"/> security setting.
+        /// The options to use. Before this call, the options used come from <see cref="DefaultUserDataSerializationOptions"/>.
         /// </param>
         public void SetMessagePackSerializerOptions(MessagePackSerializerOptions options)
         {

--- a/src/StreamJsonRpc/Reflection/ExceptionSerializationHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/ExceptionSerializationHelpers.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc.Reflection
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+
+    internal static class ExceptionSerializationHelpers
+    {
+        private static readonly Type[] DeserializingConstructorParameterTypes = new Type[] { typeof(SerializationInfo), typeof(StreamingContext) };
+
+        private static StreamingContext Context => new StreamingContext(StreamingContextStates.Remoting);
+
+        internal static T Deserialize<T>(SerializationInfo info, TraceSource? traceSource)
+            where T : Exception
+        {
+            string? runtimeTypeName = info.GetString("ClassName");
+            if (runtimeTypeName is null)
+            {
+                throw new NotSupportedException("ClassName was not found in the serialized data.");
+            }
+
+            Type? runtimeType = Type.GetType(runtimeTypeName);
+            if (runtimeType is null)
+            {
+                if (traceSource?.Switch.ShouldTrace(TraceEventType.Warning) ?? false)
+                {
+                    traceSource.TraceEvent(TraceEventType.Warning, (int)JsonRpc.TraceEvents.ExceptionTypeNotFound, "{0} type could not be loaded. Falling back to System.Exception.", runtimeTypeName);
+                }
+
+                // fallback to deserializing the base Exception type.
+                runtimeType = typeof(Exception);
+            }
+
+            // Sanity/security check: ensure the runtime type derives from the expected type.
+            if (!typeof(T).IsAssignableFrom(runtimeType))
+            {
+                throw new NotSupportedException($"{runtimeTypeName} does not derive from {typeof(T).FullName}.");
+            }
+
+            EnsureSerializableAttribute(runtimeType);
+
+            ConstructorInfo? ctor = FindDeserializingConstructor(runtimeType);
+            if (ctor is null)
+            {
+                throw new NotSupportedException($"{runtimeType.FullName} does not declare a deserializing constructor with signature ({string.Join(", ", DeserializingConstructorParameterTypes.Select(t => t.FullName))}).");
+            }
+
+            return (T)ctor.Invoke(new object?[] { info, Context });
+        }
+
+        internal static void Serialize(Exception exception, SerializationInfo info)
+        {
+            Type exceptionType = exception.GetType();
+            EnsureSerializableAttribute(exceptionType);
+            exception.GetObjectData(info, Context);
+        }
+
+        internal static object Convert(IFormatterConverter formatterConverter, object value, TypeCode typeCode)
+        {
+            return typeCode switch
+            {
+                TypeCode.Boolean => formatterConverter.ToBoolean(value),
+                TypeCode.Byte => formatterConverter.ToBoolean(value),
+                TypeCode.Char => formatterConverter.ToChar(value),
+                TypeCode.DateTime => formatterConverter.ToDateTime(value),
+                TypeCode.Decimal => formatterConverter.ToDecimal(value),
+                TypeCode.Double => formatterConverter.ToDouble(value),
+                TypeCode.Int16 => formatterConverter.ToInt16(value),
+                TypeCode.Int32 => formatterConverter.ToInt32(value),
+                TypeCode.Int64 => formatterConverter.ToInt64(value),
+                TypeCode.SByte => formatterConverter.ToSByte(value),
+                TypeCode.Single => formatterConverter.ToSingle(value),
+                TypeCode.String => formatterConverter.ToString(value),
+                TypeCode.UInt16 => formatterConverter.ToUInt16(value),
+                TypeCode.UInt32 => formatterConverter.ToUInt32(value),
+                TypeCode.UInt64 => formatterConverter.ToUInt64(value),
+                _ => throw new NotSupportedException("Unsupported type code: " + typeCode),
+            };
+        }
+
+        private static void EnsureSerializableAttribute(Type runtimeType)
+        {
+            if (runtimeType.GetCustomAttribute<SerializableAttribute>() is null)
+            {
+                throw new NotSupportedException($"{runtimeType.FullName} is not marked with the {typeof(SerializableAttribute).FullName}.");
+            }
+        }
+
+        private static ConstructorInfo? FindDeserializingConstructor(Type runtimeType) => runtimeType.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, DeserializingConstructorParameterTypes, null);
+    }
+}

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -14,4 +14,5 @@ StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
 StreamJsonRpc.RequestId.IsNull.get -> bool
+static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.Di
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -14,4 +14,5 @@ StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
 StreamJsonRpc.RequestId.IsNull.get -> bool
+static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.DisconnectedReason.RemoteProtocolViolation = 6 -> StreamJsonRpc.Di
 StreamJsonRpc.JsonRpc.DispatchCompletion.get -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.TransmissionFailed = 18 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.get -> int
 StreamJsonRpc.JsonRpcEnumerableSettings.Prefetch.set -> void


### PR DESCRIPTION
This adds support in both MessagePack and JSON formatters to serialize/deserialize `Exception`-derived types.

When a particular Exception type cannot be deserialized because it can't be loaded, we create an ordinary `System.Exception`.