### PR TITLE
Send error to client when server fails to serialize response

### DIFF
--- a/src/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/src/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1268,6 +1268,13 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task SerializationFailureInResult_ThrowsToClient()
+    {
+        var ex = await Assert.ThrowsAsync<RemoteSerializationException>(() => this.clientRpc.InvokeWithCancellationAsync(nameof(Server.GetUnserializableType), cancellationToken: this.TimeoutToken));
+        Assert.Equal(JsonRpcErrorCode.ResponseSerializationFailure, ex.ErrorCode);
+    }
+
+    [Fact]
     public async Task AddLocalRpcTarget_UseSingleObjectParameterDeserialization()
     {
         var streams = FullDuplexStream.CreatePair();
@@ -2756,6 +2763,8 @@ public abstract class JsonRpcTests : TestBase
 
         [JsonRpcMethod("ClassNameForMethod")]
         public int AddWithNameSubstitution(int a, int b) => a + b;
+
+        public TypeThrowsWhenSerialized GetUnserializableType() => new TypeThrowsWhenSerialized();
 
         public void ThrowRemoteInvocationException()
         {

--- a/src/StreamJsonRpc/Exceptions/RemoteSerializationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteSerializationException.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// An exception thrown from back to the client from various <see cref="JsonRpc"/> request methods when the server failed to serialize the response.
+    /// </summary>
+    /// <remarks>
+    /// This exception comes from the <see cref="JsonRpcErrorCode.ResponseSerializationFailure"/> error code.
+    /// </remarks>
+    public class RemoteSerializationException : RemoteRpcException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteSerializationException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="RemoteRpcException(string?)"/>
+        public RemoteSerializationException(string? message, object? errorData, object? deserializedErrorData)
+            : base(message)
+        {
+            this.ErrorCode = JsonRpcErrorCode.ResponseSerializationFailure;
+            this.ErrorData = errorData;
+            this.DeserializedErrorData = deserializedErrorData;
+        }
+    }
+}

--- a/src/StreamJsonRpc/Protocol/JsonRpcErrorCode.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcErrorCode.cs
@@ -21,6 +21,13 @@ namespace StreamJsonRpc.Protocol
         /// </summary>
         NoMarshaledObjectFound = -32001,
 
+        /* We're skipping -32002 because LSP uses it at the app level: https://github.com/microsoft/vscode-languageserver-node/issues/672 */
+
+        /// <summary>
+        /// Indicates a response could not be serialized as the application intended.
+        /// </summary>
+        ResponseSerializationFailure = -32003,
+
         /// <summary>
         /// Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
         /// </summary>

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -439,6 +439,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to serialize the response..
+        /// </summary>
+        internal static string ResponseSerializationFailure {
+            get {
+                return ResourceManager.GetString("ResponseSerializationFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Response is in an unexpected format.  Only error and result are supported: {0}.
         /// </summary>
         internal static string ResponseUnexpectedFormat {

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -257,6 +257,9 @@
   <data name="ResponseIsNotError" xml:space="preserve">
     <value>Response is not error.</value>
   </data>
+  <data name="ResponseSerializationFailure" xml:space="preserve">
+    <value>Failed to serialize the response.</value>
+  </data>
   <data name="ResponseUnexpectedFormat" xml:space="preserve">
     <value>Response is in an unexpected format.  Only error and result are supported: {0}</value>
     <comment>{0} is the response message.</comment>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -17,6 +17,7 @@ StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void
+StreamJsonRpc.Protocol.JsonRpcErrorCode.ResponseSerializationFailure = -32003 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>?
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>?
@@ -29,6 +30,8 @@ StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpc
 StreamJsonRpc.RemoteRpcException.ErrorCode.set -> void
 StreamJsonRpc.RemoteRpcException.ErrorData.get -> object?
 StreamJsonRpc.RemoteRpcException.ErrorData.set -> void
+StreamJsonRpc.RemoteSerializationException
+StreamJsonRpc.RemoteSerializationException.RemoteSerializationException(string? message, object? errorData, object? deserializedErrorData) -> void
 override StreamJsonRpc.RemoteRpcException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -17,6 +17,7 @@ StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void
+StreamJsonRpc.Protocol.JsonRpcErrorCode.ResponseSerializationFailure = -32003 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>?
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.NamedArgumentDeclaredTypes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>?
@@ -29,6 +30,8 @@ StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpc
 StreamJsonRpc.RemoteRpcException.ErrorCode.set -> void
 StreamJsonRpc.RemoteRpcException.ErrorData.get -> object?
 StreamJsonRpc.RemoteRpcException.ErrorData.set -> void
+StreamJsonRpc.RemoteSerializationException
+StreamJsonRpc.RemoteSerializationException.RemoteSerializationException(string? message, object? errorData, object? deserializedErrorData) -> void
 override StreamJsonRpc.RemoteRpcException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 static StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions.get -> MessagePack.MessagePackSerializerOptions!
 virtual StreamJsonRpc.JsonRpc.CreateExceptionFromRpcError(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.Protocol.JsonRpcError! response) -> StreamJsonRpc.RemoteRpcException!

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Odpověď není chyba.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Odpověď je v neočekávaném formátu. Podporují se jenom chyby a výsledky: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Die Antwort ist kein Fehler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Die Antwort weist ein unerwartetes Format auf. Es werden nur Fehler und Ergebnisse unterstützt: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -112,6 +112,11 @@
         <target state="translated">La respuesta no es un error.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">La respuesta tiene un formato no esperado. Solo se admiten errores y resultados: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">La réponse n’est pas une erreur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Le format de la réponse est inattendu. Seuls l'erreur et le résultat sont pris en charge : {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -112,6 +112,11 @@
         <target state="translated">La risposta non è un errore.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Il formato della risposta è imprevisto. Sono supportati solo l'errore e il risultato: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -112,6 +112,11 @@
         <target state="translated">応答は、エラーではありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">応答が予期しない形式です。エラーと結果のみがサポートされています: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -112,6 +112,11 @@
         <target state="translated">응답은 오류가 아닙니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">예기치 않은 형식의 응답입니다.  오류 및 결과만 지원됨: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Odpowiedź nie jest błędem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Odpowiedź ma nieoczekiwany format. Obsługiwane są tylko błędy i wyniki: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="translated">A resposta não é um erro.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">A resposta está em um formato inesperado. Há suporte somente para erro e resultado: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Отклик не является ошибкой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Непредвиденный формат ответа. Поддерживаются только ошибки и результаты: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Yanıt hata değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">Yanıt beklenmeyen bir biçimde. Yalnızca hata ve sonuç desteklenir: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="translated">响应不是错误。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">响应为意外格式。仅支持错误和结果: {0}</target>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -112,6 +112,11 @@
         <target state="translated">回應不是錯誤。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResponseSerializationFailure">
+        <source>Failed to serialize the response.</source>
+        <target state="new">Failed to serialize the response.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseUnexpectedFormat">
         <source>Response is in an unexpected format.  Only error and result are supported: {0}</source>
         <target state="translated">回應採用了非預期的格式。只支援錯誤和結果: {0}</target>


### PR DESCRIPTION
Previous to this change, a failure to serialize a response would lead the server to terminate the connection (since a response is required). With this change, we instead keep the connection going but send an error response to the client with the serialization error.

We also (still) log the serialization failure on the server.

Closes #549