### PR TITLE
Short-lived JsonRpc connection perf improvements

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2791,7 +2791,12 @@ namespace StreamJsonRpc
         /// <exception cref="InvalidOperationException">Thrown if <see cref="HasListeningStarted"/> is <c>true</c> and <see cref="AllowModificationWhileListening"/> is <c>false</c>.</exception>
         private void ThrowIfConfigurationLocked()
         {
-            Verify.Operation(!this.HasListeningStarted || this.AllowModificationWhileListening, Resources.MustNotBeListening);
+            // PERF: This can get called a lot in scenarios where connections are short-lived and frequent.
+            // Avoid loading the string resource unless we're going to throw the exception.
+            if (this.HasListeningStarted && !this.AllowModificationWhileListening)
+            {
+                Verify.FailOperation(Resources.MustNotBeListening);
+            }
         }
 
         internal class MethodNameMap

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -45,6 +45,7 @@ namespace StreamJsonRpc
                                                                     select method).Single();
 
         private static readonly MethodInfo NotifyAsyncOfTaskMethodInfo = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.NotifyAsync)).Single(m => !m.IsGenericMethod && m.GetParameters().Length == 3);
+        private static readonly MethodInfo AddLocalRpcMethodMethodInfo = typeof(JsonRpc).GetRuntimeMethod(nameof(JsonRpc.AddLocalRpcMethod), new Type[] { typeof(string), typeof(Delegate) })!;
 
         private static readonly MethodInfo MethodNameTransformPropertyGetter = typeof(JsonRpcProxyOptions).GetRuntimeProperty(nameof(JsonRpcProxyOptions.MethodNameTransform))!.GetMethod!;
         private static readonly MethodInfo MethodNameTransformInvoke = typeof(Func<string, string>).GetRuntimeMethod(nameof(JsonRpcProxyOptions.MethodNameTransform.Invoke), new Type[] { typeof(string) })!;
@@ -138,7 +139,6 @@ namespace StreamJsonRpc
 
                     ctorActions.Add(new Action<ILGenerator>(il =>
                     {
-                        MethodInfo addLocalRpcMethod = typeof(JsonRpc).GetRuntimeMethod(nameof(JsonRpc.AddLocalRpcMethod), new Type[] { typeof(string), typeof(Delegate) })!;
                         ConstructorInfo delegateCtor = typeof(Action<>).MakeGenericType(eventArgsType).GetTypeInfo().DeclaredConstructors.Single();
 
                         // rpc.AddLocalRpcMethod("EventName", new Action<EventArgs>(this.OnEventName));
@@ -156,7 +156,7 @@ namespace StreamJsonRpc
                         il.Emit(OpCodes.Ldarg_0);
                         il.Emit(OpCodes.Ldftn, raiseEventMethod);
                         il.Emit(OpCodes.Newobj, delegateCtor);
-                        il.Emit(OpCodes.Callvirt, addLocalRpcMethod);
+                        il.Emit(OpCodes.Callvirt, AddLocalRpcMethodMethodInfo);
                     }));
                 }
 

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -43,6 +43,9 @@ namespace StreamJsonRpc.Reflection
         private const string NextMethodName = "$/enumerator/next";
         private const string DisposeMethodName = "$/enumerator/abort";
 
+        private static readonly MethodInfo OnNextAsyncMethodInfo = typeof(MessageFormatterEnumerableTracker).GetMethod(nameof(OnNextAsync), BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly MethodInfo OnDisposeAsyncMethodInfo = typeof(MessageFormatterEnumerableTracker).GetMethod(nameof(OnDisposeAsync), BindingFlags.NonPublic | BindingFlags.Instance)!;
+
         /// <summary>
         /// Dictionary used to map the outbound request id to their progress info so that the progress objects are cleaned after getting the final response.
         /// </summary>
@@ -69,8 +72,8 @@ namespace StreamJsonRpc.Reflection
             this.jsonRpc = jsonRpc;
             this.formatterState = formatterState;
 
-            jsonRpc.AddLocalRpcMethod(NextMethodName, new Func<long, CancellationToken, ValueTask<object>>(this.OnNextAsync));
-            jsonRpc.AddLocalRpcMethod(DisposeMethodName, new Func<long, ValueTask>(this.OnDisposeAsync));
+            jsonRpc.AddLocalRpcMethod(NextMethodName, OnNextAsyncMethodInfo, this);
+            jsonRpc.AddLocalRpcMethod(DisposeMethodName, OnDisposeAsyncMethodInfo, this);
             this.formatterState = formatterState;
 
             // We don't offer a way to remove these handlers because this object should has a lifetime closely tied to the JsonRpc object anyway.

--- a/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
@@ -7,6 +7,7 @@ namespace StreamJsonRpc.Reflection
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
     using System.Runtime.Serialization;
     using Microsoft;
     using Microsoft.VisualStudio.Threading;
@@ -47,6 +48,8 @@ namespace StreamJsonRpc.Reflection
                 new JsonRpcTargetOptions { MethodNameTransform = CommonMethodNameTransforms.CamelCase }),
         };
 
+        private static readonly MethodInfo ReleaseMarshaledObjectMethodInfo = typeof(MessageFormatterRpcMarshaledContextTracker).GetMethod(nameof(ReleaseMarshaledObject), BindingFlags.NonPublic | BindingFlags.Instance)!;
+
         private readonly Dictionary<long, (IRpcMarshaledContext<object> Context, IDisposable Revert)> marshaledObjects = new Dictionary<long, (IRpcMarshaledContext<object> Context, IDisposable Revert)>();
         private readonly JsonRpc jsonRpc;
         private readonly IJsonRpcFormatterState formatterState;
@@ -67,7 +70,7 @@ namespace StreamJsonRpc.Reflection
             this.jsonRpc = jsonRpc;
             this.formatterState = formatterState;
 
-            this.jsonRpc.AddLocalRpcMethod("$/releaseMarshaledObject", new Action<long, bool>(this.ReleaseMarshaledObject));
+            this.jsonRpc.AddLocalRpcMethod("$/releaseMarshaledObject", ReleaseMarshaledObjectMethodInfo, this);
 
             // We don't offer a way to remove these handlers because this object should has a lifetime closely tied to the JsonRpc object anyway.
             IJsonRpcFormatterCallbacks callbacks = jsonRpc;

--- a/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
@@ -184,7 +184,9 @@ namespace StreamJsonRpc.Reflection
         /// </summary>
         /// <param name="handle">The handle to the object as created by the <see cref="GetToken(IRpcMarshaledContext{object})"/> method.</param>
         /// <param name="ownedBySender"><c>true</c> if the <paramref name="handle"/> was created by (and thus the original object owned by) the remote party; <c>false</c> if the token and object was created locally.</param>
+#pragma warning disable CA1801 // Review unused parameters -- Signature is dicated by protocol extension server method.
         private void ReleaseMarshaledObject(long handle, bool ownedBySender)
+#pragma warning restore CA1801 // Review unused parameters
         {
             lock (this.marshaledObjects)
             {


### PR DESCRIPTION
These are a few simple improvements to reduce GC pressure and improve perf when setting up a JsonRpc connection, as guided by ETW traces.