### PR TITLE
Fixed proxy generation for methods with many parameters

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -51,6 +51,8 @@ public class JsonRpcProxyGenerationTests : TestBase
 
         Task IncrementAsync();
 
+        ValueTask<bool> ManyParameters(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10, CancellationToken cancellationToken);
+
         Task Dispose();
     }
 
@@ -717,6 +719,11 @@ public class JsonRpcProxyGenerationTests : TestBase
         public ValueTask DoSomethingValueAsync() => default;
 
         public ValueTask<int> AddValueAsync(int a, int b) => new ValueTask<int>(a + b);
+
+        public ValueTask<bool> ManyParameters(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
 
         internal void OnItHappened(EventArgs args) => this.ItHappened?.Invoke(this, args);
 

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -264,7 +264,7 @@ namespace StreamJsonRpc
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, optionsField);
                     il.EmitCall(OpCodes.Callvirt, ServerRequiresNamedArgumentsPropertyGetter, null);
-                    il.Emit(OpCodes.Brfalse_S, positionalArgsLabel);
+                    il.Emit(OpCodes.Brfalse, positionalArgsLabel);
 
                     // The second argument is a single parameter object.
                     {
@@ -392,7 +392,7 @@ namespace StreamJsonRpc
             // Load the Type[] field, and skip initializing it if it's non-null.
             il.Emit(OpCodes.Ldsfld, field);
             il.Emit(OpCodes.Dup); // keep a copy on the stack after the test in case it's non-null.
-            il.Emit(OpCodes.Brtrue_S, skipInitLabel);
+            il.Emit(OpCodes.Brtrue, skipInitLabel);
 
             // Initialize the field.
             il.Emit(OpCodes.Pop); // pop off the extra null.


### PR DESCRIPTION
We should not use the short form jump instruction when the instructions between the jump source and target may exceed 127... (IL instructions? bytes?). Anyway, as a rule then, I've switched to long form whenever the jump crosses an IL generating loop, such that we can't be confident that the number of instructions will be small.

This regressed in 9cf9f7e86b089a19c6711eaba09e37e69e976669