### PR TITLE
Tighten up exceptions thrown by formatters

### DIFF
--- a/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/src/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -443,8 +443,8 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
         // But for a notification there's no guarantee the server handles the message and no way to get an error back,
         // so it simply should not be allowed since the risk of memory leak is too high.
         var numbers = new int[] { 1, 2, 3 }.AsAsyncEnumerable();
-        await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.NotifyAsync(nameof(Server.PassInNumbersAsync), new object?[] { numbers }));
-        await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.NotifyAsync(nameof(Server.PassInNumbersAsync), new object?[] { new { e = numbers } }));
+        await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.NotifyAsync(nameof(Server.PassInNumbersAsync), new object?[] { numbers }));
+        await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.NotifyAsync(nameof(Server.PassInNumbersAsync), new object?[] { new { e = numbers } }));
     }
 
     [SkippableFact]
@@ -563,7 +563,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
     private async Task<WeakReference> ArgumentEnumerable_ReleasedOnErrorInSubsequentArgumentSerialization_Helper()
     {
         IAsyncEnumerable<int>? numbers = new int[] { 1, 2, 3 }.AsAsyncEnumerable();
-        await Assert.ThrowsAsync<Exception>(() => this.clientRpc.InvokeWithCancellationAsync("ThisMethodDoesNotExist", new object?[] { numbers, new UnserializableType() }, this.TimeoutToken));
+        await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.InvokeWithCancellationAsync("ThisMethodDoesNotExist", new object?[] { numbers, new UnserializableType() }, this.TimeoutToken));
         WeakReference result = new WeakReference(numbers);
         numbers = null;
         return result;

--- a/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/src/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -105,7 +105,8 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         var clientRpc = JsonRpc.Attach(streamPair.Item1);
 
         (IDuplexPipe, IDuplexPipe) somePipe = FullDuplexStream.CreatePipePair();
-        await Assert.ThrowsAsync<NotSupportedException>(() => clientRpc.InvokeWithCancellationAsync(nameof(Server.TwoWayPipeAsArg), new[] { somePipe.Item2 }, this.TimeoutToken));
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => clientRpc.InvokeWithCancellationAsync(nameof(Server.TwoWayPipeAsArg), new[] { somePipe.Item2 }, this.TimeoutToken));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 
     [Theory]
@@ -551,7 +552,8 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     public async Task NotifyWithPipe_IsRejectedAtClient()
     {
         (IDuplexPipe, IDuplexPipe) duplexPipes = FullDuplexStream.CreatePipePair();
-        await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.NotifyAsync(nameof(Server.AcceptReadableStream), "fileName", duplexPipes.Item2));
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.NotifyAsync(nameof(Server.AcceptReadableStream), "fileName", duplexPipes.Item2));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 
     /// <summary>

--- a/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
+++ b/src/StreamJsonRpc.Tests/HeaderDelimitedMessageHandlerTests.cs
@@ -122,43 +122,6 @@ CRLF +
         Assert.Throws<ArgumentException>(() => this.handler.SubType = new string('a', 980));
     }
 
-    private class SlowWriteStream : Stream
-    {
-        private readonly AsyncSemaphore semaphore = new AsyncSemaphore(1);
-        private readonly MemoryStream inner = new MemoryStream();
-
-        public override bool CanRead => true;
-
-        public override bool CanSeek => true;
-
-        public override bool CanWrite => true;
-
-        public override long Length => this.inner.Length;
-
-        public override long Position { get => this.inner.Position; set => this.inner.Position = value; }
-
-        public override void Flush() => this.inner.Flush();
-
-        public override int Read(byte[] buffer, int offset, int count) => this.inner.Read(buffer, offset, count);
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => this.inner.ReadAsync(buffer, offset, count, cancellationToken);
-
-        public override long Seek(long offset, SeekOrigin origin) => this.inner.Seek(offset, origin);
-
-        public override void SetLength(long value) => this.inner.SetLength(value);
-
-        public override void Write(byte[] buffer, int offset, int count) => this.inner.Write(buffer, offset, count);
-
-        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            using (await this.semaphore.EnterAsync(cancellationToken))
-            {
-                await Task.Delay(10);
-                await this.inner.WriteAsync(buffer, offset, count, cancellationToken);
-            }
-        }
-    }
-
     private class MockFormatter : IJsonRpcMessageFormatter
     {
         public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer)

