### PR TITLE
Fix InsertConfigValues variable for 4-integer pkg versions

### DIFF
--- a/azure-pipelines/variables/InsertConfigValues.ps1
+++ b/azure-pipelines/variables/InsertConfigValues.ps1
@@ -4,7 +4,7 @@ $dirsToSearch = "$BinPath\NuGet\*.nupkg","$BinPath\CoreXT\*.nupkg" |? { Test-Pat
 $icv=@()
 if ($dirsToSearch) {
     Get-ChildItem -Path $dirsToSearch |% {
-        if ($_.Name -match "^(.*)\.(\d+\.\d+\.\d+(?:-.*?)?)(?:\.symbols)?\.nupkg$") {
+        if ($_.Name -match "^(.*?)\.(\d+\.\d+\.\d+(?:\.\d+)?(?:-.*?)?)(?:\.symbols)?\.nupkg$") {
             $id = $Matches[1]
             $version = $Matches[2]
             $icv += "$id=$version"


### PR DESCRIPTION
This regressed in ab272a9d367400560bafaec77d62f9cd36ac4a51 when a 4th integer was added to the VSInsertionMetadata package.