### PR TITLE
Fix TEventArgs serialization from events when using MessagePack and union types

### DIFF
--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -672,7 +672,7 @@ namespace StreamJsonRpc.Reflection
             private void OnEventRaisedGeneric<T>(object? sender, T args)
 #pragma warning restore CA1801 // Review unused parameters
             {
-                this.jsonRpc.NotifyAsync(this.rpcEventName, new object?[] { args }).Forget();
+                this.jsonRpc.NotifyAsync(this.rpcEventName, arguments: new object?[] { args }, argumentDeclaredTypes: new Type[] { typeof(T) }).Forget();
             }
 
             private void OnEventRaised(object? sender, EventArgs args)

--- a/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -374,7 +374,7 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
         this.serverMessageFormatter = new MessagePackFormatter();
         this.clientMessageFormatter = new MessagePackFormatter();
 
-        var options = MessagePackSerializerOptions.Standard
+        var options = MessagePackFormatter.DefaultUserDataSerializationOptions
             .WithResolver(CompositeResolver.Create(
                 new IMessagePackFormatter[] { new UnserializableTypeFormatter(), new TypeThrowsWhenDeserializedFormatter() },
                 new IFormatterResolver[] { StandardResolverAllowPrivate.Instance }));

--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -16,6 +16,8 @@
     <Compile Update="JsonRpcMessagePackLengthTests.cs" DependentUpon="JsonRpcTests.cs" />
     <Compile Update="AsyncEnumerableJsonTests.cs" DependentUpon="AsyncEnumerableTests.cs" />
     <Compile Update="AsyncEnumerableMessagePackTests.cs" DependentUpon="AsyncEnumerableTests.cs" />
+    <Compile Update="TargetObjectEventsJsonTests.cs" DependentUpon="TargetObjectEventsTests.cs" />
+    <Compile Update="TargetObjectEventsMessagePackTests.cs" DependentUpon="TargetObjectEventsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StreamJsonRpc.Tests.ExternalAssembly\StreamJsonRpc.Tests.ExternalAssembly.csproj" />

--- a/test/StreamJsonRpc.Tests/TargetObjectEventsJsonTests.cs
+++ b/test/StreamJsonRpc.Tests/TargetObjectEventsJsonTests.cs
@@ -1,0 +1,36 @@
+﻿using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class TargetObjectEventsJsonTests : TargetObjectEventsTests
+{
+    public TargetObjectEventsJsonTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        var clientFormatter = new JsonMessageFormatter
+        {
+            JsonSerializer =
+            {
+                Converters =
+                {
+                },
+            },
+        };
+
+        var serverFormatter = new JsonMessageFormatter
+        {
+            JsonSerializer =
+            {
+                Converters =
+                {
+                },
+            },
+        };
+
+        this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, serverFormatter);
+        this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, clientFormatter);
+    }
+}

--- a/test/StreamJsonRpc.Tests/TargetObjectEventsJsonTests.cs
+++ b/test/StreamJsonRpc.Tests/TargetObjectEventsJsonTests.cs
@@ -1,4 +1,7 @@
-﻿using StreamJsonRpc;
+﻿using System;
+using Microsoft;
+using Newtonsoft.Json;
+using StreamJsonRpc;
 using Xunit.Abstractions;
 
 public class TargetObjectEventsJsonTests : TargetObjectEventsTests
@@ -16,6 +19,7 @@ public class TargetObjectEventsJsonTests : TargetObjectEventsTests
             {
                 Converters =
                 {
+                    new IFruitConverter(),
                 },
             },
         };
@@ -26,11 +30,43 @@ public class TargetObjectEventsJsonTests : TargetObjectEventsTests
             {
                 Converters =
                 {
+                    new IFruitConverter(),
                 },
             },
         };
 
         this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, serverFormatter);
         this.clientMessageHandler = new HeaderDelimitedMessageHandler(this.clientStream, clientFormatter);
+    }
+
+    private class IFruitConverter : JsonConverter<IFruit?>
+    {
+        public override IFruit? ReadJson(JsonReader reader, Type objectType, IFruit? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            Assumes.True(reader.Read());
+            Assumes.True((string)reader.Value == nameof(IFruit.Name));
+            Assumes.True(reader.Read());
+            string name = (string)reader.Value;
+            return new Fruit(name);
+        }
+
+        public override void WriteJson(JsonWriter writer, IFruit? value, JsonSerializer serializer)
+        {
+            if (value is null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteStartObject();
+            writer.WritePropertyName(nameof(IFruit.Name));
+            writer.WriteValue(value.Name);
+            writer.WriteEndObject();
+        }
     }
 }

--- a/test/StreamJsonRpc.Tests/TargetObjectEventsMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/TargetObjectEventsMessagePackTests.cs
@@ -1,0 +1,29 @@
+﻿using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+using StreamJsonRpc;
+using Xunit.Abstractions;
+
+public class TargetObjectEventsMessagePackTests : TargetObjectEventsTests
+{
+    public TargetObjectEventsMessagePackTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    protected override void InitializeFormattersAndHandlers()
+    {
+        var serverMessageFormatter = new MessagePackFormatter();
+        var clientMessageFormatter = new MessagePackFormatter();
+
+        var options = MessagePackFormatter.DefaultUserDataSerializationOptions
+            .WithResolver(CompositeResolver.Create(
+                new IMessagePackFormatter[] { },
+                new IFormatterResolver[] { StandardResolverAllowPrivate.Instance }));
+        serverMessageFormatter.SetMessagePackSerializerOptions(options);
+        clientMessageFormatter.SetMessagePackSerializerOptions(options);
+
+        this.serverMessageHandler = new LengthHeaderMessageHandler(this.serverStream, this.serverStream, serverMessageFormatter);
+        this.clientMessageHandler = new LengthHeaderMessageHandler(this.clientStream, this.clientStream, clientMessageFormatter);
+    }
+}


### PR DESCRIPTION
- Use default options as basis for MessagePack tests
- Get event wire-up tests running with MessagePack and get them passing

    Previous to this the tests only ran on the JsonMessageFormatter. The tests failed on MessagePackFormatter because they were lacking a few formatters, one of which was customer impacting.
- Add type declaration when serializing TEventArgs type from server event.
  This enables use of `Union` attributes when using the MessagePack formatter.

    Fixes #612