--- a/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 using Xunit;
@@ -71,9 +72,11 @@ public class JsonRpcClient10InteropTests : InteropTestBase
     [Fact]
     public async Task ClientThrowsOnAttemptToSendParamsObject()
     {
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 }, this.TimeoutToken)).WithCancellation(this.TimeoutToken);
+        var ex = await Assert.ThrowsAsync<JsonSerializationException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 }, this.TimeoutToken)).WithCancellation(this.TimeoutToken);
+        Assert.IsType<NotSupportedException>(ex.InnerException);
         this.Logger.WriteLine(ex.ToString());
-        await Assert.ThrowsAsync<NotSupportedException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 })).WithCancellation(this.TimeoutToken);
+        ex = await Assert.ThrowsAsync<JsonSerializationException>(() => this.clientRpc.InvokeWithParameterObjectAsync("test", new { something = 3 })).WithCancellation(this.TimeoutToken);
+        Assert.IsType<NotSupportedException>(ex.InnerException);
 
         Assert.Equal(0, this.messageHandler.WrittenMessages.Count);
     }

--- a/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -246,7 +246,8 @@ public class JsonRpcClient20InteropTests : InteropTestBase
     [Fact]
     public async Task NotifyWithParameterPassedAsObjectAsync_ThrowsExceptions()
     {
-        await Assert.ThrowsAsync<ArgumentException>(() => this.clientRpc.NotifyWithParameterObjectAsync("test", new int[] { 1, 2 }));
+        var ex = await Assert.ThrowsAsync<JsonSerializationException>(() => this.clientRpc.NotifyWithParameterObjectAsync("test", new int[] { 1, 2 }));
+        Assert.IsType<ArgumentException>(ex.InnerException);
     }
 
     [Fact]

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -457,6 +457,27 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task DisposeInDisconnectedHandler()
+    {
+        var eventHandlerResultSource = new TaskCompletionSource<object?>();
+        this.serverRpc.Disconnected += (s, e) =>
+        {
+            try
+            {
+                this.serverRpc.Dispose();
+                eventHandlerResultSource.SetResult(null);
+            }
+            catch (Exception ex)
+            {
+                eventHandlerResultSource.SetException(ex);
+            }
+        };
+
+        this.clientRpc.Dispose();
+        await eventHandlerResultSource.Task.WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
     public async Task CanCallMethodOnBaseClass()
     {
         string result = await this.clientRpc.InvokeAsync<string>(nameof(Server.BaseMethod));

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -856,68 +856,32 @@ namespace StreamJsonRpc
             }
         }
 
-        /// <summary>
-        /// Invoke a method on the server.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
-        /// <returns>A task that completes when the server method executes.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the server indicates completion of the method.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument"><inheritdoc cref="InvokeAsync{TResult}(string, object?)" path="/param[@name='argument']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task InvokeAsync(string targetName, object? argument)
         {
             return this.InvokeAsync<object>(targetName, argument);
         }
 
