### PR TITLE
Add support for top level properties and delegated dispatch

### DIFF
--- a/src/StreamJsonRpc/IJsonRpcMessageFactory.cs
+++ b/src/StreamJsonRpc/IJsonRpcMessageFactory.cs
@@ -5,12 +5,27 @@ namespace StreamJsonRpc
 {
     using StreamJsonRpc.Protocol;
 
+    /// <summary>
+    /// An interface that allows <see cref="IJsonRpcMessageFormatter"/> instances to offer custom types for <see cref="JsonRpcMessage"/> types.
+    /// </summary>
     public interface IJsonRpcMessageFactory
     {
+        /// <summary>
+        /// Creates an instance of <see cref="JsonRpcRequest"/> that may contain additional support such as top level properties.
+        /// </summary>
+        /// <returns>an instance of <see cref="JsonRpcRequest"/>.</returns>
         JsonRpcRequest CreateRequestMessage();
 
+        /// <summary>
+        /// Creates an instance of <see cref="JsonRpcError"/> that may contain additional support such as top level properties.
+        /// </summary>
+        /// <returns>an instance of <see cref="JsonRpcError"/>.</returns>
         JsonRpcError CreateErrorMessage();
 
+        /// <summary>
+        /// Creates an instance of <see cref="JsonRpcResult"/> that may contain additional support such as top level properties.
+        /// </summary>
+        /// <returns>an instance of <see cref="JsonRpcResult"/>.</returns>
         JsonRpcResult CreateResultMessage();
     }
 }

--- a/src/StreamJsonRpc/IJsonRpcMessageFactory.cs
+++ b/src/StreamJsonRpc/IJsonRpcMessageFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using StreamJsonRpc.Protocol;
+
+    public interface IJsonRpcMessageFactory
+    {
+        JsonRpcRequest CreateRequestMessage();
+
+        JsonRpcError CreateErrorMessage();
+
+        JsonRpcResult CreateResultMessage();
+    }
+}

--- a/src/StreamJsonRpc/Protocol/Constants.cs
+++ b/src/StreamJsonRpc/Protocol/Constants.cs
@@ -1,0 +1,64 @@
+﻿#pragma warning disable SA1303 // Const field names should begin with upper-case letter
+
+namespace StreamJsonRpc.Protocol
+{
+    using System;
+    using Microsoft;
+
+    internal static class Constants
+    {
+        internal const string jsonrpc = "jsonrpc";
+        internal const string id = "id";
+
+        internal static class Request
+        {
+            internal const string method = "method";
+            internal const string @params = "params";
+            internal const string traceparent = "traceparent";
+            internal const string tracestate = "tracestate";
+
+            internal static bool IsPropertyReserved(string propertyName)
+            {
+                Requires.NotNull(propertyName, nameof(propertyName));
+
+                return
+                    propertyName.Equals(jsonrpc, StringComparison.Ordinal) ||
+                    propertyName.Equals(method, StringComparison.Ordinal) ||
+                    propertyName.Equals(@params, StringComparison.Ordinal) ||
+                    propertyName.Equals(traceparent, StringComparison.Ordinal) ||
+                    propertyName.Equals(tracestate, StringComparison.Ordinal) ||
+                    propertyName.Equals(id, StringComparison.Ordinal);
+            }
+        }
+
+        internal static class Result
+        {
+            internal const string result = "result";
+
+            internal static bool IsPropertyReserved(string propertyName)
+            {
+                Requires.NotNull(propertyName, nameof(propertyName));
+
+                return
+                    propertyName.Equals(jsonrpc, StringComparison.Ordinal) ||
+                    propertyName.Equals(result, StringComparison.Ordinal) ||
+                    propertyName.Equals(id, StringComparison.Ordinal);
+            }
+        }
+
+        internal static class Error
+        {
+            internal const string error = "error";
+
+            internal static bool IsPropertyReserved(string propertyName)
+            {
+                Requires.NotNull(propertyName, nameof(propertyName));
+
+                return
+                    propertyName.Equals(jsonrpc, StringComparison.Ordinal) ||
+                    propertyName.Equals(error, StringComparison.Ordinal) ||
+                    propertyName.Equals(id, StringComparison.Ordinal);
+            }
+        }
+    }
+}

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -43,7 +43,7 @@ namespace StreamJsonRpc.Protocol
         /// </returns>
         public virtual bool TryGetTopLevelProperty<T>(string name, [MaybeNull] out T value)
         {
-            Requires.NotNull(name, nameof(name));
+            Requires.NotNullOrEmpty(name, nameof(name));
             value = default;
             return false;
         }
@@ -60,7 +60,7 @@ namespace StreamJsonRpc.Protocol
         /// </returns>
         public virtual bool TrySetTopLevelProperty<T>(string name, [MaybeNull] T value)
         {
-            Requires.NotNull(name, nameof(name));
+            Requires.NotNullOrEmpty(name, nameof(name));
             return false;
         }
     }

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -3,7 +3,12 @@
 
 namespace StreamJsonRpc.Protocol
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Collections.ObjectModel;
     using System.Runtime.Serialization;
+    using Microsoft;
 
     /// <summary>
     /// The base class for a JSON-RPC request or response.
