### PR TITLE
Improve ConnectionLostException docs and add a test

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1502,7 +1502,7 @@ namespace StreamJsonRpc
         /// <exception cref="ArgumentException">Thrown when <paramref name="targetName" /> is empty.</exception>
         /// <exception cref="ObjectDisposedException">If this instance of <see cref="JsonRpc"/> has already been disposed prior to this call.</exception>
         /// <exception cref="ConnectionLostException">
-        /// Thrown when the connection is terminated (by either side) while the request is in progress,
+        /// Thrown when the connection is terminated (by either side) before the request or while the request is in progress,
         /// unless <paramref name="cancellationToken"/> is already signaled.
         /// </exception>
         /// <exception cref="Exception">

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -893,6 +893,14 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task Invoke_ThrowsConnectionLostExceptionOverDisposedException_ForNewRequests()
+    {
+        this.serverStream.Dispose();
+        await this.clientRpc.Completion;
+        await Assert.ThrowsAsync<ConnectionLostException>(() => this.clientRpc.InvokeAsync("Something"));
+    }
+
+    [Fact]
     public async Task InvokeAsync_CanCallCancellableMethodWithNoArgs()
     {
         Assert.Equal(5, await this.clientRpc.InvokeAsync<int>(nameof(Server.AsyncMethodWithCancellationAndNoArgs)));


### PR DESCRIPTION
In particular I wanted to prove that `ObjectDisposedException` would not be thrown in the case of a dropped connection.
This raises confidence that folks really just need to be prepared for `RemoteRpcException` and derived types to be thrown so long as they don't have local coding bugs.