-        /// <summary>
-        /// Invoke a method on the server.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
-        /// <returns>A task that completes when the server method executes.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the server indicates completion of the method.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task InvokeAsync(string targetName, params object?[]? arguments)
         {
             return this.InvokeAsync<object>(targetName, arguments);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument">A single method argument, must be serializable using the selected <see cref="IJsonRpcMessageFormatter"/>.</param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task<TResult> InvokeAsync<TResult>(string targetName, object? argument)
         {
             var arguments = new object?[] { argument };
@@ -925,24 +889,12 @@ namespace StreamJsonRpc
             return this.InvokeWithCancellationAsync<TResult>(targetName, arguments, CancellationToken.None);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task<TResult> InvokeAsync<TResult>(string targetName, params object?[]? arguments)
         {
             // If somebody calls InvokeInternal<T>(id, "method", null), the null is not passed as an item in the array.
@@ -953,24 +905,12 @@ namespace StreamJsonRpc
             return this.InvokeWithCancellationAsync<TResult>(targetName, arguments, CancellationToken.None);
         }
 
-        /// <summary>
-        /// Invoke a method on the server.  The parameter is passed as an object.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argument']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task InvokeWithParameterObjectAsync(string targetName, object? argument = null, CancellationToken cancellationToken = default(CancellationToken))
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -978,49 +918,25 @@ namespace StreamJsonRpc
             return this.InvokeWithParameterObjectAsync<object>(targetName, argument, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server.  The parameter is passed as an object.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argument']"/></param>
         /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argumentDeclaredTypes']"/></param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task InvokeWithParameterObjectAsync(string targetName, object? argument, IReadOnlyDictionary<string, Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
         {
             return this.InvokeWithParameterObjectAsync<object>(targetName, argument, argumentDeclaredTypes, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.  The parameter is passed as an object.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argument']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object? argument = null, CancellationToken cancellationToken = default(CancellationToken))
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -1028,29 +944,17 @@ namespace StreamJsonRpc
             return this.InvokeWithParameterObjectAsync<TResult>(targetName, argument, null, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.  The parameter is passed as an object.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument">An object whose properties match the names of parameters on the target method. Must be serializable using the selected <see cref="IJsonRpcMessageFormatter"/>.</param>
         /// <param name="argumentDeclaredTypes">
         /// A dictionary of <see cref="Type"/> objects that describe how each entry in the <see cref="IReadOnlyDictionary{TKey, TValue}"/> provided in <paramref name="argument"/> is expected by the server to be typed.
         /// If specified, this must have exactly the same set of keys as <paramref name="argument"/> and contain no <c>null</c> values.
         /// </param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task<TResult> InvokeWithParameterObjectAsync<TResult>(string targetName, object? argument, IReadOnlyDictionary<string, Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
         {
             // If argument is null, this indicates that the method does not take any parameters.
@@ -1058,26 +962,12 @@ namespace StreamJsonRpc
             return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, argumentToPass, positionalArgumentDeclaredTypes: null, argumentDeclaredTypes, cancellationToken, isParameterObject: true);
         }
 
-        /// <summary>
-        /// Invoke a method on the server.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
-        /// or in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception,
-        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task InvokeWithCancellationAsync(string targetName, IReadOnlyList<object?>? arguments = null, CancellationToken cancellationToken = default(CancellationToken))
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -1085,27 +975,13 @@ namespace StreamJsonRpc
             return this.InvokeWithCancellationAsync<object>(targetName, arguments, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server.
-        /// </summary>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
         /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeWithCancellationAsync{TResult}(string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, CancellationToken)" path="/param[@name='argumentDeclaredTypes']"/></param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task that completes when the server method executes.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
-        /// or in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception,
-        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task InvokeWithCancellationAsync(string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type> argumentDeclaredTypes, CancellationToken cancellationToken)
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -1113,27 +989,13 @@ namespace StreamJsonRpc
             return this.InvokeWithCancellationAsync<object>(targetName, arguments, argumentDeclaredTypes, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
-        /// or in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception,
-        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
 #pragma warning disable RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
         public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object?>? arguments = null, CancellationToken cancellationToken = default(CancellationToken))
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
@@ -1141,47 +1003,32 @@ namespace StreamJsonRpc
             return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, cancellationToken);
         }
 
-        /// <summary>
-        /// Invoke a method on the server and get back the result.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">Type of the method result.</typeparam>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
-        /// <param name="argumentDeclaredTypes">
-        /// A list of <see cref="Type"/> objects that describe how each element in <paramref name="arguments"/> is expected by the server to be typed.
-        /// If specified, this must have exactly the same length as <paramref name="arguments"/> and contain no <c>null</c> elements.
-        /// </param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='positionalArgumentDeclaredTypes']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
         /// <returns>A task that completes when the server method executes and returns the result.</returns>
-        /// <exception cref="OperationCanceledException">
-        /// Result task fails with this exception if the communication channel ends before the result gets back from the server
-        /// or in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteInvocationException">
-        /// Result task fails with this exception if the server method throws an exception,
-        /// which may occur in response to the <paramref name="cancellationToken"/> being canceled.
-        /// </exception>
-        /// <exception cref="RemoteMethodNotFoundException">
-        /// Result task fails with this exception if the <paramref name="targetName"/> method has not been registered on the server.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/exception"/>
         public Task<TResult> InvokeWithCancellationAsync<TResult>(string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? argumentDeclaredTypes, CancellationToken cancellationToken)
         {
             return this.InvokeCoreAsync<TResult>(this.CreateNewRequestId(), targetName, arguments, argumentDeclaredTypes, namedArgumentDeclaredTypes: null, cancellationToken, isParameterObject: false);
         }
 
         /// <summary>
-        /// Invoke a method on the server and don't wait for its completion, fire-and-forget style.
+        /// Invokes a given method on a JSON-RPC server without waiting for its response.
         /// </summary>
         /// <remarks>
         /// Any error that happens on the server side is ignored.
         /// </remarks>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument">Method argument, must be serializable using the selected <see cref="IJsonRpcMessageFormatter"/>.</param>
         /// <returns>A task that completes when the notify request is sent to the channel to the server.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="targetName" /> is empty.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has already been disposed prior to this call.</exception>
+        /// <exception cref="ConnectionLostException">Thrown when the connection is terminated (by either side) while the request is being transmitted.</exception>
         public Task NotifyAsync(string targetName, object? argument)
         {
             var arguments = new object?[] { argument };
@@ -1192,18 +1039,15 @@ namespace StreamJsonRpc
         /// <inheritdoc cref="NotifyAsync(string, object?[], IReadOnlyList{Type}?)"/>
         public Task NotifyAsync(string targetName, params object?[]? arguments) => this.NotifyAsync(targetName, arguments, null);
 
-        /// <summary>
-        /// Invoke a method on the server and don't wait for its completion, fire-and-forget style.
-        /// </summary>
+        /// <summary><inheritdoc cref="NotifyAsync(string, object?)" path="/summary"/></summary>
         /// <remarks>
         /// Any error that happens on the server side is ignored.
         /// </remarks>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="arguments">Method arguments, must be serializable to JSON.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
         /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeWithCancellationAsync{TResult}(string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, CancellationToken)" path="/param[@name='argumentDeclaredTypes']"/></param>
         /// <returns>A task that completes when the notify request is sent to the channel to the server.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <inheritdoc cref="NotifyAsync(string, object?)" path="/exception"/>
         public Task NotifyAsync(string targetName, object?[]? arguments, IReadOnlyList<Type>? argumentDeclaredTypes)
         {
             return this.InvokeCoreAsync<object>(RequestId.NotSpecified, targetName, arguments, argumentDeclaredTypes, null, CancellationToken.None, isParameterObject: false);
@@ -1214,18 +1058,15 @@ namespace StreamJsonRpc
         public Task NotifyWithParameterObjectAsync(string targetName, object? argument = null) => this.NotifyWithParameterObjectAsync(targetName, argument, null);
 #pragma warning restore RS0027 // Public API with optional parameter(s) should have the most parameters amongst its public overloads.
 
-        /// <summary>
-        /// Invoke a method on the server and don't wait for its completion, fire-and-forget style.  The parameter is passed as an object.
-        /// </summary>
+        /// <summary><inheritdoc cref="NotifyAsync(string, object?)" path="/summary"/></summary>
         /// <remarks>
         /// Any error that happens on the server side is ignored.
         /// </remarks>
-        /// <param name="targetName">The name of the method to invoke on the server. Must not be null or empty string.</param>
-        /// <param name="argument">Method argument, must be serializable to JSON.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="argument"><inheritdoc cref="InvokeWithParameterObjectAsync{TResult}(string, object?, IReadOnlyDictionary{string, Type}?, CancellationToken)" path="/param[@name='argument']"/></param>
         /// <param name="argumentDeclaredTypes"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='namedArgumentDeclaredTypes']"/></param>
-        /// <returns>A task that completes when the notify request is sent to the channel to the server.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
-        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has been disposed.</exception>
+        /// <returns>A task that completes when the notification has been transmitted.</returns>
+        /// <inheritdoc cref="NotifyAsync(string, object?)" path="/exception"/>
         public Task NotifyWithParameterObjectAsync(string targetName, object? argument, IReadOnlyDictionary<string, Type>? argumentDeclaredTypes)
         {
             // If argument is null, this indicates that the method does not take any parameters.
@@ -1511,10 +1352,10 @@ namespace StreamJsonRpc
         /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
-        /// <param name="targetName">Name of the method to invoke.</param>
-        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
         [Obsolete("Use the InvokeCoreAsync(RequestId, ...) overload instead.")]
         protected Task<TResult> InvokeCoreAsync<TResult>(long? id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken)
         {
@@ -1527,25 +1368,23 @@ namespace StreamJsonRpc
         /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
         /// If it is not included it is assumed to be a notification.</param>
-        /// <param name="targetName">Name of the method to invoke.</param>
-        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
-        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
         protected Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken)
         {
             return this.InvokeCoreAsync<TResult>(id, targetName, arguments, cancellationToken, isParameterObject: false);
         }
 
-        /// <summary>
-        /// Invokes the specified RPC method.
-        /// </summary>
+        /// <summary><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/summary"/></summary>
         /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
-        /// <param name="targetName">Name of the method to invoke.</param>
-        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
-        /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
+        /// <param name="targetName"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='targetName']"/></param>
+        /// <param name="arguments"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='arguments']"/></param>
+        /// <param name="cancellationToken"><inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/param[@name='cancellationToken']"/></param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
-        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        /// <inheritdoc cref="InvokeCoreAsync{TResult}(RequestId, string, IReadOnlyList{object?}?, IReadOnlyList{Type}?, IReadOnlyDictionary{string, Type}?, CancellationToken, bool)" path="/returns"/>
         [Obsolete("Use the InvokeCoreAsync(RequestId, ...) overload instead.")]
         protected Task<TResult> InvokeCoreAsync<TResult>(long? id, string targetName, IReadOnlyList<object?>? arguments, CancellationToken cancellationToken, bool isParameterObject)
         {
@@ -1559,12 +1398,12 @@ namespace StreamJsonRpc
         }
 
         /// <summary>
-        /// Invokes the specified RPC method.
+        /// Invokes a given method on a JSON-RPC server.
         /// </summary>
         /// <typeparam name="TResult">RPC method return type.</typeparam>
         /// <param name="id">An identifier established by the Client. If the default value is given, it is assumed to be a notification.</param>
-        /// <param name="targetName">Name of the method to invoke.</param>
-        /// <param name="arguments">Arguments to pass to the invoked method. If null, no arguments are passed.</param>
+        /// <param name="targetName">Name of the method to invoke. Must not be null or empty.</param>
+        /// <param name="arguments">Arguments to pass to the invoked method. They must be serializable using the selected <see cref="IJsonRpcMessageFormatter"/>. If <c>null</c>, no arguments are passed.</param>
         /// <param name="positionalArgumentDeclaredTypes">
         /// A list of <see cref="Type"/> objects that describe how each element in <paramref name="arguments"/> is expected by the server to be typed.
         /// If specified, this must have exactly the same length as <paramref name="arguments"/> and contain no <c>null</c> elements.
@@ -1576,7 +1415,29 @@ namespace StreamJsonRpc
         /// </param>
         /// <param name="cancellationToken">The token whose cancellation should signal the server to stop processing this request.</param>
         /// <param name="isParameterObject">Value which indicates if parameter should be passed as an object.</param>
-        /// <returns>A task whose result is the deserialized response from the JSON-RPC server.</returns>
+        /// <returns>A task that completes with the response from the JSON-RPC server.</returns>
+        /// <exception cref="OperationCanceledException">
+        /// Thrown after <paramref name="cancellationToken"/> is canceled.
+        /// If the request has already been transmitted, the exception is only thrown after the server has received the cancellation notification and responded to it.
+        /// If the server completes the request instead of cancelling, this exception will not be thrown.
+        /// When the connection drops before receiving a response, this exception is thrown if <paramref name="cancellationToken"/> has been canceled.
+        /// </exception>
+        /// <exception cref="RemoteRpcException">
+        /// A common base class for a variety of RPC exceptions that may be thrown. Some common derived types are listed individually.
+        /// </exception>
+        /// <exception cref="RemoteInvocationException">
+        /// Thrown when an error is returned from the server in consequence of executing the requested method.
+        /// </exception>
+        /// <exception cref="RemoteMethodNotFoundException">
+        /// Thrown when the server reports that no matching method was found to invoke.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetName"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="targetName" /> is empty.</exception>
+        /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has already been disposed prior to this call.</exception>
+        /// <exception cref="ConnectionLostException">
+        /// Thrown when the connection is terminated (by either side) while the request is in progress,
+        /// unless <paramref name="cancellationToken"/> is already signaled.
+        /// </exception>
         protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? positionalArgumentDeclaredTypes, IReadOnlyDictionary<string, Type>? namedArgumentDeclaredTypes, CancellationToken cancellationToken, bool isParameterObject)
         {
             Requires.NotNullOrEmpty(targetName, nameof(targetName));

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1029,6 +1029,11 @@ namespace StreamJsonRpc
         /// <exception cref="ArgumentException">Thrown when <paramref name="targetName" /> is empty.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has already been disposed prior to this call.</exception>
         /// <exception cref="ConnectionLostException">Thrown when the connection is terminated (by either side) while the request is being transmitted.</exception>
+        /// <exception cref="Exception">
+        /// Any exception thrown by the <see cref="IJsonRpcMessageFormatter"/> (typically due to serialization failures).
+        /// When using <see cref="JsonMessageFormatter"/> this should be <see cref="JsonSerializationException"/>.
+        /// When using <see cref="MessagePackFormatter"/> this should be <see cref="T:MessagePack.MessagePackSerializationException"/>.
+        /// </exception>
         public Task NotifyAsync(string targetName, object? argument)
         {
             var arguments = new object?[] { argument };
@@ -1437,6 +1442,11 @@ namespace StreamJsonRpc
         /// <exception cref="ConnectionLostException">
         /// Thrown when the connection is terminated (by either side) while the request is in progress,
         /// unless <paramref name="cancellationToken"/> is already signaled.
+        /// </exception>
+        /// <exception cref="Exception">
+        /// Any exception thrown by the <see cref="IJsonRpcMessageFormatter"/> (typically due to serialization failures).
+        /// When using <see cref="JsonMessageFormatter"/> this should be <see cref="JsonSerializationException"/>.
+        /// When using <see cref="MessagePackFormatter"/> this should be <see cref="T:MessagePack.MessagePackSerializationException"/>.
         /// </exception>
         protected async Task<TResult> InvokeCoreAsync<TResult>(RequestId id, string targetName, IReadOnlyList<object?>? arguments, IReadOnlyList<Type>? positionalArgumentDeclaredTypes, IReadOnlyDictionary<string, Type>? namedArgumentDeclaredTypes, CancellationToken cancellationToken, bool isParameterObject)
         {

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -283,8 +283,15 @@ namespace StreamJsonRpc
             }
 
             var writer = new MessagePackWriter(contentBuffer);
-            this.messageSerializationOptions.Resolver.GetFormatterWithVerify<JsonRpcMessage>().Serialize(ref writer, message, this.messageSerializationOptions);
-            writer.Flush();
+            try
+            {
+                this.messageSerializationOptions.Resolver.GetFormatterWithVerify<JsonRpcMessage>().Serialize(ref writer, message, this.messageSerializationOptions);
+                writer.Flush();
+            }
+            catch (Exception ex)
+            {
+                throw new MessagePackSerializationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.ErrorWritingJsonRpcMessage, ex.GetType().Name, ex.Message), ex);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -196,6 +196,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deserializing JSON-RPC result to type {0} failed with {1}: {2}.
+        /// </summary>
+        internal static string FailureDeserializingRpcResult {
+            get {
+                return ResourceManager.GetString("FailureDeserializingRpcResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A fatal exception was thrown from the server method {0}: {1}.
         /// </summary>
         internal static string FatalExceptionWasThrown {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -169,6 +169,10 @@
     <value>Deserializing JSON-RPC argument with name "{0}" and position {1} to type "{2}" failed: {3}</value>
     <comment>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</comment>
   </data>
+  <data name="FailureDeserializingRpcResult" xml:space="preserve">
+    <value>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</value>
+    <comment>{0} is the result type, {1} is the exception type, {2} is the exception message.</comment>
+  </data>
   <data name="FatalExceptionWasThrown" xml:space="preserve">
     <value>A fatal exception was thrown from the server method {0}: {1}</value>
     <comment>{0} is the exception type, {1} is the exception message</comment>

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Nepovedlo se deserializovat argument JSON-RPC s názvem {0} a pozicí {1} na typ {2}: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Daný typ nejde přetypovat na IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Fehler beim Deserialisieren des JSON-RPC-Arguments mit dem Namen "{0}" und der Position {1} in den Typ "{2}": {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Der angegebene Typ kann nicht in IProgress&lt;T&gt; umgewandelt werden.</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Error al deserializar el argumento JSON-RPC con el nombre "{0}" y la posición {1} en el tipo "{2}": {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">No se puede convertir el tipo dado en IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">La désérialisation de l'argument JSON-RPC avec le nom "{0}" et la position {1} en type "{2}" a échoué : {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Impossible de caster le type donné en IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">La deserializzazione dell'argomento di JSON-RPC con nome "{0}" e posizione {1} nel tipo "{2}" non è riuscita: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Non è possibile eseguire il cast del tipo specificato in IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">名前が "{0}"、位置が {1} の JSON-RPC 引数を型 "{2}" に逆シリアル化できませんでした: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">指定された型は IProgress&lt;T&gt; にキャストできません</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">이름이 "{0}"(이)고 위치가 {1}인 JSON-RPC 인수를 "{2}" 형식에 역직렬화하지 못했습니다. {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">지정된 형식을 IProgress로 캐스팅할 수 없음&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Deserializowanie argumentu JSON-RPC o nazwie „{0}” i pozycji {1} do typu „{2}” nie powiodło się: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Nie można rzutować danego typu na typ IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Falha na desserialização do argumento JSON-RPC com o nome "{0}" e a posição {1} para o tipo "{2}": {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Não é possível converter o Tipo fornecido em IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Не удалось десериализировать аргумент JSON-RPC с именем "{0}" и позицией {1} в тип "{2}": {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Не удалось привести указанный тип к IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">{1} konumundaki "{0}" adlı JSON-RPC bağımsız değişkeni "{2}" türüne seri durumdan çıkarılamadı: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">Verilen Tür IProgress&lt;T&gt; olarak atanamıyor</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">未能将名称为“{0}”且位置为 {1} 的 JSON-RPC 参数反序列化为类型“{2}”: {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">无法将给定类型强制转换为 IProgress&lt;T&gt;</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">無法將名稱為 "{0}" 且位於 {1} 的 JSON-RPC 引數還原序列化為類型 "{2}": {3}</target>
         <note>{0} is a parameter name, {1} is an integer, {2} is a CLR type name and {3} is an exception object.</note>
       </trans-unit>
+      <trans-unit id="FailureDeserializingRpcResult">
+        <source>Deserializing JSON-RPC result to type {0} failed with {1}: {2}</source>
+        <target state="new">Deserializing JSON-RPC result to type {0} failed with {1}: {2}</target>
+        <note>{0} is the result type, {1} is the exception type, {2} is the exception message.</note>
+      </trans-unit>
       <trans-unit id="FindIProgressOfTError">
         <source>Unable to cast given Type to IProgress&lt;T&gt;</source>
         <target state="translated">無法將指定的類型轉換為 IProgress&lt;T&gt;</target>


### PR DESCRIPTION
Wrap any/all exceptions thrown by formatters in the exception type native to their serializer.

This PR builds on #538, so until that completes, the diff on this PR will look larger than [its one unique commit](https://github.com/microsoft/vs-streamjsonrpc/pull/539/commits/de5cc5edd6b52a4faaf98b7cd15f46ab9bee06c6).