### PR TITLE
Add option to deserialize the original exception types thrown by the RPC server

### DIFF
--- a/src/StreamJsonRpc/ExceptionProcessing.cs
+++ b/src/StreamJsonRpc/ExceptionProcessing.cs
@@ -14,6 +14,8 @@ namespace StreamJsonRpc
         /// <summary>
         /// Exceptions thrown by the server are serialized as the simple <see cref="Protocol.CommonErrorData"/> class
         /// and the default error code is <see cref="JsonRpcErrorCode.InvocationError"/>.
+        /// The client experiences a <see cref="RemoteInvocationException"/> whose <see cref="RemoteInvocationException.DeserializedErrorData"/> property
+        /// is the deserialized <see cref="Protocol.CommonErrorData"/>.
         /// </summary>
         CommonErrorData,
 
@@ -21,6 +23,7 @@ namespace StreamJsonRpc
         /// Exceptions thrown by the server are serialized via the <see cref="System.Runtime.Serialization.ISerializable"/> mechanism and captures more detail,
         /// using the error code <see cref="JsonRpcErrorCode.InvocationErrorWithException"/>.
         /// These are deserialized with the original exception types as inner exceptions of the <see cref="RemoteInvocationException"/> thrown at the client.
+        /// The <see cref="RemoteInvocationException.DeserializedErrorData"/> is also set to an instance of <see cref="Protocol.CommonErrorData"/> that resembles the inner exception tree.
         /// </summary>
         ISerializable,
     }

