### PR TITLE
Add ICancellationStrategy extensibility point

### DIFF
--- a/src/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/src/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class CustomCancellationStrategyTests : TestBase
+{
+    private readonly JsonRpc clientRpc;
+    private readonly Server server;
+    private readonly JsonRpc serverRpc;
+    private readonly MockCancellationStrategy mockStrategy;
+
+    public CustomCancellationStrategyTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.mockStrategy = new MockCancellationStrategy(logger);
+
+        var streams = FullDuplexStream.CreatePair();
+        this.clientRpc = new JsonRpc(streams.Item1)
+        {
+            CancellationStrategy = this.mockStrategy,
+            TraceSource = new TraceSource("Client", SourceLevels.Verbose)
+            {
+                Listeners = { new XunitTraceListener(logger) },
+            },
+        };
+        this.clientRpc.StartListening();
+
+        this.server = new Server();
+        this.serverRpc = new JsonRpc(streams.Item2)
+        {
+            CancellationStrategy = this.mockStrategy,
+            TraceSource = new TraceSource("Server", SourceLevels.Verbose)
+            {
+                Listeners = { new XunitTraceListener(logger) },
+            },
+        };
+        this.serverRpc.AddLocalRpcTarget(this.server);
+        this.serverRpc.StartListening();
+    }
+
+    /// <summary>
+    /// Verifies that cancellation can occur through a custom strategy.
+    /// </summary>
+    [Fact]
+    public async Task CancelRequest()
+    {
+        using var cts = new CancellationTokenSource();
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), cancellationToken: cts.Token);
+        var completingTask = await Task.WhenAny(invokeTask, this.server.MethodEntered.WaitAsync()).WithCancellation(this.TimeoutToken);
+        await completingTask;  // rethrow an exception if there is one.
+
+        cts.Cancel();
+        await invokeTask.WithCancellation(this.TimeoutToken);
+        Assert.True(this.mockStrategy.CancelRequestMade);
+    }
+
+    private class Server
+    {
+        internal AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
+
+        public async Task NoticeCancellationAsync(CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
+            var canceled = new AsyncManualResetEvent();
+            using (cancellationToken.Register(canceled.Set))
+            {
+                await canceled.WaitAsync();
+            }
+        }
+    }
+
+    private class MockCancellationStrategy : ICancellationStrategy
+    {
+        private readonly Dictionary<RequestId, CancellationTokenSource> cancelableRequests = new Dictionary<RequestId, CancellationTokenSource>();
+        private readonly ITestOutputHelper logger;
+
+        internal MockCancellationStrategy(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
+        internal bool CancelRequestMade { get; private set; }
+
+        public void CancelOutboundRequest(RequestId requestId)
+        {
+            this.logger.WriteLine("Canceling outbound request: {0}", requestId);
+            CancellationTokenSource? cts;
+            lock (this.cancelableRequests)
+            {
+                this.cancelableRequests.TryGetValue(requestId, out cts);
+            }
+
+            cts?.Cancel();
+            this.CancelRequestMade = true;
+        }
+
+        public void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource)
+        {
+            this.logger.WriteLine("Recognizing incoming request start: {0}", requestId);
+            lock (this.cancelableRequests)
+            {
+                this.cancelableRequests.Add(requestId, cancellationTokenSource);
+            }
+        }
+
+        public void IncomingRequestEnded(RequestId requestId)
+        {
+            this.logger.WriteLine("Recognizing incoming request end: {0}", requestId);
+            lock (this.cancelableRequests)
+            {
+                this.cancelableRequests.Remove(requestId);
+            }
+        }
+    }
+}

--- a/src/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/src/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
@@ -25,7 +23,7 @@ public class CustomCancellationStrategyTests : TestBase
     public CustomCancellationStrategyTests(ITestOutputHelper logger)
         : base(logger)
     {
-        this.mockStrategy = new MockCancellationStrategy(logger);
+        this.mockStrategy = new MockCancellationStrategy(this, logger);
 
         var streams = FullDuplexStream.CreatePair();
         this.clientRpc = new JsonRpc(streams.Item1)
@@ -55,48 +53,119 @@ public class CustomCancellationStrategyTests : TestBase
     /// Verifies that cancellation can occur through a custom strategy.
     /// </summary>
     [Fact]
-    public async Task CancelRequest()
+    public async Task CancelRequest_ServerMethodReturns()
     {
         using var cts = new CancellationTokenSource();
-        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), cancellationToken: cts.Token);
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { false }, cancellationToken: cts.Token);
         var completingTask = await Task.WhenAny(invokeTask, this.server.MethodEntered.WaitAsync()).WithCancellation(this.TimeoutToken);
         await completingTask;  // rethrow an exception if there is one.
 
         cts.Cancel();
         await invokeTask.WithCancellation(this.TimeoutToken);
         Assert.True(this.mockStrategy.CancelRequestMade);
