### PR TITLE
Improve handling of various non-serializable Exception situations

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1361,12 +1361,21 @@ namespace StreamJsonRpc
         /// <seealso cref="CreateExceptionFromRpcError(JsonRpcRequest, JsonRpcError)"/>
         protected virtual JsonRpcError.ErrorDetail CreateErrorDetails(JsonRpcRequest request, Exception exception)
         {
+            Requires.NotNull(exception, nameof(exception));
+
             var localRpcEx = exception as LocalRpcException;
+            bool iserializable = this.ExceptionStrategy == ExceptionProcessing.ISerializable;
+            if (!ExceptionSerializationHelpers.IsSerializable(exception))
+            {
+                this.TraceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.ExceptionNotSerializable, "An exception of type {0} was thrown but is not serializable.", exception.GetType().AssemblyQualifiedName);
+                iserializable = false;
+            }
+
             return new JsonRpcError.ErrorDetail
             {
-                Code = (JsonRpcErrorCode?)localRpcEx?.ErrorCode ?? (this.ExceptionStrategy == ExceptionProcessing.ISerializable ? JsonRpcErrorCode.InvocationErrorWithException : JsonRpcErrorCode.InvocationError),
+                Code = (JsonRpcErrorCode?)localRpcEx?.ErrorCode ?? (iserializable ? JsonRpcErrorCode.InvocationErrorWithException : JsonRpcErrorCode.InvocationError),
                 Message = exception.Message,
-                Data = localRpcEx != null ? localRpcEx.ErrorData : (this.ExceptionStrategy == ExceptionProcessing.ISerializable ? (object?)exception : new CommonErrorData(exception)),
+                Data = localRpcEx != null ? localRpcEx.ErrorData : (iserializable ? (object?)exception : new CommonErrorData(exception)),
             };
         }
 

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -405,6 +405,17 @@ namespace StreamJsonRpc
             /// An incoming <see cref="Exception"/> cannot be deserialized to its original type because the type could not be loaded.
             /// </summary>
             ExceptionTypeNotFound,
+
+            /// <summary>
+            /// An instance of an <see cref="Exception"/>-derived type was serialized as its base type because it did not have the <see cref="SerializableAttribute"/> applied.
+            /// </summary>
+            ExceptionNotSerializable,
+
+            /// <summary>
+            /// An <see cref="Exception"/>-derived type could not be deserialized because it was missing a deserializing constructor.
+            /// A base-type that <em>does</em> offer the constructor will be instantiated instead.
+            /// </summary>
+            ExceptionNotDeserializable,
         }
 
         /// <summary>

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync<TResult>(string! targetName, object? argument, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.NotifyAsync(string! targetName, object?[]? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object? argument, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? argumentDeclaredTypes) -> System.Threading.Tasks.Task!
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync(string! targetName, object?
 StreamJsonRpc.JsonRpc.InvokeWithParameterObjectAsync<TResult>(string! targetName, object? argument, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? argumentDeclaredTypes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
 StreamJsonRpc.JsonRpc.NotifyAsync(string! targetName, object?[]? arguments, System.Collections.Generic.IReadOnlyList<System.Type!>? argumentDeclaredTypes) -> System.Threading.Tasks.Task!
 StreamJsonRpc.JsonRpc.NotifyWithParameterObjectAsync(string! targetName, object? argument, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>? argumentDeclaredTypes) -> System.Threading.Tasks.Task!
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionTypeNotFound = 19 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpcProxyOptions.JsonRpcProxyOptions(StreamJsonRpc.JsonRpcProxyOptions! copyFrom) -> void
 StreamJsonRpc.JsonRpcTargetOptions.JsonRpcTargetOptions(StreamJsonRpc.JsonRpcTargetOptions! copyFrom) -> void

--- a/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
+++ b/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
@@ -3,12 +3,15 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
 
 public class CollectingTraceListener : TraceListener
 {
     private readonly StringBuilder lineInProgress = new StringBuilder();
 
     private readonly ImmutableList<string>.Builder messages = ImmutableList.CreateBuilder<string>();
+
+    private readonly ImmutableList<JsonRpc.TraceEvents>.Builder traceEventIds = ImmutableList.CreateBuilder<JsonRpc.TraceEvents>();
 
     public override bool IsThreadSafe => false;
 
@@ -23,7 +26,28 @@ public class CollectingTraceListener : TraceListener
         }
     }
 
+    public ImmutableList<JsonRpc.TraceEvents> Ids
+    {
+        get
+        {
+            lock (this.traceEventIds)
+            {
+                return this.traceEventIds.ToImmutable();
+            }
+        }
+    }
+
     public AsyncAutoResetEvent MessageReceived { get; } = new AsyncAutoResetEvent();
+
+    public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
+    {
+        lock (this.traceEventIds)
+        {
+            this.traceEventIds.Add((JsonRpc.TraceEvents)id);
+        }
+
+        base.TraceEvent(eventCache, source, eventType, id, message);
+    }
 
     public override void Write(string message) => this.lineInProgress.Append(message);
 

--- a/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
+++ b/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
@@ -39,6 +39,16 @@ public class CollectingTraceListener : TraceListener
 
     public AsyncAutoResetEvent MessageReceived { get; } = new AsyncAutoResetEvent();
 
+    public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string format, params object[] args)
+    {
+        lock (this.traceEventIds)
+        {
+            this.traceEventIds.Add((JsonRpc.TraceEvents)id);
+        }
+
+        base.TraceEvent(eventCache, source, eventType, id, format, args);
+    }
+
     public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
     {
         lock (this.traceEventIds)
@@ -47,6 +57,16 @@ public class CollectingTraceListener : TraceListener
         }
 
         base.TraceEvent(eventCache, source, eventType, id, message);
+    }
+
+    public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id)
+    {
+        lock (this.traceEventIds)
+        {
+            this.traceEventIds.Add((JsonRpc.TraceEvents)id);
+        }
+
+        base.TraceEvent(eventCache, source, eventType, id);
     }
 
     public override void Write(string message) => this.lineInProgress.Append(message);

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -402,6 +402,65 @@ public abstract class JsonRpcTests : TestBase
         }
     }
 
