### PR TITLE
Begin using service connection for Git token

### DIFF
--- a/azure-pipelines/richnav.yml
+++ b/azure-pipelines/richnav.yml
@@ -9,5 +9,6 @@ jobs:
     inputs:
       languages: 'csharp'
       environment: production
+      githubServiceConnection: Microsoft
       isPrivateFeed: false
     continueOnError: true


### PR DESCRIPTION
A recent update to our service requires a Git token with all indexing requests. With this change, the Rich Nav task will have access to the aforementioned token to make requests to our service.