### PR TITLE
Add ETW trace testing to pipeline

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -12,6 +12,16 @@ steps:
     arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest$(FailsOnMonoFilter)" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net472.binlog"
     testRunTitle: net472-$(Agent.JobName)
   condition: ne(variables['OptProf'], 'true')
+  
+- task: DotNetCoreCLI@2
+  displayName: dotnet test -f net472 (+EventSource)
+  inputs:
+    command: test
+    arguments: --no-build -c $(BuildConfiguration) -f net472 --filter "TestCategory!=FailsInCloudTest$(FailsOnMonoFilter)" -v n /p:CollectCoverage=true --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings" /bl:"$(Build.ArtifactStagingDirectory)/build_logs/test_net472_etw.binlog"
+    testRunTitle: net472-$(Agent.JobName)-etw
+  env:
+    StreamJsonRpc_TestWithEventSource: 1
+  condition: ne(variables['OptProf'], 'true')
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test -f netcoreapp2.1

--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -3,6 +3,7 @@
 
 namespace StreamJsonRpc
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics.Tracing;
     using System.Text;
@@ -99,6 +100,11 @@ namespace StreamJsonRpc
         private const int MessageHandlerReceivedEvent = 33;
 
         /// <summary>
+        /// A flag indicating whether to force tracing to be on.
+        /// </summary>
+        private static readonly bool AlwaysOn = Environment.GetEnvironmentVariable("StreamJsonRpc_TestWithEventSource") == "1";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonRpcEventSource"/> class.
         /// </summary>
         /// <remarks>
@@ -107,6 +113,9 @@ namespace StreamJsonRpc
         private JsonRpcEventSource()
         {
         }
+
+        /// <inheritdoc cref="EventSource.IsEnabled(EventLevel, EventKeywords)"/>
+        public new bool IsEnabled(EventLevel level, EventKeywords keywords) => AlwaysOn || base.IsEnabled(level, keywords);
 
         /// <summary>
         /// Signals the transmission of a notification.


### PR DESCRIPTION
A regression was uncaught in v2.9 until inserted into VS where ETW tracing was on during perf tests. 
We'll avoid such a regression in the future by testing with ETW tracing code executing regularly going forward, starting with v2.8 before the regression.