### PR TITLE
Promote error info into `RemoteRpcException`

### DIFF
--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -7,7 +7,6 @@ namespace StreamJsonRpc
     using System.IO;
     using System.Runtime.Serialization;
     using System.Text;
-    using Newtonsoft.Json.Linq;
     using StreamJsonRpc.Protocol;
 
     /// <summary>
@@ -28,8 +27,8 @@ namespace StreamJsonRpc
         public RemoteInvocationException(string? message, int errorCode, object? errorData)
             : base(message)
         {
-            this.ErrorCode = errorCode;
-            this.ErrorData = errorData;
+            base.ErrorCode = (JsonRpcErrorCode)errorCode;
+            base.ErrorData = errorData;
         }
 
         /// <summary>
@@ -42,9 +41,9 @@ namespace StreamJsonRpc
         public RemoteInvocationException(string? message, int errorCode, object? errorData, object? deserializedErrorData)
             : base(message)
         {
-            this.ErrorCode = errorCode;
-            this.ErrorData = errorData;
-            this.DeserializedErrorData = deserializedErrorData;
+            base.ErrorCode = (JsonRpcErrorCode)errorCode;
+            base.ErrorData = errorData;
+            base.DeserializedErrorData = deserializedErrorData;
         }
 
         /// <summary>
@@ -55,7 +54,6 @@ namespace StreamJsonRpc
         protected RemoteInvocationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.ErrorCode = info.GetInt32(nameof(this.ErrorCode));
         }
 
         /// <summary>
@@ -65,27 +63,13 @@ namespace StreamJsonRpc
         /// The value may be any integer.
         /// The value may be <see cref="JsonRpcErrorCode.InvocationError"/>, which is a general value used for exceptions thrown on the server when the server does not give an app-specific error code.
         /// </value>
-        public int ErrorCode { get; }
+        public new int ErrorCode => (int)base.ErrorCode!.Value;
 
-        /// <summary>
-        /// Gets the <c>error.data</c> value in the error response, if one was provided.
-        /// </summary>
-        /// <remarks>
-        /// Depending on the <see cref="IJsonRpcMessageFormatter"/> used, the value of this property, if any,
-        /// may be a <see cref="JToken"/> or a deserialized object.
-        /// If a deserialized object, the type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
-        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
-        /// </remarks>
-        public object? ErrorData { get; }
+        /// <inheritdoc cref="RemoteRpcException.ErrorData" />
+        public new object? ErrorData => base.ErrorData;
 
-        /// <summary>
-        /// Gets the <c>error.data</c> value in the error response, if one was provided.
-        /// </summary>
-        /// <remarks>
-        /// The type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
-        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
-        /// </remarks>
-        public object? DeserializedErrorData { get; }
+        /// <inheritdoc cref="RemoteRpcException.DeserializedErrorData" />
+        public new object? DeserializedErrorData => base.DeserializedErrorData;
 
         /// <inheritdoc/>
         public override string ToString()
@@ -108,13 +92,6 @@ namespace StreamJsonRpc
             }
 
             return result;
-        }
-
-        /// <inheritdoc/>
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            info.AddValue(nameof(this.ErrorCode), this.ErrorCode);
         }
 
         private static void ContributeInnerExceptionDetails(StringBuilder builder, CommonErrorData errorData)

--- a/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteMethodNotFoundException.cs
@@ -33,10 +33,10 @@ namespace StreamJsonRpc
             : base(message)
         {
             Requires.NotNullOrEmpty(targetMethod, nameof(targetMethod));
-            this.ErrorCode = errorCode;
+            base.ErrorCode = errorCode;
             this.TargetMethod = targetMethod;
-            this.ErrorData = errorData;
-            this.DeserializedErrorData = deserializedErrorData;
+            base.ErrorData = errorData;
+            base.DeserializedErrorData = deserializedErrorData;
         }
 
         /// <summary>
@@ -61,27 +61,13 @@ namespace StreamJsonRpc
         /// <value>
         /// The value is typically either <see cref="JsonRpcErrorCode.InvalidParams"/> or <see cref="JsonRpcErrorCode.MethodNotFound"/>.
         /// </value>
-        public JsonRpcErrorCode ErrorCode { get; }
+        public new JsonRpcErrorCode ErrorCode => base.ErrorCode!.Value;
 
-        /// <summary>
-        /// Gets the <c>error.data</c> value in the error response, if one was provided.
-        /// </summary>
-        /// <remarks>
-        /// Depending on the <see cref="IJsonRpcMessageFormatter"/> used, the value of this property, if any,
-        /// may be a <see cref="JToken"/> or a deserialized object.
-        /// If a deserialized object, the type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
-        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
-        /// </remarks>
-        public object? ErrorData { get; }
+        /// <inheritdoc cref="RemoteRpcException.ErrorData" />
+        public new object? ErrorData => base.ErrorData;
 
