### PR TITLE
GC pressure fixes

### DIFF
--- a/src/StreamJsonRpc/MessageHandlerBase.cs
+++ b/src/StreamJsonRpc/MessageHandlerBase.cs
@@ -253,12 +253,12 @@ namespace StreamJsonRpc
                 // If they're active, they'll take care of themselves when they finish since we signaled disposal.
                 lock (this.syncObject)
                 {
-                    if (!this.state.HasFlag(MessageHandlerState.Reading))
+                    if ((this.state & MessageHandlerState.Reading) != MessageHandlerState.Reading)
                     {
                         this.readingCompleted.Set();
                     }
 
-                    if (!this.state.HasFlag(MessageHandlerState.Writing))
+                    if ((this.state & MessageHandlerState.Writing) != MessageHandlerState.Writing)
                     {
                         this.writingCompleted.Set();
                     }
@@ -347,7 +347,7 @@ namespace StreamJsonRpc
             {
                 Verify.NotDisposed(this);
                 MessageHandlerState state = this.state;
-                Assumes.False(state.HasFlag(startingOperation));
+                Assumes.False((state & startingOperation) == startingOperation);
                 this.state |= startingOperation;
             }
         }

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -781,12 +781,7 @@ namespace StreamJsonRpc
             {
                 Verify.Operation(this.encodedMessage.HasValue, "This object has not been activated. It may have already been recycled.");
 
-                if (this.jsonString is null)
-                {
-                    this.jsonString = MessagePackSerializer.ConvertToJson(this.encodedMessage.Value, this.options);
-                }
-
-                return this.jsonString;
+                return this.jsonString ??= MessagePackSerializer.ConvertToJson(this.encodedMessage.Value, this.options);
             }
 
             /// <summary>

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -87,6 +87,10 @@ namespace StreamJsonRpc
 
         private readonly PipeFormatterResolver pipeFormatterResolver;
 
+        private readonly ToStringHelper serializationToStringHelper = new ToStringHelper();
+
+        private readonly ToStringHelper deserializationToStringHelper = new ToStringHelper();
+
         /// <summary>
         /// Backing field for the <see cref="MultiplexingStream"/> property.
         /// </summary>
@@ -286,7 +290,15 @@ namespace StreamJsonRpc
             JsonRpcMessage message = MessagePackSerializer.Deserialize<JsonRpcMessage>(contentBuffer, this.messageSerializationOptions);
 
             IJsonRpcTracingCallbacks? tracingCallbacks = this.rpc;
-            tracingCallbacks?.OnMessageDeserialized(message, new ToStringHelper(contentBuffer, this.messageSerializationOptions));
+            this.deserializationToStringHelper.Activate(contentBuffer, this.messageSerializationOptions);
+            try
+            {
+                tracingCallbacks?.OnMessageDeserialized(message, this.deserializationToStringHelper);
+            }
+            finally
+            {
+                this.deserializationToStringHelper.Deactivate();
+            }
 
             return message;
         }
@@ -323,7 +335,15 @@ namespace StreamJsonRpc
         void IJsonRpcFormatterTracingCallbacks.OnSerializationComplete(JsonRpcMessage message, ReadOnlySequence<byte> encodedMessage)
         {
             IJsonRpcTracingCallbacks? tracingCallbacks = this.rpc;
-            tracingCallbacks?.OnMessageSerialized(message, new ToStringHelper(encodedMessage, this.messageSerializationOptions));
+            this.serializationToStringHelper.Activate(encodedMessage, this.messageSerializationOptions);
+            try
+            {
+                tracingCallbacks?.OnMessageSerialized(message, this.serializationToStringHelper);
+            }
+            finally
+            {
+                this.serializationToStringHelper.Deactivate();
+            }
         }
 
         /// <inheritdoc/>
@@ -743,18 +763,50 @@ namespace StreamJsonRpc
             public ulong ToUInt64(object value) => ((RawMessagePack)value).Deserialize<ulong>(this.options);
         }
 
+        /// <summary>
+        /// A recyclable object that can serialize a message to JSON on demand.
+        /// </summary>
+        /// <remarks>
+        /// In perf traces, creation of this object used to show up as one of the most allocated objects.
+        /// It is used even when tracing isn't active. So we changed its design it to be reused,
+        /// since its lifetime is only required during a synchronous call to a trace API.
+        /// </remarks>
         private class ToStringHelper
         {
-            private readonly ReadOnlySequence<byte> encodedMessage;
-            private readonly MessagePackSerializerOptions options;
+            private ReadOnlySequence<byte>? encodedMessage;
+            private MessagePackSerializerOptions? options;
+            private string? jsonString;
 
-            internal ToStringHelper(ReadOnlySequence<byte> encodedMessage, MessagePackSerializerOptions options)
+            public override string ToString()
+            {
+                Verify.Operation(this.encodedMessage.HasValue, "This object has not been activated. It may have already been recycled.");
+
+                if (this.jsonString is null)
+                {
+                    this.jsonString = MessagePackSerializer.ConvertToJson(this.encodedMessage.Value, this.options);
+                }
+
+                return this.jsonString;
+            }
+
+            /// <summary>
+            /// Initializes this object to represent a message.
+            /// </summary>
+            internal void Activate(ReadOnlySequence<byte> encodedMessage, MessagePackSerializerOptions options)
             {
                 this.encodedMessage = encodedMessage;
                 this.options = options;
             }
 
-            public override string ToString() => MessagePackSerializer.ConvertToJson(this.encodedMessage, this.options);
+            /// <summary>
+            /// Cleans out this object to release memory and ensure <see cref="ToString"/> throws if someone uses it after deactivation.
+            /// </summary>
+            internal void Deactivate()
+            {
+                this.encodedMessage = null;
+                this.options = null;
+                this.jsonString = null;
+            }
         }
 
         private class RequestIdFormatter : IMessagePackFormatter<RequestId>


### PR DESCRIPTION
- Avoid boxing an enum in `MessageHandlerBase.SetState`
    This was allocating 8012 objects in a perf trace I took (the no. 1 most allocated object). It should have been 0.

- Recycle ToStringHelper objects
    This was the no. 2 allocated object in high traffic perf testing. Yet we only need one for serialization and one for deserialization. In this change, I create and cache these for reuse, bringing it down from 4000 in one test to just 4.