### PR TITLE
Only raise events from RPC targets once

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -753,6 +753,7 @@ namespace StreamJsonRpc
 
                 if (options.NotifyClientOfEvents)
                 {
+                    HashSet<string>? eventsDiscovered = null;
                     for (TypeInfo? t = exposingMembersOn.GetTypeInfo(); t != null && t != typeof(object).GetTypeInfo(); t = t.BaseType?.GetTypeInfo())
                     {
                         foreach (EventInfo evt in t.DeclaredEvents)
@@ -762,6 +763,17 @@ namespace StreamJsonRpc
                                 if (this.eventReceivers == null)
                                 {
                                     this.eventReceivers = new List<EventReceiver>();
+                                }
+
+                                if (eventsDiscovered is null)
+                                {
+                                    eventsDiscovered = new HashSet<string>(StringComparer.Ordinal);
+                                }
+
+                                if (!eventsDiscovered.Add(evt.Name))
+                                {
+                                    // Do not add the same event again. It can appear multiple times in a type hierarchy.
+                                    continue;
                                 }
 
                                 if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Information))


### PR DESCRIPTION
Before this fix, when events were declared (as abstract or virtual) on a base class and overridden in the target object, we attached a handler to the event once for each time it was declared in the hierarchy, leading to multiple invocations on the client.

Fixes #481