### PR TITLE
Fix possible data corruption from deserializing error details twice

### DIFF
--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1228,6 +1228,10 @@ namespace StreamJsonRpc
                     Verify.Operation(!this.MsgPackData.IsEmpty, "Data is no longer available or has already been deserialized.");
 
                     this.Data = this.GetData(dataType);
+
+                    // Clear the source now that we've deserialized to prevent GetData from attempting
+                    // deserialization later when the buffer may be recycled on another thread.
+                    this.MsgPackData = default;
                 }
             }
         }

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -4,11 +4,11 @@
 namespace StreamJsonRpc.Protocol
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Runtime.Serialization;
     using Microsoft;
     using Newtonsoft.Json.Linq;
+    using StreamJsonRpc.Reflection;
 
     /// <summary>
     /// Describes the error resulting from a <see cref="JsonRpcRequest"/> that failed on the server.
@@ -122,6 +122,11 @@ namespace StreamJsonRpc.Protocol
             /// argument that will be used when calling <see cref="GetData{T}"/> later.
             /// </summary>
             /// <param name="dataType">The type that will be used as the generic type argument to <see cref="GetData{T}"/>.</param>
+            /// <remarks>
+            /// Overridding methods in types that retain buffers used to deserialize should deserialize within this method and clear those buffers
+            /// to prevent further access to these buffers which may otherwise happen concurrently with a call to <see cref="IJsonRpcMessageBufferManager.DeserializationComplete"/>
+            /// that would recycle the same buffer being deserialized from.
+            /// </remarks>
             protected internal virtual void SetExpectedDataType(Type dataType)
             {
             }


### PR DESCRIPTION
The MessagePackFormatter would deserialize error details twice. The first happened with a live buffer. The second one happened sometime later, concurrently with another thread that is clearing/recycling the buffer. This led to non-deterministic behavior including returning null as the error details but could also lead to reading corrupted data due to use of a recycled buffer.

Fixes #585