+        await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
+    }
+
+    /// <summary>
+    /// Verifies that cancellation can occur through a custom strategy.
+    /// </summary>
+    [Fact]
+    public async Task CancelRequest_ServerMethodThrows()
+    {
+        using var cts = new CancellationTokenSource();
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { true }, cancellationToken: cts.Token);
+        var completingTask = await Task.WhenAny(invokeTask, this.server.MethodEntered.WaitAsync()).WithCancellation(this.TimeoutToken);
+        await completingTask;  // rethrow an exception if there is one.
+
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask).WithCancellation(this.TimeoutToken);
+        Assert.True(this.mockStrategy.CancelRequestMade);
+        await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
+    }
+
+    [Fact]
+    public async Task UncanceledRequest_GetsNoClientSideInvocations()
+    {
+        using var cts = new CancellationTokenSource();
+        await this.clientRpc.InvokeWithCancellationAsync(nameof(Server.EmptyMethod), cancellationToken: cts.Token);
+
+        Assert.False(this.mockStrategy.CancelRequestMade);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(ExpectedTimeoutToken));
+    }
+
+    /// <summary>
+    /// This test attempts to force the timing issue where <see cref="ICancellationStrategy.OutboundRequestEnded(RequestId)"/>
+    /// is called before <see cref="ICancellationStrategy.CancelOutboundRequest(RequestId)"/> has finished executing
+    /// as this would be most undesirable for any implementation that needs to clean up state in the former that is created by the latter.
+    /// </summary>
+    [Fact]
+    public async Task OutboundCancellationStartAndRequestFinishOverlap()
+    {
+        using var cts = new CancellationTokenSource();
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.EmptyMethod), cancellationToken: cts.Token);
+        var completingTask = await Task.WhenAny(invokeTask, this.server.MethodEntered.WaitAsync()).WithCancellation(this.TimeoutToken);
+        await completingTask;  // rethrow an exception if there is one.
+
+        this.mockStrategy.AllowCancelOutboundRequestToExit.Reset();
+        cts.Cancel();
+
+        // This may be invoked, but if the product doesn't invoke it, that's ok too.
+        ////await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
     }
 
     private class Server
     {
         internal AsyncManualResetEvent MethodEntered { get; } = new AsyncManualResetEvent();
 
-        public async Task NoticeCancellationAsync(CancellationToken cancellationToken)
+        public async Task NoticeCancellationAsync(bool throwOnCanceled, CancellationToken cancellationToken)
         {
             this.MethodEntered.Set();
             var canceled = new AsyncManualResetEvent();
             using (cancellationToken.Register(canceled.Set))
             {
                 await canceled.WaitAsync();
+                if (throwOnCanceled)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
             }
+        }
+
+        public void EmptyMethod(CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
         }
     }
 
     private class MockCancellationStrategy : ICancellationStrategy
     {
         private readonly Dictionary<RequestId, CancellationTokenSource> cancelableRequests = new Dictionary<RequestId, CancellationTokenSource>();
+        private readonly CustomCancellationStrategyTests owner;
         private readonly ITestOutputHelper logger;
+        private readonly List<RequestId> endedRequestIds = new List<RequestId>();
 
-        internal MockCancellationStrategy(ITestOutputHelper logger)
+        internal MockCancellationStrategy(CustomCancellationStrategyTests owner, ITestOutputHelper logger)
         {
+            this.owner = owner;
             this.logger = logger;
         }
 
         internal bool CancelRequestMade { get; private set; }
 
+        internal AsyncAutoResetEvent OutboundRequestEndedInvoked { get; } = new AsyncAutoResetEvent();
+
+        internal ManualResetEventSlim AllowCancelOutboundRequestToExit { get; } = new ManualResetEventSlim(initialState: true);
+
         public void CancelOutboundRequest(RequestId requestId)
         {
-            this.logger.WriteLine("Canceling outbound request: {0}", requestId);
+            this.logger.WriteLine($"{nameof(this.CancelOutboundRequest)}({requestId})");
+            lock (this.endedRequestIds)
+            {
+                // We should NEVER be called about a request ID that has already ended.
+                // If so, the product can cause a custom cancellation strategy to leak state.
+                Assert.DoesNotContain(requestId, this.endedRequestIds);
+            }
+
             CancellationTokenSource? cts;
             lock (this.cancelableRequests)
             {
@@ -105,11 +174,31 @@ public class CustomCancellationStrategyTests : TestBase
 
             cts?.Cancel();
             this.CancelRequestMade = true;
+
+            // Wait for the out of order invocation to happen if it's possible,
+            // so the OutboundCancellationStartAndRequestFinishOverlap test can catch it.
+            // Otherwise timeout, which is necessary to avoid a test hang when the product DOES work,
+            // since it shouldn't allow OutboundRequestEnded to execute before this method exits.
+            if (!this.AllowCancelOutboundRequestToExit.Wait(ExpectedTimeout))
+            {
+                this.logger.WriteLine("Timed out waiting for " + nameof(this.AllowCancelOutboundRequestToExit) + " to be signaled (good thing).");
+            }
+        }
+
+        public void OutboundRequestEnded(RequestId requestId)
+        {
+            this.logger.WriteLine($"{nameof(this.OutboundRequestEnded)}({requestId}) invoked.");
+            lock (this.endedRequestIds)
+            {
+                this.endedRequestIds.Add(requestId);
+            }
+
+            this.OutboundRequestEndedInvoked.Set();
         }
 
         public void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource)
         {
-            this.logger.WriteLine("Recognizing incoming request start: {0}", requestId);
+            this.logger.WriteLine($"{nameof(this.IncomingRequestStarted)}({requestId})");
             lock (this.cancelableRequests)
             {
                 this.cancelableRequests.Add(requestId, cancellationTokenSource);
@@ -118,7 +207,7 @@ public class CustomCancellationStrategyTests : TestBase
 
         public void IncomingRequestEnded(RequestId requestId)
         {
-            this.logger.WriteLine("Recognizing incoming request end: {0}", requestId);
+            this.logger.WriteLine($"{nameof(this.IncomingRequestEnded)}({requestId})");
             lock (this.cancelableRequests)
             {
                 this.cancelableRequests.Remove(requestId);

--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2181,6 +2181,15 @@ public abstract class JsonRpcTests : TestBase
         Assert.Null(this.server.ReceivedException);
     }
 
+    [Fact]
+    public void CancellationStrategy_ConfigurationLocked()
+    {
+        Assert.Throws<InvalidOperationException>(() => this.clientRpc.CancellationStrategy = null);
+        Assert.NotNull(this.clientRpc.CancellationStrategy);
+        this.clientRpc.AllowModificationWhileListening = true;
+        this.clientRpc.CancellationStrategy = null;
+    }
+
     protected static Exception CreateExceptionToBeThrownByDeserializer() => new Exception("This exception is meant to be thrown.");
 
     protected override void Dispose(bool disposing)

--- a/src/StreamJsonRpc/ICancellationStrategy.cs
+++ b/src/StreamJsonRpc/ICancellationStrategy.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System.Threading;
+
+    /// <summary>
+    /// Defines an extensibility point by which RPC methods may be canceled using <see cref="CancellationToken"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>A cancellation strategy can be set on the <see cref="JsonRpc.CancellationStrategy"/> property.</para>
+    /// <para>The default implementation is defined by <see cref="StandardCancellationStrategy"/>.</para>
+    /// <para>Implementations must be thread-safe.</para>
+    /// </remarks>
+    public interface ICancellationStrategy
+    {
+        /// <summary>
+        /// Translates a canceled <see cref="CancellationToken"/> that was used in an outbound RPC request into terms that
+        /// the RPC server can understand.
+        /// </summary>
+        /// <param name="requestId">The ID of the canceled request.</param>
+        void CancelOutboundRequest(RequestId requestId);
+
+        /// <summary>
+        /// Reports an incoming request and the <see cref="CancellationTokenSource"/> that is assigned to it.
+        /// </summary>
+        /// <param name="requestId">The ID of the incoming request.</param>
+        /// <param name="cancellationTokenSource">A means to cancel the <see cref="CancellationToken"/> that will be used when invoking the RPC server method.</param>
+        /// <remarks>
+        /// Implementations are expected to store the arguments in a dictionary so the implementing strategy can cancel it when the trigger occurs.
+        /// The trigger is outside the scope of this interface and will vary by implementation.
+        /// </remarks>
+        void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource);
+
+        /// <summary>
+        /// Reports that an incoming request is no longer a candidate for cancellation.
+        /// </summary>
+        /// <param name="requestId">The ID of the request that has been fulfilled.</param>
+        /// <remarks>
+        /// Implementations are expected to release memory allocated by a prior call to <see cref="IncomingRequestStarted(RequestId, CancellationTokenSource)"/>.
+        /// This method should *not* dispose of the <see cref="CancellationTokenSource"/> received previously as <see cref="JsonRpc"/> owns its lifetime.
+        /// </remarks>
+        void IncomingRequestEnded(RequestId requestId);
+    }
+}

--- a/src/StreamJsonRpc/ICancellationStrategy.cs
+++ b/src/StreamJsonRpc/ICancellationStrategy.cs
@@ -20,10 +20,25 @@ namespace StreamJsonRpc
         /// the RPC server can understand.
         /// </summary>
         /// <param name="requestId">The ID of the canceled request.</param>
+        /// <remarks>
+        /// Every call to this method is followed by a subsequent call to <see cref="OutboundRequestEnded(RequestId)"/>.
+        /// </remarks>
         void CancelOutboundRequest(RequestId requestId);
 
         /// <summary>
-        /// Reports an incoming request and the <see cref="CancellationTokenSource"/> that is assigned to it.
+        /// Cleans up any state associated with an earlier <see cref="CancelOutboundRequest(RequestId)"/> call.
+        /// </summary>
+        /// <param name="requestId">The ID of the canceled request.</param>
+        /// <remarks>
+        /// This method is invoked by <see cref="JsonRpc"/> when the response to a canceled request has been received.
+        /// It *may* be invoked for requests for which a prior call to <see cref="CancelOutboundRequest(RequestId)"/> was *not* made, due to timing.
+        /// But it should never be invoked concurrently with <see cref="CancelOutboundRequest(RequestId)"/> for the same <see cref="RequestId"/>.
+        /// </remarks>
+        void OutboundRequestEnded(RequestId requestId);
+
+        /// <summary>
+        /// Associates the <see cref="RequestId"/> from an incoming request with the <see cref="CancellationTokenSource"/>
+        /// that is used for the <see cref="CancellationToken"/> passed to that RPC method so it can be canceled later.
         /// </summary>
         /// <param name="requestId">The ID of the incoming request.</param>
         /// <param name="cancellationTokenSource">A means to cancel the <see cref="CancellationToken"/> that will be used when invoking the RPC server method.</param>
@@ -34,7 +49,7 @@ namespace StreamJsonRpc
         void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource);
 
         /// <summary>
-        /// Reports that an incoming request is no longer a candidate for cancellation.
+        /// Cleans up any state associated with an earlier <see cref="IncomingRequestStarted(RequestId, CancellationTokenSource)"/> call.
         /// </summary>
         /// <param name="requestId">The ID of the request that has been fulfilled.</param>
         /// <remarks>

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -8,22 +8,26 @@ namespace StreamJsonRpc
     using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+    using System.Threading;
     using Microsoft;
 
     [DebuggerDisplay("{DebuggerDisplay}")]
     internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     {
-        public MethodSignatureAndTarget(MethodInfo method, object? target, JsonRpcMethodAttribute? attribute)
+        public MethodSignatureAndTarget(MethodInfo method, object? target, JsonRpcMethodAttribute? attribute, SynchronizationContext? perMethodSynchronizationContext)
         {
             Requires.NotNull(method, nameof(method));
 
             this.Signature = new MethodSignature(method, attribute);
             this.Target = target;
+            this.SynchronizationContext = perMethodSynchronizationContext;
         }
 
         public MethodSignature Signature { get; }
 
         public object? Target { get; }
+
+        internal SynchronizationContext? SynchronizationContext { get; }
 
         [ExcludeFromCodeCoverage]
         private string DebuggerDisplay => $"{this.Signature} ({this.Target})";

--- a/src/StreamJsonRpc/StandardCancellationStrategy.cs
+++ b/src/StreamJsonRpc/StandardCancellationStrategy.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+    using Microsoft.VisualStudio.Threading;
+    using StreamJsonRpc.Protocol;
+
+    internal class StandardCancellationStrategy : ICancellationStrategy
+    {
+        /// <summary>
+        /// The JSON-RPC method name used to send/receive cancellation requests.
+        /// </summary>
+        private const string CancelRequestSpecialMethod = "$/cancelRequest";
+
+        /// <summary>
+        /// The <see cref="MethodInfo"/> for the <see cref="CancelInboundRequest(RequestId)"/> method.
+        /// </summary>
+        private static readonly MethodInfo CancelInboundRequestMethodInfo = typeof(StandardCancellationStrategy).GetMethod(nameof(CancelInboundRequest), BindingFlags.Instance | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// A map of id's from inbound calls that have not yet completed and may be canceled,
+        /// to their <see cref="CancellationTokenSource"/> instances.
+        /// </summary>
+        private readonly Dictionary<RequestId, CancellationTokenSource> inboundCancellationSources = new Dictionary<RequestId, CancellationTokenSource>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardCancellationStrategy"/> class.
+        /// </summary>
+        /// <param name="jsonRpc">The <see cref="JsonRpc"/> connection that this strategy is associated with.</param>
+        public StandardCancellationStrategy(JsonRpc jsonRpc)
+        {
+            this.JsonRpc = jsonRpc ?? throw new ArgumentNullException(nameof(jsonRpc));
+
+            // When we add this method, we *must* specify to use a plain SynchronizationContext instance
+            // instead of whatever the user may be using in order to support cancelling of server methods
+            // that have not yet yielded their SyncContext back for calling another method.
+            this.JsonRpc.AddLocalRpcMethod(
+                CancelInboundRequestMethodInfo,
+                this,
+                new JsonRpcMethodAttribute(CancelRequestSpecialMethod),
+                JsonRpc.DefaultSynchronizationContext);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonRpc"/> connection that this strategy is associated with.
+        /// </summary>
+        internal JsonRpc JsonRpc { get; }
+
+        /// <inheritdoc />
+        public virtual void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource)
+        {
+            lock (this.inboundCancellationSources)
+            {
+                this.inboundCancellationSources.Add(requestId, cancellationTokenSource);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void IncomingRequestEnded(RequestId requestId)
+        {
+            lock (this.inboundCancellationSources)
+            {
+                this.inboundCancellationSources.Remove(requestId);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void CancelOutboundRequest(RequestId requestId)
+        {
+            Task.Run(async delegate
+            {
+                if (!this.JsonRpc.IsDisposed)
+                {
+                    if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+                    {
+                        JsonRpcEventSource.Instance.SendingCancellationRequest(requestId.NumberIfPossibleForEvent);
+                    }
+
+                    var args = new Dictionary<string, object?>
+                    {
+                        { "id", requestId },
+                    };
+
+                    await this.JsonRpc.NotifyWithParameterObjectAsync(CancelRequestSpecialMethod, args).ConfigureAwait(false);
+                }
+            }).Forget();
+        }
+
+        /// <summary>
+        /// Cancels an inbound request that was previously received by <see cref="IncomingRequestStarted(RequestId, CancellationTokenSource)"/>.
+        /// </summary>
+        /// <param name="id">The ID of the request to be canceled.</param>
+        /// <devremarks>
+        /// The name of the only parameter MUST be "id" in order to match the named arguments in the JSON-RPC request.
+        /// </devremarks>
+        protected void CancelInboundRequest(RequestId id)
+        {
+            if (this.JsonRpc.TraceSource.Switch.ShouldTrace(TraceEventType.Information))
+            {
+                this.JsonRpc.TraceSource.TraceEvent(TraceEventType.Information, (int)JsonRpc.TraceEvents.ReceivedCancellation, "Cancellation request received for \"{0}\".", id);
+            }
+
+            if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Informational, System.Diagnostics.Tracing.EventKeywords.None))
+            {
+                JsonRpcEventSource.Instance.ReceivedCancellationRequest(id.NumberIfPossibleForEvent);
+            }
+
+            CancellationTokenSource? cts;
+            lock (this.inboundCancellationSources)
+            {
+                if (this.inboundCancellationSources.TryGetValue(id, out cts))
+                {
+                    this.inboundCancellationSources.Remove(id);
+                }
+            }
+
+            if (cts is object)
+            {
+                // This cancellation token is the one that is passed to the server method.
+                // It may have callbacks registered on cancellation.
+                // Cancel it asynchronously to ensure that these callbacks do not delay handling of other json rpc messages.
+                try
+                {
+                    cts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // There is a race condition between when we retrieve the CTS and actually call Cancel,
+                    // vs. another thread that disposes the CTS at the conclusion of the method invocation.
+                    // It cannot be prevented, so just swallow it since the method executed successfully.
+                }
+            }
+        }
+    }
+}

--- a/src/StreamJsonRpc/StandardCancellationStrategy.cs
+++ b/src/StreamJsonRpc/StandardCancellationStrategy.cs
@@ -7,12 +7,9 @@ namespace StreamJsonRpc
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Reflection;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft;
     using Microsoft.VisualStudio.Threading;
-    using StreamJsonRpc.Protocol;
 
     internal class StandardCancellationStrategy : ICancellationStrategy
     {
@@ -56,7 +53,7 @@ namespace StreamJsonRpc
         internal JsonRpc JsonRpc { get; }
 
         /// <inheritdoc />
-        public virtual void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource)
+        public void IncomingRequestStarted(RequestId requestId, CancellationTokenSource cancellationTokenSource)
         {
             lock (this.inboundCancellationSources)
             {
@@ -65,7 +62,7 @@ namespace StreamJsonRpc
         }
 
         /// <inheritdoc />
-        public virtual void IncomingRequestEnded(RequestId requestId)
+        public void IncomingRequestEnded(RequestId requestId)
         {
             lock (this.inboundCancellationSources)
             {
@@ -74,7 +71,7 @@ namespace StreamJsonRpc
         }
 
         /// <inheritdoc />
-        public virtual void CancelOutboundRequest(RequestId requestId)
+        public void CancelOutboundRequest(RequestId requestId)
         {
             Task.Run(async delegate
             {
@@ -93,6 +90,11 @@ namespace StreamJsonRpc
                     await this.JsonRpc.NotifyWithParameterObjectAsync(CancelRequestSpecialMethod, args).ConfigureAwait(false);
                 }
             }).Forget();
+        }
+
+        /// <inheritdoc />
+        public void OutboundRequestEnded(RequestId requestId)
+        {
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.ICancellationStrategy
 StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestStarted(StreamJsonRpc.RequestId requestId, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
+StreamJsonRpc.ICancellationStrategy.OutboundRequestEnded(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
+StreamJsonRpc.ICancellationStrategy
+StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.ICancellationStrategy.IncomingRequestStarted(StreamJsonRpc.RequestId requestId, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
+StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?
+StreamJsonRpc.JsonRpc.CancellationStrategy.set -> void
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? positionalArgumentDeclaredTypes, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? namedArgumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ StreamJsonRpc.ICancellationStrategy
 StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestStarted(StreamJsonRpc.RequestId requestId, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
+StreamJsonRpc.ICancellationStrategy.OutboundRequestEnded(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
+StreamJsonRpc.ICancellationStrategy
+StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
+StreamJsonRpc.ICancellationStrategy.IncomingRequestStarted(StreamJsonRpc.RequestId requestId, System.Threading.CancellationTokenSource! cancellationTokenSource) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
+StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?
+StreamJsonRpc.JsonRpc.CancellationStrategy.set -> void
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? positionalArgumentDeclaredTypes, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? namedArgumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!


### PR DESCRIPTION
This allows specific JsonRpc instances to be configured to implement `CancellationToken` support in a totally different way. They are *not* given the freedom to mutate the the request object itself, but they may trigger and respond to any other JSON-RPC message or do something entirely out of band (e.g. creating a file and/or testing for existing of the file).

As part of this change, we had to move `$/cancelRequest` handling out of its very special place in `JsonRpc.HandleRpcAsync` into a standard method handler. But that would have changed the method handler to be invoked on the user-configurable `SynchronizationContext` (which is now by default order-preserving). But this special method *shouldn't* be subject to that order-preserving `SynchronizationContext` because in fact we want these cancellation requests handled as soon as they come in so they can cancel an ongoing RPC server method that has not yet yielded. In order to support this, I modified how we record `TargetMethod` to include an optional override `SynchronizationContext`.

Closes #436