### PR TITLE
Fix unstable tests

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1007,7 +1007,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task InvokeWithParameterObject_ProgressParameterAndFields()
     {
         int report = 0;
-        ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report += n);
+        var progress = new ProgressWithCompletion<int>(n => Interlocked.Add(ref report, n));
 
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithProgressAndMoreParameters), new { p = progress, x = 2, y = 5 }, this.TimeoutToken);
 
@@ -1021,7 +1021,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task InvokeWithParameterObject_ProgressAndDefaultParameters()
     {
         int report = 0;
-        ProgressWithCompletion<int> progress = new ProgressWithCompletion<int>(n => report += n);
+        var progress = new ProgressWithCompletion<int>(n => Interlocked.Add(ref report, n));
 
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithProgressAndMoreParameters), new { p = progress, x = 2 }, this.TimeoutToken);
 
@@ -1087,7 +1087,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task InvokeWithSingleObjectParameter_SendingWithProgressProperty()
     {
         int report = 0;
-        var progress = new ProgressWithCompletion<int>(n => report += n);
+        var progress = new ProgressWithCompletion<int>(n => Interlocked.Add(ref report, n));
 
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>("test/MethodWithSingleObjectParameterWithProgress", new XAndYFieldsWithProgress { x = 2, y = 5, p = progress }, this.TimeoutToken);
 
@@ -1101,7 +1101,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task InvokeWithArrayParameters_SendingWithProgressProperty()
     {
         int report = 0;
-        var progress = new ProgressWithCompletion<int>(n => report += n);
+        var progress = new ProgressWithCompletion<int>(n => Interlocked.Add(ref report, n));
 
         int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new XAndYFieldsWithProgress { x = 2, y = 5, p = progress } }, this.TimeoutToken);
 
@@ -1115,7 +1115,7 @@ public abstract class JsonRpcTests : TestBase
     public async Task InvokeWithArrayParameters_SendingWithProgressConcreteTypeProperty()
     {
         int report = 0;
-        var progress = new ProgressWithCompletion<int>(n => report += n);
+        var progress = new ProgressWithCompletion<int>(n => Interlocked.Add(ref report, n));
 
         int sum = await this.clientRpc.InvokeWithCancellationAsync<int>(nameof(Server.MethodWithParameterContainingIProgress), new object[] { new StrongTypedProgressType { x = 2, y = 5, p = progress } }, this.TimeoutToken);
 


### PR DESCRIPTION
These tests were vulnerable to the fact that `ProgressWithCompletion<T>` can invoke callbacks concurrently.
