### PR TITLE
Expose CreateExceptionFromRpcError as a `protected virtual` method

### DIFF
--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
 StreamJsonRpc.RequestId.IsNull.get -> bool
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId
+virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -17,3 +17,4 @@ StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
 StreamJsonRpc.RequestId.IsNull.get -> bool
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 static StreamJsonRpc.RequestId.Null.get -> StreamJsonRpc.RequestId
+virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!


### PR DESCRIPTION
This provides the counterpart to the pre-existing virtual method `CreateErrorDetails`.

Closes #502