### PR TITLE
Avoid loading Newtonsoft.Json in MessagePack scenarios

### DIFF
--- a/src/StreamJsonRpc/CommonMethodNameTransforms.cs
+++ b/src/StreamJsonRpc/CommonMethodNameTransforms.cs
@@ -5,7 +5,6 @@ namespace StreamJsonRpc
 {
     using System;
     using Microsoft;
-    using Newtonsoft.Json.Serialization;
 
     /// <summary>
     /// Common RPC method transform functions that may be supplied to <see cref="JsonRpc.AddLocalRpcTarget(object, JsonRpcTargetOptions)"/>
@@ -13,11 +12,6 @@ namespace StreamJsonRpc
     /// </summary>
     public static class CommonMethodNameTransforms
     {
-        /// <summary>
-        /// The Newtonsoft.Json camel casing converter.
-        /// </summary>
-        private static readonly NamingStrategy CamelCaseStrategy = new CamelCaseNamingStrategy();
-
         /// <summary>
         /// Gets a function that converts a given string from PascalCase to camelCase.
         /// </summary>
@@ -34,12 +28,7 @@ namespace StreamJsonRpc
 #pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
                     }
 
-                    if (name.Length == 0)
-                    {
-                        return string.Empty;
-                    }
-
-                    return CamelCaseStrategy.GetPropertyName(name, hasSpecifiedName: false);
+                    return Utilities.ToCamelCase(name);
                 };
             }
         }

--- a/src/StreamJsonRpc/Utilities.cs
+++ b/src/StreamJsonRpc/Utilities.cs
@@ -5,6 +5,7 @@ namespace StreamJsonRpc
 {
     using System;
     using System.Buffers;
+    using System.Diagnostics.CodeAnalysis;
     using Microsoft;
 
     internal static class Utilities
@@ -73,6 +74,56 @@ namespace StreamJsonRpc
             {
                 writer.Write(segment.Span);
             }
+        }
+
+        /// <summary>
+        /// Converts a PascalCase identifier to camelCase.
+        /// </summary>
+        /// <param name="identifier">The identifier to convert to camcelCase.</param>
+        /// <returns>The camelCase identifier. Null if <paramref name="identifier"/> is null.</returns>
+        /// <devremarks>
+        /// Originally taken from <see href="https://github.com/JamesNK/Newtonsoft.Json/blob/666d9760719e5ec5b2a50046f7dbd6a1267c01c6/Src/Newtonsoft.Json/Utilities/StringUtils.cs#L155-L194">Newtonsoft.Json</see>.
+        /// </devremarks>
+        [return: NotNullIfNotNull("identifier")]
+        internal static string? ToCamelCase(string? identifier)
+        {
+            if (identifier is null || identifier.Length == 0 || !char.IsUpper(identifier[0]))
+            {
+                return identifier;
+            }
+
+            char[] chars = identifier.ToCharArray();
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (i == 1 && !char.IsUpper(chars[i]))
+                {
+                    break;
+                }
+
+                bool hasNext = i + 1 < chars.Length;
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                {
+                    // if the next character is a space, which is not considered uppercase
+                    // (otherwise we wouldn't be here...)
+                    // we want to ensure that the following:
+                    // 'FOO bar' is rewritten as 'foo bar', and not as 'foO bar'
+                    // The code was written in such a way that the first word in uppercase
+                    // ends when if finds an uppercase letter followed by a lowercase letter.
+                    // now a ' ' (space, (char)32) is considered not upper
+                    // but in that case we still want our current character to become lowercase
+                    if (char.IsSeparator(chars[i + 1]))
+                    {
+                        chars[i] = char.ToLowerInvariant(chars[i]);
+                    }
+
+                    break;
+                }
+
+                chars[i] = char.ToLowerInvariant(chars[i]);
+            }
+
+            return new string(chars);
         }
     }
 }

--- a/test/StreamJsonRpc.Tests/AssemblyLoadTests.cs
+++ b/test/StreamJsonRpc.Tests/AssemblyLoadTests.cs
@@ -42,7 +42,7 @@ public class AssemblyLoadTests : TestBase
         }
     }
 
-    [Fact(Skip = "By design for now, since we use the CamelCaseNamingStrategy from Newtonsoft.Json")]
+    [Fact]
     public void MessagePackDoesNotLoadNewtonsoftJsonUnnecessarily()
     {
         AppDomain testDomain = CreateTestAppDomain();
@@ -139,7 +139,6 @@ public class AssemblyLoadTests : TestBase
 
         internal void CreateMessagePackConnection()
         {
-            // By design for now, since we use the CamelCaseNamingStrategy from Newtonsoft.Json
             var jsonRpc = new JsonRpc(new LengthHeaderMessageHandler(FullDuplexStream.CreatePipePair().Item1, new MessagePackFormatter()));
         }
 


### PR DESCRIPTION
The only dependency was our camelCase conversion.

This avoids an assembly load, which is independently valuable. But it is also a prereq to fixing #576.