### PR TITLE
Force upgrade of vulnerable System.Text.Encodings.Web 4.5.0 to 4.5.1

### DIFF
--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.10.34" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.combinatorial" Version="1.4.1" />


### PR DESCRIPTION
Force upgrade of vulnerable System.Text.Encodings.Web 4.5.0 to 4.5.1.
This is according to https://github.com/dotnet/runtime/issues/49377