### PR TITLE
Remove service connection that we actually can't use

### DIFF
--- a/azure-pipelines/richnav.yml
+++ b/azure-pipelines/richnav.yml
@@ -9,6 +9,5 @@ jobs:
     inputs:
       languages: 'csharp'
       environment: production
-      githubServiceConnection: Microsoft
       isPrivateFeed: false
     continueOnError: true


### PR DESCRIPTION
We actually can't use the service connection with forks. Removing it as we no longer need it