+    [Theory, PairwiseData]
+    public async Task CanCallAsyncMethodThatThrowsNonSerializableException(ExceptionProcessing exceptionStrategy)
+    {
+        this.clientRpc.AllowModificationWhileListening = true;
+        this.serverRpc.AllowModificationWhileListening = true;
+        this.clientRpc.ExceptionStrategy = exceptionStrategy;
+        this.serverRpc.ExceptionStrategy = exceptionStrategy;
+
+        RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsNonSerializableException)));
+        var errorData = Assert.IsType<CommonErrorData>(exception.DeserializedErrorData);
+        Assert.Equal(Server.ExceptionMessage, errorData.Message);
+
+        if (exceptionStrategy == ExceptionProcessing.ISerializable)
+        {
+            // The inner exception type should be the nearest base type that applies the [Serializable] attribute.
+            Exception inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal(Server.ExceptionMessage, inner.Message);
+        }
+
+        // Assert that the server logged a warning about the exception problem.
+        Assert.Contains(JsonRpc.TraceEvents.ExceptionNotSerializable, this.serverTraces.Ids);
+    }
+
+    [Theory, PairwiseData]
+    public async Task CanCallAsyncMethodThatThrowsExceptionWithoutDeserializingConstructor(ExceptionProcessing exceptionStrategy)
+    {
+        this.clientRpc.AllowModificationWhileListening = true;
+        this.serverRpc.AllowModificationWhileListening = true;
+        this.clientRpc.ExceptionStrategy = exceptionStrategy;
+        this.serverRpc.ExceptionStrategy = exceptionStrategy;
+
+        RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsAnExceptionWithoutDeserializingConstructor)));
+        var errorData = Assert.IsType<CommonErrorData>(exception.DeserializedErrorData);
+        Assert.Equal(Server.ExceptionMessage, errorData.Message);
+
+        if (exceptionStrategy == ExceptionProcessing.ISerializable)
+        {
+            // The inner exception type should be the nearest base type that declares the deserializing constructor.
+            Exception inner = Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal(Server.ExceptionMessage, inner.Message);
+        }
+
+        Assert.Contains(JsonRpc.TraceEvents.ExceptionNotDeserializable, this.clientTraces.Ids);
+    }
+
+    [Fact]
+    public async Task CanCallAsyncMethodThatThrowsExceptionWhileSerializingException()
+    {
+        this.clientRpc.AllowModificationWhileListening = true;
+        this.serverRpc.AllowModificationWhileListening = true;
+        this.clientRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
+        this.serverRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
+
+        RemoteInvocationException exception = await Assert.ThrowsAnyAsync<RemoteInvocationException>(() => this.clientRpc.InvokeAsync<string>(nameof(Server.AsyncMethodThatThrowsExceptionThatThrowsOnSerialization)));
+        Assert.Equal((int)JsonRpcErrorCode.ResponseSerializationFailure, exception.ErrorCode);
+        Assert.NotEqual(Server.ExceptionMessage, exception.Message);
+        Assert.Null(exception.InnerException);
+    }
+
     [Fact]
     public async Task CanCallOverloadedMethod()
     {
@@ -2289,6 +2348,15 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task NonSerializableExceptionInArgumentThrowsLocally()
+    {
+        // Synthesize an exception message that refers to an exception type that does not exist.
+        var exceptionToSend = new NonSerializableException(Server.ExceptionMessage);
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => this.clientRpc.InvokeWithCancellationAsync(nameof(Server.SendException), new[] { exceptionToSend }, new[] { typeof(Exception) }, this.TimeoutToken));
+        Assert.True(exception is JsonSerializationException || exception is MessagePackSerializationException);
+    }
+
+    [Fact]
     public void CancellationStrategy_ConfigurationLocked()
     {
         Assert.Throws<InvalidOperationException>(() => this.clientRpc.CancellationStrategy = null);
@@ -2832,6 +2900,24 @@ public abstract class JsonRpcTests : TestBase
             throw new Exception(ExceptionMessage);
         }
 
