### PR TITLE
Render named arguments in ETW events, including when using the MessagePack formatter

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1634,7 +1634,7 @@ namespace StreamJsonRpc
                     {
                         if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Verbose, System.Diagnostics.Tracing.EventKeywords.None))
                         {
-                            JsonRpcEventSource.Instance.SendingNotification(request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.SendingNotification(request.Method, JsonRpcEventSource.GetArgumentsString(request));
                         }
 
                         await this.TransmitAsync(request, cts.Token).ConfigureAwait(false);
@@ -1718,7 +1718,7 @@ namespace StreamJsonRpc
                     {
                         if (JsonRpcEventSource.Instance.IsEnabled(System.Diagnostics.Tracing.EventLevel.Verbose, System.Diagnostics.Tracing.EventKeywords.None))
                         {
-                            JsonRpcEventSource.Instance.SendingRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.SendingRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request));
                         }
 
                         await this.TransmitAsync(request, cts.Token).ConfigureAwait(false);
@@ -1862,11 +1862,11 @@ namespace StreamJsonRpc
                     {
                         if (request.IsResponseExpected)
                         {
-                            JsonRpcEventSource.Instance.ReceivedRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.ReceivedRequest(request.RequestId.NumberIfPossibleForEvent, request.Method, JsonRpcEventSource.GetArgumentsString(request));
                         }
                         else
                         {
-                            JsonRpcEventSource.Instance.ReceivedNotification(request.Method, JsonRpcEventSource.GetArgumentsString(request.Arguments));
+                            JsonRpcEventSource.Instance.ReceivedNotification(request.Method, JsonRpcEventSource.GetArgumentsString(request));
                         }
                     }
 

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -282,7 +282,7 @@ namespace StreamJsonRpc
             {
                 return string.Empty;
             }
-            else if (arguments is object[] args)
+            else if (arguments is object?[] args)
             {
                 var stringBuilder = new StringBuilder();
                 for (int i = 0; i < args.Length; ++i)
@@ -296,10 +296,10 @@ namespace StreamJsonRpc
 
                 return stringBuilder.ToString();
             }
-            else if (arguments is Dictionary<string, object> dict)
+            else if (arguments is IReadOnlyDictionary<string, object?> dict)
             {
                 var stringBuilder = new StringBuilder();
-                foreach (KeyValuePair<string, object> entry in dict)
+                foreach (KeyValuePair<string, object?> entry in dict)
                 {
                     stringBuilder.Append($"{entry.Key}: {entry.Value}, ");
                     if (stringBuilder.Length > maxLength)

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -278,18 +278,33 @@ namespace StreamJsonRpc
 
             const int maxLength = 128;
 
-            if (arguments is object?[] args)
+            if (arguments is null)
+            {
+                return string.Empty;
+            }
+            else if (arguments is object[] args)
             {
                 var stringBuilder = new StringBuilder();
-                if (args != null && args.Length > 0)
+                for (int i = 0; i < args.Length; ++i)
                 {
-                    for (int i = 0; i < args.Length; ++i)
+                    stringBuilder.Append($"arg{i}: {args[i]}, ");
+                    if (stringBuilder.Length > maxLength)
                     {
-                        stringBuilder.Append($"arg{i}: {args[i]}, ");
-                        if (stringBuilder.Length > maxLength)
-                        {
-                            return $"{stringBuilder.ToString(0, maxLength)}...(truncated)";
-                        }
+                        return $"{stringBuilder.ToString(0, maxLength)}...(truncated)";
+                    }
+                }
+
+                return stringBuilder.ToString();
+            }
+            else if (arguments is Dictionary<string, object> dict)
+            {
+                var stringBuilder = new StringBuilder();
+                foreach (KeyValuePair<string, object> entry in dict)
+                {
+                    stringBuilder.Append($"{entry.Key}: {entry.Value}, ");
+                    if (stringBuilder.Length > maxLength)
+                    {
+                        return $"{stringBuilder.ToString(0, maxLength)}...(truncated)";
                     }
                 }
 

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -3,7 +3,7 @@
 
 namespace StreamJsonRpc
 {
-    using System.Collections.Generic;
+    using System.Collections;
     using System.Diagnostics.Tracing;
     using System.Text;
     using StreamJsonRpc.Protocol;
@@ -296,15 +296,18 @@ namespace StreamJsonRpc
 
                 return stringBuilder.ToString();
             }
-            else if (arguments is IReadOnlyDictionary<string, object?> dict)
+            else if (arguments is IDictionary dict)
             {
                 var stringBuilder = new StringBuilder();
-                foreach (KeyValuePair<string, object?> entry in dict)
+                if (dict.Count > 0)
                 {
-                    stringBuilder.Append($"{entry.Key}: {entry.Value}, ");
-                    if (stringBuilder.Length > maxLength)
+                    foreach (var key in dict.Keys)
                     {
-                        return $"{stringBuilder.ToString(0, maxLength)}...(truncated)";
+                        stringBuilder.Append($"{key}: {dict[key]}, ");
+                        if (stringBuilder.Length > maxLength)
+                        {
+                            return $"{stringBuilder.ToString(0, maxLength)}...(truncated)";
+                        }
                     }
                 }
 

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -271,18 +271,14 @@ namespace StreamJsonRpc
         /// <returns>String representation of first argument only.</returns>
         internal static string GetArgumentsString(object? arguments)
         {
-            if (arguments == null)
+            if (arguments is null)
             {
                 return string.Empty;
             }
 
             const int maxLength = 128;
 
-            if (arguments is null)
-            {
-                return string.Empty;
-            }
-            else if (arguments is object?[] args)
+            if (arguments is object?[] args)
             {
                 var stringBuilder = new StringBuilder();
                 for (int i = 0; i < args.Length; ++i)

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -2148,6 +2148,8 @@ namespace StreamJsonRpc
 
             public override int ArgumentCount => this.MsgPackNamedArguments?.Count ?? this.MsgPackPositionalArguments?.Count ?? base.ArgumentCount;
 
+            public override IEnumerable<string>? ArgumentNames => this.MsgPackNamedArguments?.Keys;
+
             public ReadOnlySequence<byte> OriginalMessagePack { get; internal set; }
 
             internal ReadOnlySequence<byte> MsgPackArguments { get; set; }

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -161,6 +161,12 @@ namespace StreamJsonRpc.Protocol
         public IReadOnlyList<Type>? ArgumentListDeclaredTypes { get; set; }
 
         /// <summary>
+        /// Gets the sequence of argument names, if applicable.
+        /// </summary>
+        [IgnoreDataMember]
+        public virtual IEnumerable<string>? ArgumentNames => this.NamedArguments?.Keys;
+
+        /// <summary>
         /// Gets or sets the data for the <see href="https://www.w3.org/TR/trace-context/">W3C Trace Context</see> <c>traceparent</c> value.
         /// </summary>
         [DataMember(Name = "traceparent", EmitDefaultValue = false)]

--- a/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -31,3 +31,4 @@ StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? messag
 StreamJsonRpc.RequestId.RequestId() -> void
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
+virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -31,3 +31,4 @@ StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? messag
 StreamJsonRpc.RequestId.RequestId() -> void
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
+virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?


### PR DESCRIPTION
Presently, `JsonRpcEventSource.GetArgumentsString` prints dictionaries as ``System.Collections.Generic.Dictionary`2[System.String,System.Object]``, making `StreamJsonRpc/InboundCall` events unhelpful. Since `Dictionary<string, object>` seems like a case that would be generally useful when stringifying JSON objects, add special handling to `GetArgumentsString`.