--- a/src/StreamJsonRpc/ExceptionProcessing.cs
+++ b/src/StreamJsonRpc/ExceptionProcessing.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using StreamJsonRpc.Protocol;
+
+    /// <summary>
+    /// Enumerates the exception handling behaviors that are built into the <see cref="JsonRpc"/> class.
+    /// </summary>
+    /// <seealso cref="JsonRpc.ExceptionStrategy"/>
+    public enum ExceptionProcessing
+    {
+        /// <summary>
+        /// Exceptions thrown by the server are serialized as the simple <see cref="Protocol.CommonErrorData"/> class
+        /// and the default error code is <see cref="JsonRpcErrorCode.InvocationError"/>.
+        /// </summary>
+        CommonErrorData,
+
+        /// <summary>
+        /// Exceptions thrown by the server are serialized via the <see cref="System.Runtime.Serialization.ISerializable"/> mechanism and captures more detail,
+        /// using the error code <see cref="JsonRpcErrorCode.InvocationErrorWithException"/>.
+        /// These are deserialized with the original exception types as inner exceptions of the <see cref="RemoteInvocationException"/> thrown at the client.
+        /// </summary>
+        ISerializable,
+    }
+}

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -58,6 +58,9 @@ namespace StreamJsonRpc
             : base(message, innerException)
         {
             base.ErrorCode = (JsonRpcErrorCode)errorCode;
+
+            // Emulate the CommonErrorData object tree as well so folks can keep reading that if they were before.
+            base.DeserializedErrorData = new CommonErrorData(innerException);
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
+++ b/src/StreamJsonRpc/Exceptions/RemoteInvocationException.cs
@@ -51,6 +51,18 @@ namespace StreamJsonRpc
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
         /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="errorCode">The value of the error.code field in the response.</param>
+        /// <param name="innerException">The deserialized exception thrown by the RPC server.</param>
+        public RemoteInvocationException(string? message, int errorCode, Exception innerException)
+            : base(message, innerException)
+        {
+            base.ErrorCode = (JsonRpcErrorCode)errorCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteInvocationException"/> class.
+        /// </summary>
         /// <param name="info">Serialization info.</param>
         /// <param name="context">Streaming context.</param>
         protected RemoteInvocationException(SerializationInfo info, StreamingContext context)

--- a/src/StreamJsonRpc/Protocol/JsonRpcErrorCode.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcErrorCode.cs
@@ -3,16 +3,21 @@
 
 namespace StreamJsonRpc.Protocol
 {
+    using System;
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// Error codes laid out in the JSON-RPC spec or this library.
     /// </summary>
     /// <remarks>
-    /// The error codes from and including -32768 to -32000 are reserved for pre-defined errors.
+    /// Per <see href="https://www.jsonrpc.org/specification#error_object">the spec</see>, the error codes from and including -32768 to -32000 are reserved for pre-defined errors.
+    /// The range from -32000 to -32099 is "Reserved for implementation-defined server-errors", so we define whatever new we need for StreamJsonRpc.
     /// </remarks>
     public enum JsonRpcErrorCode : int
     {
         /// <summary>
         /// Indicates the RPC call was made but the target threw an exception.
+        /// The <see cref="JsonRpcError.ErrorDetail.Data"/> included in the <see cref="JsonRpcError.Error"/> is likely to be <see cref="CommonErrorData"/>.
         /// </summary>
         InvocationError = -32000,
 
@@ -27,6 +32,12 @@ namespace StreamJsonRpc.Protocol
         /// Indicates a response could not be serialized as the application intended.
         /// </summary>
         ResponseSerializationFailure = -32003,
+
+        /// <summary>
+        /// Indicates the RPC call was made but the target threw an exception.
+        /// The <see cref="JsonRpcError.ErrorDetail.Data"/> included in the <see cref="JsonRpcError.Error"/> should be interpreted as an <see cref="Exception"/> serialized via <see cref="ISerializable"/>.
+        /// </summary>
+        InvocationErrorWithException = -32004,
 
         /// <summary>
         /// Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.ExceptionProcessing.CommonErrorData = 0 -> StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.ExceptionProcessing.ISerializable = 1 -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.ICancellationStrategy
 StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
@@ -7,6 +10,8 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! 
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?
 StreamJsonRpc.JsonRpc.CancellationStrategy.set -> void
+StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? positionalArgumentDeclaredTypes, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? namedArgumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
@@ -17,6 +22,7 @@ StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void
+StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcErrorCode.ResponseSerializationFailure = -32003 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>?
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
@@ -30,6 +36,7 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetPipeWriter(ulong? 
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.IDuplexPipe? duplexPipe) -> ulong?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.PipeReader? reader) -> ulong?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.PipeWriter? writer) -> ulong?
+StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RemoteRpcException.DeserializedErrorData.get -> object?
 StreamJsonRpc.RemoteRpcException.DeserializedErrorData.set -> void
 StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.ExceptionProcessing.CommonErrorData = 0 -> StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.ExceptionProcessing.ISerializable = 1 -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.ICancellationStrategy
 StreamJsonRpc.ICancellationStrategy.CancelOutboundRequest(StreamJsonRpc.RequestId requestId) -> void
 StreamJsonRpc.ICancellationStrategy.IncomingRequestEnded(StreamJsonRpc.RequestId requestId) -> void
@@ -7,6 +10,8 @@ StreamJsonRpc.JsonRpc.AddLocalRpcTarget(System.Type! exposingMembersOn, object! 
 StreamJsonRpc.JsonRpc.AddLocalRpcTarget<T>(T target, StreamJsonRpc.JsonRpcTargetOptions? options) -> void
 StreamJsonRpc.JsonRpc.CancellationStrategy.get -> StreamJsonRpc.ICancellationStrategy?
 StreamJsonRpc.JsonRpc.CancellationStrategy.set -> void
+StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
+StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.InvokeCoreAsync<TResult>(StreamJsonRpc.RequestId id, string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? positionalArgumentDeclaredTypes, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? namedArgumentDeclaredTypes, System.Threading.CancellationToken cancellationToken, bool isParameterObject) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>! argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.InvokeWithCancellationAsync<TResult>(string! targetName, System.Collections.Generic.IReadOnlyList<object?>? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
@@ -17,6 +22,7 @@ StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void
+StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcErrorCode.ResponseSerializationFailure = -32003 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>?
 StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentListDeclaredTypes.set -> void
@@ -30,6 +36,7 @@ StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetPipeWriter(ulong? 
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.IDuplexPipe? duplexPipe) -> ulong?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.PipeReader? reader) -> ulong?
 StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker.GetULongToken(System.IO.Pipelines.PipeWriter? writer) -> ulong?
+StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RemoteRpcException.DeserializedErrorData.get -> object?
 StreamJsonRpc.RemoteRpcException.DeserializedErrorData.set -> void
 StreamJsonRpc.RemoteRpcException.ErrorCode.get -> StreamJsonRpc.Protocol.JsonRpcErrorCode?

--- a/test/StreamJsonRpc.Tests/.editorconfig
+++ b/test/StreamJsonRpc.Tests/.editorconfig
@@ -5,3 +5,6 @@ csharp_style_var_elsewhere = false:silent
 
 # SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
+
+# SA1133: Do not combine attributes
+dotnet_diagnostic.SA1133.severity = none

--- a/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -159,7 +159,7 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
     [Fact]
     public async Task ExceptionControllingErrorData()
     {
-        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowRemoteInvocationException)));
+        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowLocalRpcException)));
 
         // C# dynamic is infamously unstable. If this test ends up being unstable, yet the dump clearly shows the fields are there even though the exception claims it isn't,
         // that's consistent with the instability I've seen before. Switching to using JToken APIs will fix the instability, but it relies on using the JsonMessageFormatter.

--- a/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -49,7 +49,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
     [Fact]
     public async Task ExceptionControllingErrorData()
     {
-        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowRemoteInvocationException))).WithCancellation(this.TimeoutToken);
+        var exception = await Assert.ThrowsAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync(nameof(Server.ThrowLocalRpcException))).WithCancellation(this.TimeoutToken);
 
         IDictionary<object, object>? data = (IDictionary<object, object>?)exception.ErrorData;
         object myCustomData = data!["myCustomData"];


### PR DESCRIPTION
This was already possible in v2.6 thanks to #505, but it required overriding virtual methods to take advantage of. Now it's as easy as setting a property on the `JsonRpc` instance.

Closes #468