-        /// <summary>
-        /// Gets the <c>error.data</c> value in the error response, if one was provided.
-        /// </summary>
-        /// <remarks>
-        /// The type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
-        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
-        /// </remarks>
-        public object? DeserializedErrorData { get; }
+        /// <inheritdoc cref="RemoteRpcException.DeserializedErrorData" />
+        public new object? DeserializedErrorData => base.DeserializedErrorData;
 
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteRpcException.cs
@@ -4,6 +4,9 @@
 namespace StreamJsonRpc
 {
     using System;
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json.Linq;
+    using StreamJsonRpc.Protocol;
 
     /// <summary>
     /// Base exception class for any exception that happens while receiving an JSON-RPC communication.
@@ -35,11 +38,50 @@ namespace StreamJsonRpc
         /// </summary>
         /// <param name="info">Serialization info.</param>
         /// <param name="context">Streaming context.</param>
-        protected RemoteRpcException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
+        protected RemoteRpcException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            this.ErrorCode = (JsonRpcErrorCode?)(int?)info.GetValue(nameof(this.ErrorCode), typeof(int?));
+        }
+
+        /// <summary>
+        /// Gets or sets the value of the <c>error.code</c> field in the response, if one is available.
+        /// </summary>
+        public JsonRpcErrorCode? ErrorCode { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the <c>error.data</c> value in the error response, if one was provided.
+        /// </summary>
+        /// <remarks>
+        /// Depending on the <see cref="IJsonRpcMessageFormatter"/> used, the value of this property, if any,
+        /// may be a <see cref="JToken"/> or a deserialized object.
+        /// If a deserialized object, the type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
+        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
+        /// </remarks>
+        public object? ErrorData { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the <c>error.data</c> value in the error response, if one was provided.
+        /// </summary>
+        /// <remarks>
+        /// The type of this object is determined by <see cref="JsonRpc.GetErrorDetailsDataType(JsonRpcError)"/>.
+        /// The default implementation of this method produces a <see cref="CommonErrorData"/> object.
+        /// </remarks>
+        public object? DeserializedErrorData { get; protected set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            if (this.ErrorCode.HasValue)
+            {
+                info.AddValue(nameof(this.ErrorCode), (int)this.ErrorCode.Value);
+            }
+            else
+            {
+                info.AddValue(nameof(this.ErrorCode), null);
+            }
         }
     }
 }

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Shipped.txt
@@ -438,7 +438,6 @@ override StreamJsonRpc.NewLineDelimitedMessageHandler.ReadCoreAsync(System.Threa
 override StreamJsonRpc.NewLineDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage! content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
-override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RemoteInvocationException.ToString() -> string!
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object? obj) -> bool

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -23,5 +23,12 @@ StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.C
 StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
+StreamJsonRpc.RemoteRpcException.DeserializedErrorData.get -> object?
+StreamJsonRpc.RemoteRpcException.DeserializedErrorData.set -> void
+StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode?
+StreamJsonRpc.RemoteRpcException.ErrorCode.set -> void
+StreamJsonRpc.RemoteRpcException.ErrorData.get -> object?
+StreamJsonRpc.RemoteRpcException.ErrorData.set -> void
+override StreamJsonRpc.RemoteRpcException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -438,7 +438,6 @@ override StreamJsonRpc.NewLineDelimitedMessageHandler.ReadCoreAsync(System.Threa
 override StreamJsonRpc.NewLineDelimitedMessageHandler.Write(StreamJsonRpc.Protocol.JsonRpcMessage! content, System.Threading.CancellationToken cancellationToken) -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeReader() -> void
 override StreamJsonRpc.PipeMessageHandler.DisposeWriter() -> void
-override StreamJsonRpc.RemoteInvocationException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RemoteInvocationException.ToString() -> string!
 override StreamJsonRpc.RemoteMethodNotFoundException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override StreamJsonRpc.RequestId.Equals(object? obj) -> bool

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -23,5 +23,12 @@ StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.C
 StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcResult.ResultDeclaredType.set -> void
+StreamJsonRpc.RemoteRpcException.DeserializedErrorData.get -> object?
+StreamJsonRpc.RemoteRpcException.DeserializedErrorData.set -> void
+StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode?
+StreamJsonRpc.RemoteRpcException.ErrorCode.set -> void
+StreamJsonRpc.RemoteRpcException.ErrorData.get -> object?
+StreamJsonRpc.RemoteRpcException.ErrorData.set -> void
+override StreamJsonRpc.RemoteRpcException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!


### PR DESCRIPTION
Some of this error info was unique to `RemoteInvocationException` but some was replicated across `RemoteMethodNotFoundException` as well. In fact, most RPC error exceptions should include an error code, so promoting these to the base class makes sense.
But not *all* `RemoteRpcException` derived types come from a JSON-RPC error, so we must allow for not having an error code.
We also need to be creative to avoid any backward breaking API changes. So instead of *moving* the properties to the base class, I add them to the base class and 'redefine' them in the derived types to simply forward the value from the base class.