@@ -14,11 +19,105 @@ namespace StreamJsonRpc.Protocol
     [KnownType(typeof(JsonRpcError))]
     public abstract class JsonRpcMessage
     {
+        private Dictionary<string, TypedValue>? extraTopLevelProperties;
+        private ReadOnlyDictionary<string, TypedValue>? readOnlyExtraTopLevelProperties;
+
         /// <summary>
         /// Gets or sets the version of the JSON-RPC protocol that this message conforms to.
         /// </summary>
         /// <value>Defaults to "2.0".</value>
         [DataMember(Name = "jsonrpc", Order = 0, IsRequired = true)]
         public string Version { get; set; } = "2.0";
+
+        /// <summary>
+        /// Gets a map of the extra top-level properties set with <see cref="SetTopLevelProperty{T}(string, T)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This map should not be used on incoming messages.
+        /// Use <see cref="TryGetTopLevelProperty{T}(string, out T)"/> to read such extra top-level properties.
+        /// </remarks>
+        public IReadOnlyDictionary<string, TypedValue> OutboundExtraTopLevelProperties
+        {
+            get
+            {
+                if (this.readOnlyExtraTopLevelProperties is null)
+                {
+                    if (this.extraTopLevelProperties?.Count > 0)
+                    {
+                        this.readOnlyExtraTopLevelProperties = new ReadOnlyDictionary<string, TypedValue>(this.extraTopLevelProperties);
+                    }
+                    else
+                    {
+                        return ImmutableDictionary<string, TypedValue>.Empty;
+                    }
+                }
+
+                return this.readOnlyExtraTopLevelProperties;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves a top-level property from an incoming message that is an extension to the JSON-RPC specification.
+        /// </summary>
+        /// <typeparam name="T">The type to deserialize the value as, if it is present.</typeparam>
+        /// <param name="name">The name of the top-level property.</param>
+        /// <param name="value">
+        /// Receives the deserialized value if the <see cref="IJsonRpcMessageFormatter"/> supports reading such properties
+        /// and the property is present in the message.
+        /// Otherwise, this parameter is set to its <see langword="default" /> value.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if the <see cref="IJsonRpcMessageFormatter"/> supports this extensibility
+        /// and the property was present on the message; otherwise <see langword="false" />.
+        /// </returns>
+        public virtual bool TryGetTopLevelProperty<T>(string name, out T? value)
+        {
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Sets a top-level property in the message that is an extension to JSON-RPC specification.
+        /// </summary>
+        /// <typeparam name="T">The type of value to be serialized.</typeparam>
+        /// <param name="name">The name of the property. This should <em>not</em> collide with any property defined by the JSON-RPC specification.</param>
+        /// <param name="value">The value for the property.</param>
+        public void SetTopLevelProperty<T>(string name, T? value)
+        {
+            Requires.NotNull(name, nameof(name));
+            this.extraTopLevelProperties ??= new(StringComparer.Ordinal);
+            this.extraTopLevelProperties[name] = new TypedValue(value, typeof(T));
+        }
+
+        /// <summary>
+        /// A value and its declared type.
+        /// </summary>
+        public struct TypedValue
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TypedValue"/> struct.
+            /// </summary>
+            /// <param name="value">The value.</param>
+            /// <param name="valueType">The declared type of the value.</param>
+            public TypedValue(object? value, Type valueType)
+            {
+                this.Value = value;
+                this.ValueType = valueType;
+            }
+
+            /// <summary>
+            /// Gets the value.
+            /// </summary>
+            public object? Value { get; }
+
+            /// <summary>
+            /// Gets the declared type of the value.
+            /// </summary>
+            /// <remarks>
+            /// This may not be the concrete type of <see cref="Value"/>, but is the type that the receiving side is expecting to deserialize.
+            /// When union types are involved, the declared type may be critical to successful deserialization, even if the concrete type is derived from this.
+            /// </remarks>
+            public Type? ValueType { get; }
+        }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -19,42 +19,12 @@ namespace StreamJsonRpc.Protocol
     [KnownType(typeof(JsonRpcError))]
     public abstract class JsonRpcMessage
     {
-        private Dictionary<string, TypedValue>? extraTopLevelProperties;
-        private ReadOnlyDictionary<string, TypedValue>? readOnlyExtraTopLevelProperties;
-
         /// <summary>
         /// Gets or sets the version of the JSON-RPC protocol that this message conforms to.
         /// </summary>
         /// <value>Defaults to "2.0".</value>
         [DataMember(Name = "jsonrpc", Order = 0, IsRequired = true)]
         public string Version { get; set; } = "2.0";
-
-        /// <summary>
-        /// Gets a map of the extra top-level properties set with <see cref="SetTopLevelProperty{T}(string, T)"/>.
-        /// </summary>
-        /// <remarks>
-        /// This map should not be used on incoming messages.
-        /// Use <see cref="TryGetTopLevelProperty{T}(string, out T)"/> to read such extra top-level properties.
-        /// </remarks>
-        public IReadOnlyDictionary<string, TypedValue> OutboundExtraTopLevelProperties
-        {
-            get
-            {
-                if (this.readOnlyExtraTopLevelProperties is null)
-                {
-                    if (this.extraTopLevelProperties?.Count > 0)
-                    {
-                        this.readOnlyExtraTopLevelProperties = new ReadOnlyDictionary<string, TypedValue>(this.extraTopLevelProperties);
-                    }
-                    else
-                    {
-                        return ImmutableDictionary<string, TypedValue>.Empty;
-                    }
-                }
-
-                return this.readOnlyExtraTopLevelProperties;
-            }
-        }
 
         /// <summary>
         /// Retrieves a top-level property from an incoming message that is an extension to the JSON-RPC specification.
@@ -82,42 +52,14 @@ namespace StreamJsonRpc.Protocol
         /// <typeparam name="T">The type of value to be serialized.</typeparam>
         /// <param name="name">The name of the property. This should <em>not</em> collide with any property defined by the JSON-RPC specification.</param>
         /// <param name="value">The value for the property.</param>
-        public void SetTopLevelProperty<T>(string name, T? value)
+        /// <returns>
+        /// <see langword="true" /> if the formatter supports setting top-level properties;
+        /// <see langword="false" /> otherwise.
+        /// </returns>
+        public virtual bool TrySetTopLevelProperty<T>(string name, T? value)
         {
             Requires.NotNull(name, nameof(name));
-            this.extraTopLevelProperties ??= new(StringComparer.Ordinal);
-            this.extraTopLevelProperties[name] = new TypedValue(value, typeof(T));
-        }
-
-        /// <summary>
-        /// A value and its declared type.
-        /// </summary>
-        public struct TypedValue
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="TypedValue"/> struct.
-            /// </summary>
-            /// <param name="value">The value.</param>
-            /// <param name="valueType">The declared type of the value.</param>
-            public TypedValue(object? value, Type valueType)
-            {
-                this.Value = value;
-                this.ValueType = valueType;
-            }
-
-            /// <summary>
-            /// Gets the value.
-            /// </summary>
-            public object? Value { get; }
-
-            /// <summary>
-            /// Gets the declared type of the value.
-            /// </summary>
-            /// <remarks>
-            /// This may not be the concrete type of <see cref="Value"/>, but is the type that the receiving side is expecting to deserialize.
-            /// When union types are involved, the declared type may be critical to successful deserialization, even if the concrete type is derived from this.
-            /// </remarks>
-            public Type? ValueType { get; }
+            return false;
         }
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -41,6 +41,9 @@ namespace StreamJsonRpc.Protocol
         /// <see langword="true" /> if the <see cref="IJsonRpcMessageFormatter"/> supports this extensibility
         /// and the property was present on the message; otherwise <see langword="false" />.
         /// </returns>
+        /// <exception cref="InvalidOperationException">May be thrown when called on an outbound message.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is reserved by the JSON-RPC spec.</exception>
         public virtual bool TryGetTopLevelProperty<T>(string name, [MaybeNull] out T value)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
@@ -58,6 +61,9 @@ namespace StreamJsonRpc.Protocol
         /// <see langword="true" /> if the formatter supports setting top-level properties;
         /// <see langword="false" /> otherwise.
         /// </returns>
+        /// <exception cref="InvalidOperationException">May be thrown when called on an inbound message.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is reserved by the JSON-RPC spec.</exception>
         public virtual bool TrySetTopLevelProperty<T>(string name, [MaybeNull] T value)
         {
             Requires.NotNullOrEmpty(name, nameof(name));

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -7,6 +7,7 @@ namespace StreamJsonRpc.Protocol
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Serialization;
     using Microsoft;
 
@@ -40,8 +41,9 @@ namespace StreamJsonRpc.Protocol
         /// <see langword="true" /> if the <see cref="IJsonRpcMessageFormatter"/> supports this extensibility
         /// and the property was present on the message; otherwise <see langword="false" />.
         /// </returns>
-        public virtual bool TryGetTopLevelProperty<T>(string name, out T? value)
+        public virtual bool TryGetTopLevelProperty<T>(string name, [MaybeNull] out T value)
         {
+            Requires.NotNull(name, nameof(name));
             value = default;
             return false;
         }
@@ -56,7 +58,7 @@ namespace StreamJsonRpc.Protocol
         /// <see langword="true" /> if the formatter supports setting top-level properties;
         /// <see langword="false" /> otherwise.
         /// </returns>
-        public virtual bool TrySetTopLevelProperty<T>(string name, T? value)
+        public virtual bool TrySetTopLevelProperty<T>(string name, [MaybeNull] T value)
         {
             Requires.NotNull(name, nameof(name));
             return false;

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -16,7 +16,10 @@ namespace StreamJsonRpc
     using Newtonsoft.Json.Linq;
     using StreamJsonRpc.Protocol;
 
-    internal sealed class TargetMethod
+    /// <summary>
+    /// Represents the dispatch target of an incoming request.
+    /// </summary>
+    public sealed class TargetMethod
     {
         private readonly JsonRpcRequest request;
         private readonly object? target;

--- a/src/StreamJsonRpc/Resources.Designer.cs
+++ b/src/StreamJsonRpc/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace StreamJsonRpc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -259,6 +259,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation is only appropriate for inbound messages..
+        /// </summary>
+        internal static string InboundMessageOnly {
+            get {
+                return ResourceManager.GetString("InboundMessageOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This operation is not allowed after listening for messages has started..
         /// </summary>
         internal static string InvalidAfterListenHasStarted {
@@ -367,6 +376,15 @@ namespace StreamJsonRpc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation is only appropriate for outbound messages..
+        /// </summary>
+        internal static string OutboundMessageOnly {
+            get {
+                return ResourceManager.GetString("OutboundMessageOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameter is not in the form of a single object.
         /// </summary>
         internal static string ParameterNotObject {
@@ -426,6 +444,15 @@ namespace StreamJsonRpc {
         internal static string RequiredArgumentMissing {
             get {
                 return ResourceManager.GetString("RequiredArgumentMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This property name is reserved by the JSON-RPC spec or this library..
+        /// </summary>
+        internal static string ReservedPropertyName {
+            get {
+                return ResourceManager.GetString("ReservedPropertyName", resourceCulture);
             }
         }
         
@@ -651,6 +678,15 @@ namespace StreamJsonRpc {
         internal static string UnsupportedPropertiesOnClientProxyInterface {
             get {
                 return ResourceManager.GetString("UnsupportedPropertiesOnClientProxyInterface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation can only be performed once on this object..
+        /// </summary>
+        internal static string UsableOnceOnly {
+            get {
+                return ResourceManager.GetString("UsableOnceOnly", resourceCulture);
             }
         }
     }

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -193,6 +193,9 @@
   <data name="HeaderValueTooLarge" xml:space="preserve">
     <value>The size of the message header exceeds the maximum supported size.</value>
   </data>
+  <data name="InboundMessageOnly" xml:space="preserve">
+    <value>This operation is only appropriate for inbound messages.</value>
+  </data>
   <data name="InvalidAfterListenHasStarted" xml:space="preserve">
     <value>This operation is not allowed after listening for messages has started.</value>
   </data>
@@ -232,6 +235,9 @@
   <data name="NotSupportedWithoutMultiplexingStream" xml:space="preserve">
     <value>Out of band streams/pipes are not supported in this configuration. Have you set a MultiplexingStream on the formatter?</value>
   </data>
+  <data name="OutboundMessageOnly" xml:space="preserve">
+    <value>This operation is only appropriate for outbound messages.</value>
+  </data>
   <data name="ParameterNotObject" xml:space="preserve">
     <value>Parameter is not in the form of a single object</value>
   </data>
@@ -253,6 +259,9 @@
   </data>
   <data name="RequiredArgumentMissing" xml:space="preserve">
     <value>An argument was not supplied for a required parameter.</value>
+  </data>
+  <data name="ReservedPropertyName" xml:space="preserve">
+    <value>This property name is reserved by the JSON-RPC spec or this library.</value>
   </data>
   <data name="ResponseIsNotError" xml:space="preserve">
     <value>Response is not error.</value>
@@ -338,5 +347,8 @@
   </data>
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>
+  </data>
+  <data name="UsableOnceOnly" xml:space="preserve">
+    <value>This operation can only be performed once on this object.</value>
   </data>
 </root>

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -24,6 +24,13 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
+StreamJsonRpc.Protocol.JsonRpcMessage.OutboundExtraTopLevelProperties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue>!
+StreamJsonRpc.Protocol.JsonRpcMessage.SetTopLevelProperty<T>(string! name, T? value) -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue() -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue(object? value, System.Type! valueType) -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.Value.get -> object?
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.ValueType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
@@ -34,4 +41,5 @@ StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+override StreamJsonRpc.TargetMethod.ToString() -> string!
 static StreamJsonRpc.CorrelationManagerTracingStrategy.TraceState.get -> string?
 static StreamJsonRpc.CorrelationManagerTracingStrategy.TraceState.set -> void
 StreamJsonRpc.ActivityTracingStrategy
@@ -29,6 +30,8 @@ StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.set -> void
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RequestId.RequestId() -> void
+StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
+virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -17,6 +17,10 @@ StreamJsonRpc.ExceptionProcessing.ISerializable = 1 -> StreamJsonRpc.ExceptionPr
 StreamJsonRpc.IActivityTracingStrategy
 StreamJsonRpc.IActivityTracingStrategy.ApplyInboundActivity(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> System.IDisposable?
 StreamJsonRpc.IActivityTracingStrategy.ApplyOutboundActivity(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> void
+StreamJsonRpc.IJsonRpcMessageFactory
+StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
@@ -24,13 +28,6 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
-StreamJsonRpc.Protocol.JsonRpcMessage.OutboundExtraTopLevelProperties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue>!
-StreamJsonRpc.Protocol.JsonRpcMessage.SetTopLevelProperty<T>(string! name, T? value) -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue() -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue(object? value, System.Type! valueType) -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.Value.get -> object?
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.ValueType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
@@ -42,4 +39,5 @@ virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(S
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
 virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T? value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -38,6 +38,6 @@ StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
-virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
-virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T? value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -21,12 +21,18 @@ StreamJsonRpc.IJsonRpcMessageFactory
 StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
+StreamJsonRpc.JsonMessageFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.JsonMessageFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.JsonMessageFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.MessagePackFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.MessagePackFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.MessagePackFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void

--- a/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -21,18 +21,12 @@ StreamJsonRpc.IJsonRpcMessageFactory
 StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
-StreamJsonRpc.JsonMessageFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
-StreamJsonRpc.JsonMessageFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
-StreamJsonRpc.JsonMessageFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
-StreamJsonRpc.MessagePackFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
-StreamJsonRpc.MessagePackFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
-StreamJsonRpc.MessagePackFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -24,6 +24,13 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
+StreamJsonRpc.Protocol.JsonRpcMessage.OutboundExtraTopLevelProperties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue>!
+StreamJsonRpc.Protocol.JsonRpcMessage.SetTopLevelProperty<T>(string! name, T? value) -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue() -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue(object? value, System.Type! valueType) -> void
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.Value.get -> object?
+StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.ValueType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
@@ -34,4 +41,5 @@ StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+override StreamJsonRpc.TargetMethod.ToString() -> string!
 static StreamJsonRpc.CorrelationManagerTracingStrategy.TraceState.get -> string?
 static StreamJsonRpc.CorrelationManagerTracingStrategy.TraceState.set -> void
 StreamJsonRpc.ActivityTracingStrategy
@@ -29,6 +30,8 @@ StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.set -> void
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RequestId.RequestId() -> void
+StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
+virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -17,6 +17,10 @@ StreamJsonRpc.ExceptionProcessing.ISerializable = 1 -> StreamJsonRpc.ExceptionPr
 StreamJsonRpc.IActivityTracingStrategy
 StreamJsonRpc.IActivityTracingStrategy.ApplyInboundActivity(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> System.IDisposable?
 StreamJsonRpc.IActivityTracingStrategy.ApplyOutboundActivity(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> void
+StreamJsonRpc.IJsonRpcMessageFactory
+StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
@@ -24,13 +28,6 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
-StreamJsonRpc.Protocol.JsonRpcMessage.OutboundExtraTopLevelProperties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue>!
-StreamJsonRpc.Protocol.JsonRpcMessage.SetTopLevelProperty<T>(string! name, T? value) -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue() -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.TypedValue(object? value, System.Type! valueType) -> void
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.Value.get -> object?
-StreamJsonRpc.Protocol.JsonRpcMessage.TypedValue.ValueType.get -> System.Type?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
@@ -42,4 +39,5 @@ virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(S
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
 virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T? value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -38,6 +38,6 @@ StreamJsonRpc.TargetMethod
 virtual StreamJsonRpc.CorrelationManagerTracingStrategy.GetInboundActivityName(StreamJsonRpc.Protocol.JsonRpcRequest! request) -> string?
 virtual StreamJsonRpc.JsonRpc.DispatchRequestAsync(StreamJsonRpc.Protocol.JsonRpcRequest! request, StreamJsonRpc.TargetMethod! targetMethod, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<StreamJsonRpc.Protocol.JsonRpcMessage!>
 virtual StreamJsonRpc.JsonRpc.LoadType(string! typeFullName, string? assemblyName) -> System.Type?
-virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T? value) -> bool
-virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T? value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TryGetTopLevelProperty<T>(string! name, out T value) -> bool
+virtual StreamJsonRpc.Protocol.JsonRpcMessage.TrySetTopLevelProperty<T>(string! name, T value) -> bool
 virtual StreamJsonRpc.Protocol.JsonRpcRequest.ArgumentNames.get -> System.Collections.Generic.IEnumerable<string!>?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -21,12 +21,18 @@ StreamJsonRpc.IJsonRpcMessageFactory
 StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
+StreamJsonRpc.JsonMessageFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.JsonMessageFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.JsonMessageFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.MessagePackFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
+StreamJsonRpc.MessagePackFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
+StreamJsonRpc.MessagePackFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -21,18 +21,12 @@ StreamJsonRpc.IJsonRpcMessageFactory
 StreamJsonRpc.IJsonRpcMessageFactory.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
 StreamJsonRpc.IJsonRpcMessageFactory.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
-StreamJsonRpc.JsonMessageFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
-StreamJsonRpc.JsonMessageFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
-StreamJsonRpc.JsonMessageFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.get -> StreamJsonRpc.IActivityTracingStrategy?
 StreamJsonRpc.JsonRpc.ActivityTracingStrategy.set -> void
 StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
-StreamJsonRpc.MessagePackFormatter.CreateErrorMessage() -> StreamJsonRpc.Protocol.JsonRpcError!
-StreamJsonRpc.MessagePackFormatter.CreateRequestMessage() -> StreamJsonRpc.Protocol.JsonRpcRequest!
-StreamJsonRpc.MessagePackFormatter.CreateResultMessage() -> StreamJsonRpc.Protocol.JsonRpcResult!
 StreamJsonRpc.Protocol.JsonRpcErrorCode.InvocationErrorWithException = -32004 -> StreamJsonRpc.Protocol.JsonRpcErrorCode
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void

--- a/src/StreamJsonRpc/xlf/Resources.cs.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Konfigurace je zamknutá, protože tento formátovací modul už je přidružený k instanci JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC nesmí být null.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Proudy nebo kanály mimo pásmo nejsou v této konfiguraci podporované. Nastavili jste ve formátovacím modulu MultiplexingStream?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Bylo dosaženo konce streamu.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Připojení přenosu již bylo navázáno.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Chyba při zápisu zprávy JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.de.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Die Konfiguration ist gesperrt, weil dieser Formatierer bereits einer JsonRpc-Instanz zugeordnet wurde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">Der JSON-RPC darf nicht NULL sein.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Out-of-Band-Streams/-Pipes werden in dieser Konfiguration nicht unterstützt. Haben Sie einen MultiplexingStream für den Formatierer festgelegt?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Das Ende des Datenstroms wurde erreicht.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Die Relayverbindung wurde bereits eingerichtet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Fehler beim Schreiben der JSON-RPC-Nachricht: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.es.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">La configuración está bloqueada porque este formateador ya se ha asociado a una instancia de JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC no debe ser NULL.</target>
@@ -92,6 +97,11 @@
         <target state="translated">No se admiten los flujos o canalizaciones fuera de banda en esta configuración. ¿Ha establecido un elemento MultiplexingStream en el formateador?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Se alcanzó el final de la secuencia.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Ya se ha establecido la conexión de retransmisión.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Error al escribir el mensaje de JSON RPC: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.fr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">La configuration est verrouillée, car ce formateur a déjà été associé à une instance JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC ne doit pas être Null.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Les flux/canaux hors bande ne sont pas pris en charge dans cette configuration. Avez-vous défini un MultiplexingStream sur le formateur ?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Fin de flux atteinte.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">La connexion au relais a déjà été établie.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Erreur lors de l'écriture du message RPC JSON : {0} : {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.it.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">La configurazione è bloccata perché questo formattatore è già stato associato a un'istanza di JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">La RPC JSON non deve essere Null.</target>
@@ -92,6 +97,11 @@
         <target state="translated">I flussi e/o le pipe fuori banda non sono supportati in questa configurazione. È stato impostato un elemento MultiplexingStream sul formattatore?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">È stata raggiunta la fine del flusso.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">La connessione di inoltro è già stata stabilita.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Si è verificato un errore durante la scrittura del messaggio della RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ja.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">このフォーマッタは既に JsonRpc インスタンスに関連付けられているため、構成はロックされています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC は null にできません。</target>
@@ -92,6 +97,11 @@
         <target state="translated">帯域外のストリームやパイプはこの構成ではサポートされていません。フォーマッタに MultiplexingStream を設定しましたか?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">ストリームの終わりに達しました。</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">リレー接続は既に確立されています。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC メッセージの書き込み時のエラー: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ko.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">이 포맷터가 이미 JsonRpc 인스턴스와 연결되어 있기 때문에 구성이 잠겼습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC는 null이면 안 됩니다.</target>
@@ -92,6 +97,11 @@
         <target state="translated">이 구성에서는 대역 외 스트림/파이프가 지원되지 않습니다. 포맷터에 MultiplexingStream을 설정하셨습니까?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">스트림 끝에 도달했습니다.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">릴레이 연결이 이미 설정되었습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC 메시지를 쓰는 동안 오류 발생: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.pl.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Konfiguracja jest zablokowana, ponieważ ten program formatujący został już skojarzony z wystąpieniem JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">Wywołanie JSON RPC nie może mieć wartości null.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Strumienie/potoki poza pasmem nie są obsługiwane w tej konfiguracji. Czy element MultiplexingStream został ustawiony w programie formatującym?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Osiągnięto koniec strumienia.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Połączenie przekazywania zostało już ustanowione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Błąd zapisywania komunikatu JSON zdalnego wywołania procedury: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">A configuração está bloqueada porque este formatador já foi associado a uma instância de JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">O RPC de JSON não deve ser nulo.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Não há suporte para fluxos ou pipes fora de banda nesta configuração. Você definiu um MultiplexingStream no formatador?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Fim do fluxo alcançado.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">A conexão de retransmissão já foi estabelecida.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Erro ao gravar a Mensagem da RPC do JSON: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.ru.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Конфигурация заблокирована, так как этот модуль форматирования уже связан с экземпляром JsonRpc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">RPC JSON не должен равняться NULL.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Потоки или каналы, находящиеся вне диапазона, не поддерживаются в этой конфигурации. Вы установили MultiplexingStream для модуля форматирования?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Достигнут конец потока.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Подключение к ретрансляции уже установлено.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">Произошла ошибка при записи сообщения RPC JSON. {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.tr.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Bu biçimlendirici bir JsonRpc örneğiyle zaten ilişkili olduğundan yapılandırma kilitli.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC null olmamalıdır.</target>
@@ -92,6 +97,11 @@
         <target state="translated">Bu yapılandırmada bant dışı akışlar/yöneltmeler desteklenmiyor. Biçimlendirici üzerinde bir MultiplexingStream ayarladınız mı?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">Akışın sonuna ulaşıldı.</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">Geçiş bağlantısı zaten kuruldu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">JSON RPC İletisi yazılırken bir hata oluştu: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">配置已锁定，因为此格式化程序已与 JsonRpc 实例关联。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC 不得为 null。</target>
@@ -92,6 +97,11 @@
         <target state="translated">此配置中不支持带外流/管道。是否在格式化程序上设置了 MultiplexingStream?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">已达到流结尾。</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">已建立中继连接。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">写入 JSON RPC 消息时出错: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
+++ b/src/StreamJsonRpc/xlf/Resources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">設定已鎖定，因為這個格式器已經與 JsonRpc 執行個體建立關聯。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InboundMessageOnly">
+        <source>This operation is only appropriate for inbound messages.</source>
+        <target state="new">This operation is only appropriate for inbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonRpcCannotBeNull" translate="yes" xml:space="preserve">
         <source>JSON RPC must not be null.</source>
         <target state="translated">JSON RPC 不得為 Null。</target>
@@ -92,6 +97,11 @@
         <target state="translated">此設定不支援頻外資料流/管道。要在格式器上設定 MultiplexingStream 嗎?</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutboundMessageOnly">
+        <source>This operation is only appropriate for outbound messages.</source>
+        <target state="new">This operation is only appropriate for outbound messages.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReachedEndOfStream" translate="yes" xml:space="preserve">
         <source>Reached end of stream.</source>
         <target state="translated">已到達資料流結尾。</target>
@@ -105,6 +115,11 @@
       <trans-unit id="RelayAlreadySet">
         <source>Relay connection has already been established.</source>
         <target state="translated">已建立轉送連線。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReservedPropertyName">
+        <source>This property name is reserved by the JSON-RPC spec or this library.</source>
+        <target state="new">This property name is reserved by the JSON-RPC spec or this library.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseIsNotError" translate="yes" xml:space="preserve">
@@ -331,6 +346,11 @@
         <source>Error writing JSON RPC Message: {0}: {1}</source>
         <target state="translated">寫入 JSON RPC 訊息時發生錯誤: {0}: {1}</target>
         <note from="MultilingualBuild" annotates="source" priority="2">{0} is the exception type, {1} is the exception message.</note>
+      </trans-unit>
+      <trans-unit id="UsableOnceOnly">
+        <source>This operation can only be performed once on this object.</source>
+        <target state="new">This operation can only be performed once on this object.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -230,6 +230,40 @@ public class JsonMessageFormatterTests : TestBase
         Assert.Equal("2019-01-29T03:37:28.4433841Z", value);
     }
 
+    [Fact]
+    public void TopLevelPropertiesCanBeSerialized()
+    {
+        var formatter = new JsonMessageFormatter();
+        var jsonRequest = formatter.CreateRequestMessage();
+        Assert.NotNull(jsonRequest);
+
+        jsonRequest.Method = "test";
+        Assert.True(jsonRequest.TrySetTopLevelProperty("testProperty", "testValue"));
+
+        var messageJsonObject = formatter.Serialize(jsonRequest);
+        var jsonMessage = (JsonRpcRequest)formatter.Deserialize(messageJsonObject);
+
+        Assert.True(jsonMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+    }
+
+    [Fact]
+    public void TopLevelPropertiesWithNullValue()
+    {
+        var formatter = new JsonMessageFormatter();
+        var jsonRequest = formatter.CreateRequestMessage();
+        Assert.NotNull(jsonRequest);
+
+        jsonRequest.Method = "test";
+        Assert.True(jsonRequest.TrySetTopLevelProperty<string?>("testProperty", null));
+
+        var messageJsonObject = formatter.Serialize(jsonRequest);
+        var jsonMessage = (JsonRpcRequest)formatter.Deserialize(messageJsonObject);
+
+        Assert.True(jsonMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Null(value);
+    }
+
     private static long MeasureLength(JsonRpcRequest msg, JsonMessageFormatter formatter)
     {
         var builder = new Sequence<byte>();

--- a/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -234,7 +234,7 @@ public class JsonMessageFormatterTests : TestBase
     public void TopLevelPropertiesCanBeSerialized()
     {
         var formatter = new JsonMessageFormatter();
-        var jsonRequest = formatter.CreateRequestMessage();
+        var jsonRequest = ((IJsonRpcMessageFactory)formatter).CreateRequestMessage();
         Assert.NotNull(jsonRequest);
 
         jsonRequest.Method = "test";
@@ -252,10 +252,38 @@ public class JsonMessageFormatterTests : TestBase
     }
 
     [Fact]
+    public void TopLevelPropertiesCanBeSerializedInError()
+    {
+        var formatter = new JsonMessageFormatter();
+        var jsonError = ((IJsonRpcMessageFactory)formatter).CreateErrorMessage();
+        jsonError.Error = new JsonRpcError.ErrorDetail() { Message = "test" };
+
+        Assert.True(jsonError.TrySetTopLevelProperty("testProperty", "testValue"));
+
+        var messageJsonObject = formatter.Serialize(jsonError);
+        var jsonMessage = (JsonRpcError)formatter.Deserialize(messageJsonObject);
+
+        Assert.True(jsonMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+    }
+
+    [Fact]
+    public void TopLevelPropertiesCanBeSerializedInResult()
+    {
+        var formatter = new JsonMessageFormatter();
+        var jsonResult = ((IJsonRpcMessageFactory)formatter).CreateResultMessage();
+        Assert.True(jsonResult.TrySetTopLevelProperty("testProperty", "testValue"));
+        var messageJsonObject = formatter.Serialize(jsonResult);
+        var jsonMessage = (JsonRpcResult)formatter.Deserialize(messageJsonObject);
+        Assert.True(jsonMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+    }
+
+    [Fact]
     public void TopLevelPropertiesWithNullValue()
     {
         var formatter = new JsonMessageFormatter();
-        var jsonRequest = formatter.CreateRequestMessage();
+        var jsonRequest = ((IJsonRpcMessageFactory)formatter).CreateRequestMessage();
         Assert.NotNull(jsonRequest);
 
         jsonRequest.Method = "test";

--- a/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -239,12 +239,16 @@ public class JsonMessageFormatterTests : TestBase
 
         jsonRequest.Method = "test";
         Assert.True(jsonRequest.TrySetTopLevelProperty("testProperty", "testValue"));
+        Assert.True(jsonRequest.TrySetTopLevelProperty("objectProperty", new CustomType() { Age = 25 }));
 
         var messageJsonObject = formatter.Serialize(jsonRequest);
         var jsonMessage = (JsonRpcRequest)formatter.Deserialize(messageJsonObject);
 
         Assert.True(jsonMessage.TryGetTopLevelProperty("testProperty", out string? value));
         Assert.Equal("testValue", value);
+
+        Assert.True(jsonMessage.TryGetTopLevelProperty("objectProperty", out CustomType? customObject));
+        Assert.Equal(25, customObject?.Age);
     }
 
     [Fact]
@@ -273,5 +277,10 @@ public class JsonMessageFormatterTests : TestBase
         Assert.Equal(msg.Method, readMsg.Method);
 
         return length;
+    }
+
+    public class CustomType
+    {
+        public int Age { get; set; }
     }
 }

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcDelegatedDispatchTests : TestBase
+{
+    private readonly Server server;
+    private readonly DelegatedJsonRpc clientRpc;
+    private readonly DelegatedJsonRpc serverRpc;
+
+    public JsonRpcDelegatedDispatchTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.server = new Server();
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+
+        this.clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        this.serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2), this.server);
+
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Information);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Information);
+
+        this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+
+        this.clientRpc.StartListening();
+        this.serverRpc.StartListening();
+    }
+
+    [Fact]
+    public async Task DispatchRequestIsPassedCorrectTypeOfRequest()
+    {
+        await this.clientRpc.InvokeAsync<string>(nameof(Server.TestMethodAsync));
+        Assert.Equal("StreamJsonRpc.JsonMessageFormatter+JsonRpcRequest", this.serverRpc.LastRequestDispatched?.GetType().FullName);
+    }
+
+    [Fact]
+    public async Task DelegatedDispatcherCanDispatchInReverseOrder()
+    {
+        this.serverRpc.EnableBuffering = true;
+
+        var totalCallCount = 10;
+        var taskList = new List<Task<int>>();
+
+        for (int i = 0; i < totalCallCount; i++)
+        {
+            taskList.Add(this.clientRpc.InvokeAsync<int>(nameof(Server.GetCallCountAsync)));
+        }
+
+        await this.serverRpc.FlushRequestQueueAsync(totalCallCount);
+
+        for (int i = 0; i < totalCallCount; i++)
+        {
+            var result = await taskList[i];
+            Assert.Equal(totalCallCount - i, result);
+        }
+    }
+
+#pragma warning disable CA1801 // use all parameters
+    public class Server
+    {
+        private int callCounter = 0;
+
+        public Task TestMethodAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<int> GetCallCountAsync()
+        {
+            int currentCount = Interlocked.Increment(ref this.callCounter);
+            return Task.FromResult(currentCount);
+        }
+
+        public Task MethodThatThrowsAsync()
+        {
+            throw new InvalidProgramException();
+        }
+    }
+
+    public class DelegatedJsonRpc : JsonRpc
+    {
+        private List<(TaskCompletionSource<bool>, Task<JsonRpcMessage>)> requestSignalQueue = new List<(TaskCompletionSource<bool>, Task<JsonRpcMessage>)>();
+
+        public DelegatedJsonRpc(IJsonRpcMessageHandler handler)
+            : base(handler)
+        {
+        }
+
+        public DelegatedJsonRpc(IJsonRpcMessageHandler handler, object target)
+            : base(handler, target)
+        {
+        }
+
+        public bool EnableBuffering { get; set; }
+
+        public JsonRpcRequest? LastRequestDispatched { get; private set; }
+
+        public async Task FlushRequestQueueAsync(int expectedCount)
+        {
+            while (this.requestSignalQueue.Count != expectedCount)
+            {
+                await Task.Delay(100);
+            }
+
+            // For test purposes, lets dispatch messages in reverse order
+            this.requestSignalQueue.Reverse();
+            foreach (var entry in this.requestSignalQueue)
+            {
+                entry.Item1.SetResult(true);
+                await entry.Item2;
+            }
+
+            this.requestSignalQueue.Clear();
+        }
+
+        protected override async ValueTask<JsonRpcMessage> DispatchRequestAsync(JsonRpcRequest request, TargetMethod targetMethod, CancellationToken cancellationToken)
+        {
+            this.LastRequestDispatched = request;
+
+            TaskCompletionSource<JsonRpcMessage>? completionTcs = null;
+            if (this.EnableBuffering)
+            {
+                TaskCompletionSource<bool> signalTask = new TaskCompletionSource<bool>();
+                completionTcs = new TaskCompletionSource<JsonRpcMessage>();
+                this.requestSignalQueue.Add((signalTask, completionTcs.Task));
+
+                await signalTask.Task;
+            }
+
+            JsonRpcMessage result = await base.DispatchRequestAsync(request, targetMethod, cancellationToken);
+            completionTcs?.SetResult(result);
+            return result;
+        }
+    }
+
+#pragma warning restore CA1801 // use all parameters
+}

--- a/test/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
@@ -77,7 +77,7 @@ public class JsonRpcRemoteTargetTests : InteropTestBase
     public async Task CanNotifyOnRemoteTargetServer()
     {
         await this.originRpc.NotifyAsync(nameof(RemoteTargetOne.GetOne));
-        var result = await RemoteTargetOne.NotificationReceived;
+        var result = await RemoteTargetOne.NotificationReceived.WithCancellation(this.TimeoutToken);
         Assert.Equal(1, result);
     }
 
@@ -92,7 +92,7 @@ public class JsonRpcRemoteTargetTests : InteropTestBase
     public async Task CanNotifyOnOriginServer()
     {
         await this.remoteRpc1.NotifyAsync(nameof(OriginTarget.GetTwo));
-        var result = await OriginTarget.NotificationReceived;
+        var result = await OriginTarget.NotificationReceived.WithCancellation(this.TimeoutToken);
         Assert.Equal(2, result);
     }
 

--- a/test/StreamJsonRpc.Tests/JsonRpcWithMessageFactoryTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcWithMessageFactoryTests.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JsonRpcWithMessageFactoryTests : TestBase
+{
+    private readonly Server server;
+    private readonly IJsonRpcMessageHandler clientMessageHandler;
+    private readonly IJsonRpcMessageHandler serverMessageHandler;
+    private readonly MessageFormatterWithMessageFactory clientMessageFormatter;
+    private readonly MessageFormatterWithMessageFactory serverMessageFormatter;
+    private readonly JsonRpc clientRpc;
+    private readonly JsonRpc serverRpc;
+
+    public JsonRpcWithMessageFactoryTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.server = new Server();
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+
+        this.clientMessageFormatter = new MessageFormatterWithMessageFactory();
+        this.clientMessageHandler = new HeaderDelimitedMessageHandler(streams.Item1, streams.Item1, this.clientMessageFormatter);
+
+        this.serverMessageFormatter = new MessageFormatterWithMessageFactory();
+        this.serverMessageHandler = new HeaderDelimitedMessageHandler(streams.Item2, streams.Item2, this.serverMessageFormatter);
+
+        this.clientRpc = new JsonRpc(this.clientMessageHandler);
+        this.serverRpc = new JsonRpc(this.serverMessageHandler, this.server);
+
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Information);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Information);
+
+        this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+
+        this.clientRpc.StartListening();
+        this.serverRpc.StartListening();
+    }
+
+    [Fact]
+    public async Task RequestMessageIsCreatedFromClientFactory()
+    {
+        await this.clientRpc.InvokeAsync<string>(nameof(Server.TestMethodAsync));
+        Assert.True(this.clientMessageFormatter.IsCreateRequestMessageCalled);
+        Assert.False(this.serverMessageFormatter.IsCreateRequestMessageCalled);
+    }
+
+    [Fact]
+    public async Task ResultMessageIsCreatedFromServerFactory()
+    {
+        await this.clientRpc.InvokeAsync<string>(nameof(Server.TestMethodAsync));
+        Assert.False(this.clientMessageFormatter.IsCreateResultMessageCalled);
+        Assert.True(this.serverMessageFormatter.IsCreateResultMessageCalled);
+    }
+
+    [Fact]
+    public async Task ErrorMessageIsCreatedFromServerFactory()
+    {
+        await Assert.ThrowsAsync<RemoteInvocationException>(async () => await this.clientRpc.InvokeAsync<string>(nameof(Server.MethodThatThrowsAsync)));
+        Assert.False(this.clientMessageFormatter.IsCreateErrorMessageCalled);
+        Assert.False(this.serverMessageFormatter.IsCreateResultMessageCalled);
+        Assert.True(this.serverMessageFormatter.IsCreateErrorMessageCalled);
+    }
+
+#pragma warning disable CA1801 // use all parameters
+    public class Server
+    {
+        public Task TestMethodAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task MethodThatThrowsAsync()
+        {
+            throw new InvalidProgramException();
+        }
+    }
+
+    internal class MessageFormatterWithMessageFactory : IJsonRpcMessageTextFormatter, IJsonRpcMessageFactory
+    {
+        private readonly IJsonRpcMessageTextFormatter formatter = new JsonMessageFormatter();
+
+        public bool IsCreateErrorMessageCalled { get; private set; }
+
+        public bool IsCreateRequestMessageCalled { get; private set; }
+
+        public bool IsCreateResultMessageCalled { get; private set; }
+
+        public Encoding Encoding { get => this.formatter.Encoding; set => this.formatter.Encoding = value; }
+
+        public JsonRpcError CreateErrorMessage()
+        {
+            this.IsCreateErrorMessageCalled = true;
+            return new MyJsonRpcError();
+        }
+
+        public JsonRpcRequest CreateRequestMessage()
+        {
+            this.IsCreateRequestMessageCalled = true;
+            return new MyJsonRpcRequest();
+        }
+
+        public JsonRpcResult CreateResultMessage()
+        {
+            this.IsCreateResultMessageCalled = true;
+            return new MyJsonRpcResult();
+        }
+
+        public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer)
+        {
+            return this.formatter.Deserialize(contentBuffer);
+        }
+
+        public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer, Encoding encoding)
+        {
+            return this.formatter.Deserialize(contentBuffer, encoding);
+        }
+
+        public object GetJsonText(JsonRpcMessage message)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Serialize(IBufferWriter<byte> bufferWriter, JsonRpcMessage message)
+        {
+            this.formatter.Serialize(bufferWriter, message);
+        }
+    }
+
+    internal class MyJsonRpcError : JsonRpcError
+    {
+    }
+
+    internal class MyJsonRpcRequest : JsonRpcRequest
+    {
+    }
+
+    internal class MyJsonRpcResult : JsonRpcResult
+    {
+    }
+#pragma warning restore CA1801 // use all parameters
+}

--- a/test/StreamJsonRpc.Tests/JsonRpcWithMessageFactoryTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcWithMessageFactoryTests.cs
@@ -118,7 +118,7 @@ public class JsonRpcWithMessageFactoryTests : TestBase
 
         public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer)
         {
-            return this.formatter.Deserialize(contentBuffer);
+            throw new NotSupportedException();
         }
 
         public JsonRpcMessage Deserialize(ReadOnlySequence<byte> contentBuffer, Encoding encoding)

--- a/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -354,10 +354,14 @@ public class MessagePackFormatterTests : TestBase
 
         requestMessage.Method = "test";
         Assert.True(requestMessage.TrySetTopLevelProperty("testProperty", "testValue"));
+        Assert.True(requestMessage.TrySetTopLevelProperty("objectProperty", new CustomType() { Age = 25 }));
 
         var roundTripMessage = this.Roundtrip(requestMessage);
         Assert.True(roundTripMessage.TryGetTopLevelProperty("testProperty", out string? value));
         Assert.Equal("testValue", value);
+
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("objectProperty", out CustomType? customObject));
+        Assert.Equal(25, customObject?.Age);
     }
 
     [Fact]

--- a/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -346,6 +346,34 @@ public class MessagePackFormatterTests : TestBase
         Assert.Equal(dynamic.error.code, (int?)request.Error?.Code);
     }
 
+    [Fact]
+    public void TopLevelPropertiesCanBeSerialized()
+    {
+        var requestMessage = this.formatter.CreateRequestMessage();
+        Assert.NotNull(requestMessage);
+
+        requestMessage.Method = "test";
+        Assert.True(requestMessage.TrySetTopLevelProperty("testProperty", "testValue"));
+
+        var roundTripMessage = this.Roundtrip(requestMessage);
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+    }
+
+    [Fact]
+    public void TopLevelPropertiesWithNullValue()
+    {
+        var requestMessage = this.formatter.CreateRequestMessage();
+        Assert.NotNull(requestMessage);
+
+        requestMessage.Method = "test";
+        Assert.True(requestMessage.TrySetTopLevelProperty<string?>("testProperty", null));
+
+        var roundTripMessage = this.Roundtrip(requestMessage);
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Null(value);
+    }
+
     private T Read<T>(object anonymousObject)
         where T : JsonRpcMessage
     {

--- a/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -347,9 +347,9 @@ public class MessagePackFormatterTests : TestBase
     }
 
     [Fact]
-    public void TopLevelPropertiesCanBeSerialized()
+    public void TopLevelPropertiesCanBeSerializedRequest()
     {
-        var requestMessage = this.formatter.CreateRequestMessage();
+        var requestMessage = ((IJsonRpcMessageFactory)this.formatter).CreateRequestMessage();
         Assert.NotNull(requestMessage);
 
         requestMessage.Method = "test";
@@ -365,9 +365,45 @@ public class MessagePackFormatterTests : TestBase
     }
 
     [Fact]
+    public void TopLevelPropertiesCanBeSerializedResult()
+    {
+        var message = ((IJsonRpcMessageFactory)this.formatter).CreateResultMessage();
+        Assert.NotNull(message);
+
+        message.Result = "test";
+        Assert.True(message.TrySetTopLevelProperty("testProperty", "testValue"));
+        Assert.True(message.TrySetTopLevelProperty("objectProperty", new CustomType() { Age = 25 }));
+
+        var roundTripMessage = this.Roundtrip(message);
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("objectProperty", out CustomType? customObject));
+        Assert.Equal(25, customObject?.Age);
+    }
+
+    [Fact]
+    public void TopLevelPropertiesCanBeSerializedError()
+    {
+        var message = ((IJsonRpcMessageFactory)this.formatter).CreateErrorMessage();
+        Assert.NotNull(message);
+
+        message.Error = new JsonRpcError.ErrorDetail() { Message = "test" };
+        Assert.True(message.TrySetTopLevelProperty("testProperty", "testValue"));
+        Assert.True(message.TrySetTopLevelProperty("objectProperty", new CustomType() { Age = 25 }));
+
+        var roundTripMessage = this.Roundtrip(message);
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("testProperty", out string? value));
+        Assert.Equal("testValue", value);
+
+        Assert.True(roundTripMessage.TryGetTopLevelProperty("objectProperty", out CustomType? customObject));
+        Assert.Equal(25, customObject?.Age);
+    }
+
+    [Fact]
     public void TopLevelPropertiesWithNullValue()
     {
-        var requestMessage = this.formatter.CreateRequestMessage();
+        var requestMessage = ((IJsonRpcMessageFactory)this.formatter).CreateRequestMessage();
         Assert.NotNull(requestMessage);
 
         requestMessage.Method = "test";

--- a/test/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
+++ b/test/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
@@ -73,5 +73,13 @@ public class JsonRpcRequestTests
         };
         Assert.Null(request.ArgumentsArray);
     }
+
+    [Fact]
+    public void DefaultRequestDoesNotSupportTopLevelProperties()
+    {
+        var request = new JsonRpcRequest();
+        Assert.False(request.TrySetTopLevelProperty("test", "test"));
+        Assert.False(request.TryGetTopLevelProperty<string>("test", out string? value));
+    }
 #pragma warning restore CS0618 // Type or member is obsolete
 }


### PR DESCRIPTION
Adds support for:
* Optional top level properties on RPC messages, and implementation of it for JSON and MessagePack formatters
* An option for JsonRpc implementations to handle dispatching of calls to target object to support scenarios like ordering calls, serializing calls without blocking JsonRpc stream.