+        public async Task AsyncMethodThatThrowsNonSerializableException()
+        {
+            await Task.Yield();
+            throw new NonSerializableException(ExceptionMessage);
+        }
+
+        public async Task AsyncMethodThatThrowsExceptionThatThrowsOnSerialization()
+        {
+            await Task.Yield();
+            throw new ThrowOnSerializeException(ExceptionMessage);
+        }
+
+        public async Task AsyncMethodThatThrowsAnExceptionWithoutDeserializingConstructor()
+        {
+            await Task.Yield();
+            throw new ExceptionMissingDeserializingConstructor(ExceptionMessage);
+        }
+
         public Task<object> MethodThatReturnsTaskOfInternalClass()
         {
             var result = new Task<object>(() => new InternalClass());
@@ -3182,6 +3268,52 @@ public abstract class JsonRpcTests : TestBase
             }
 
             info.AddValue("ClassName", "My.NonExistentException");
+        }
+    }
+
+    /// <summary>
+    /// An exception that does <em>not</em> have a <see cref="SerializableAttribute"/> applied.
+    /// </summary>
+    private class NonSerializableException : InvalidOperationException
+    {
+        public NonSerializableException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An exception that throws while being serialized.
+    /// </summary>
+    [Serializable]
+    private class ThrowOnSerializeException : InvalidOperationException
+    {
+        public ThrowOnSerializeException(string message)
+            : base(message)
+        {
+        }
+
+        protected ThrowOnSerializeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            // Unlikely to ever be called since serialization throws, but complete the pattern so we test exactly what we mean to.
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new InvalidOperationException("This exception always throws when serialized.");
+        }
+    }
+
+    /// <summary>
+    /// An exception that throws while being serialized.
+    /// </summary>
+    [Serializable]
+    private class ExceptionMissingDeserializingConstructor : InvalidOperationException
+    {
+        public ExceptionMissingDeserializingConstructor(string message)
+            : base(message)
+        {
         }
     }
 


### PR DESCRIPTION
There were a few issues:
1. We didn't gracefully handle exception types that were missing the `[Serializable]` attribute. Now we log a warning and just write out `CommonErrorData`.
1. We didn't gracefully handle exception types that were missing the deserializing constructor. Now we log a warning and deserialize the nearest base type that _does_ conform to the serializable pattern.
1. We weren't even serializing *thrown* exceptions to JSON ourselves (newtonsoft.json was doing it) which means it wasn't treated as 'user data'. Now we serialize thrown exceptions with our own converter as user data.
1. Exceptions weren't serialized to include their assembly name, so unless the assembly was already loaded, we wouldn't be able to activate it. Now we artificially add `AssemblyName` as a property of the exception.
1. Even if exception's assembly were already loaded, unless it was loaded in the `From` load context it still wouldn't be found. That's still the case with this change, but if the assembly name is specified we'll load it into the `From` context automatically, assuming the CLR can find it.
1. Even if the assembly was loaded in the `From` context, if the assembly version of the transmitting side exceeded the assembly version on the receiving side, it wouldn't load properly. Now we fallback to allow an assembly _version_ mismatch (provided the name and public key token still match). We further fallback to any (loaded) assembly that defines a type with a matching full name.

Fixes #588 
See also DevDiv-1240018, #468