### PR TITLE
Add `ClientRequiresNamedArguments` option for `IProgress<T>` notifications

### DIFF
--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -31,6 +31,7 @@ namespace StreamJsonRpc
             this.NotifyClientOfEvents = copyFrom.NotifyClientOfEvents;
             this.AllowNonPublicInvocation = copyFrom.AllowNonPublicInvocation;
             this.UseSingleObjectParameterDeserialization = copyFrom.UseSingleObjectParameterDeserialization;
+            this.ClientRequiresNamedArguments = copyFrom.ClientRequiresNamedArguments;
             this.DisposeOnDisconnect = copyFrom.DisposeOnDisconnect;
         }
 
@@ -63,10 +64,17 @@ namespace StreamJsonRpc
         /// </remarks>
         public bool AllowNonPublicInvocation { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether JSON-RPC named arguments should all be deserialized into the RPC method's first parameter.
-        /// </summary>
+        /// <inheritdoc cref="JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization" />
+        /// <remarks>
+        /// This value serves as a default for <see cref="JsonRpcMethodAttribute.UseSingleObjectParameterDeserialization"/> for members that have no <see cref="JsonRpcMethodAttribute"/> applied.
+        /// </remarks>
         public bool UseSingleObjectParameterDeserialization { get; set; }
+
+        /// <inheritdoc cref="JsonRpcMethodAttribute.ClientRequiresNamedArguments" />
+        /// <remarks>
+        /// This value serves as a default for <see cref="JsonRpcMethodAttribute.ClientRequiresNamedArguments"/> for members that have no <see cref="JsonRpcMethodAttribute"/> applied.
+        /// </remarks>
+        public bool ClientRequiresNamedArguments { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to dispose of the target object

--- a/src/StreamJsonRpc/Reflection/JsonRpcMethodAttribute.cs
+++ b/src/StreamJsonRpc/Reflection/JsonRpcMethodAttribute.cs
@@ -54,8 +54,20 @@ namespace StreamJsonRpc
         public string? Name { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether JSON-RPC named arguments should all be deserialized into this method's first parameter.
+        /// Gets or sets a value indicating whether JSON-RPC named arguments should all be deserialized into the RPC method's first parameter.
         /// </summary>
-        public bool UseSingleObjectParameterDeserialization { get; set;  }
+        public bool UseSingleObjectParameterDeserialization { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether JSON-RPC named arguments should be used in callbacks sent back to the client.
+        /// </summary>
+        /// <value>The default value is <see langword="false"/>.</value>
+        /// <remarks>
+        /// An example of impact of this setting is when the client sends an <see cref="IProgress{T}"/> argument and this server
+        /// will call <see cref="IProgress{T}.Report(T)"/> on that argument.
+        /// The notification that the server then sends back to the client may use positional or named arguments in that notification.
+        /// Named arguments are used if and only if this property is set to <see langword="true" />.
+        /// </remarks>
+        public bool ClientRequiresNamedArguments { get; set; }
     }
 }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
@@ -149,24 +149,31 @@ namespace StreamJsonRpc.Reflection
             }
         }
 
-        /// <summary>
-        /// Creates a new instance of <see cref="IProgress{T}"/> to use on the receiving end of an RPC call.
-        /// </summary>
+        /// <inheritdoc cref="CreateProgress(JsonRpc, object, Type, bool)"/>
+        /// <remarks>
+        /// This overload creates an <see cref="IProgress{T}"/> that does <em>not</em> use named arguments in its notifications.
+        /// </remarks>
+        public IProgress<T> CreateProgress<T>(JsonRpc rpc, object token) => this.CreateProgress<T>(rpc, token, clientRequiresNamedArguments: false);
+
+        /// <inheritdoc cref="CreateProgress(JsonRpc, object, Type, bool)"/>
         /// <typeparam name="T">The type of the value to be reported by <see cref="IProgress{T}"/>.</typeparam>
-        /// <param name="rpc">The <see cref="JsonRpc"/> instance used to send the <see cref="ProgressRequestSpecialMethod"/> notification.</param>
-        /// <param name="token">The token used to obtain the <see cref="ProgressParamInformation"/> instance from <see cref="progressMap"/>.</param>
-#pragma warning disable CA1822 // Mark members as static
-        public IProgress<T> CreateProgress<T>(JsonRpc rpc, object token) => new JsonProgress<T>(rpc, token);
-#pragma warning restore CA1822 // Mark members as static
+        public IProgress<T> CreateProgress<T>(JsonRpc rpc, object token, bool clientRequiresNamedArguments) => new JsonProgress<T>(rpc, token, clientRequiresNamedArguments);
+
+        /// <inheritdoc cref="CreateProgress(JsonRpc, object, Type, bool)"/>
+        /// <remarks>
+        /// This overload creates an <see cref="IProgress{T}"/> that does <em>not</em> use named arguments in its notifications.
+        /// </remarks>
+        public object CreateProgress(JsonRpc rpc, object token, Type valueType) => this.CreateProgress(rpc, token, valueType, clientRequiresNamedArguments: false);
 
         /// <summary>
         /// Creates a new instance of <see cref="IProgress{T}"/> to use on the receiving end of an RPC call.
         /// </summary>
         /// <param name="rpc">The <see cref="JsonRpc"/> instance used to send the <see cref="ProgressRequestSpecialMethod"/> notification.</param>
         /// <param name="token">The token used to obtain the <see cref="ProgressParamInformation"/> instance from <see cref="progressMap"/>.</param>
-        /// <param name="valueType">The type that the <see cref="IProgress{T}"/> intance will report.</param>
+        /// <param name="valueType">A generic type whose first generic type argument is to serve as the type argument for the created <see cref="IProgress{T}"/>.</param>
+        /// <param name="clientRequiresNamedArguments"><see langword="true"/> to issue $/progress notifications using named args; <see langword="false"/> to use positional arguments.</param>
 #pragma warning disable CA1822 // Mark members as static
-        public object CreateProgress(JsonRpc rpc, object token, Type valueType)
+        public object CreateProgress(JsonRpc rpc, object token, Type valueType, bool clientRequiresNamedArguments)
 #pragma warning restore CA1822 // Mark members as static
         {
             Requires.NotNull(rpc, nameof(rpc));
@@ -174,7 +181,7 @@ namespace StreamJsonRpc.Reflection
             Requires.NotNull(valueType, nameof(valueType));
 
             Type progressType = typeof(JsonProgress<>).MakeGenericType(valueType.GenericTypeArguments[0]);
-            return Activator.CreateInstance(progressType, new object[] { rpc, token })!;
+            return Activator.CreateInstance(progressType, new object[] { rpc, token, clientRequiresNamedArguments })!;
         }
 
         private void CleanUpResources(RequestId requestId)
@@ -257,16 +264,19 @@ namespace StreamJsonRpc.Reflection
         {
             private readonly JsonRpc rpc;
             private readonly object token;
+            private readonly bool useNamedArguments;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="JsonProgress{T}"/> class.
             /// </summary>
             /// <param name="rpc">The <see cref="JsonRpc"/> instance used to send the <see cref="ProgressRequestSpecialMethod"/> notification.</param>
             /// <param name="token">The progress token used to obtain the <see cref="ProgressParamInformation"/> instance from <see cref="progressMap"/>.</param>
-            public JsonProgress(JsonRpc rpc, object token)
+            /// <param name="useNamedArguments"><see langword="true"/> to use named arguments; <see langword="false"/> to use positional arguments.</param>
+            public JsonProgress(JsonRpc rpc, object token, bool useNamedArguments)
             {
                 this.rpc = rpc ?? throw new ArgumentNullException(nameof(rpc));
                 this.token = token ?? throw new ArgumentNullException(nameof(token));
+                this.useNamedArguments = useNamedArguments;
             }
 
             /// <summary>
@@ -275,9 +285,29 @@ namespace StreamJsonRpc.Reflection
             /// <param name="value">The typed value that will be send in the notification to be reported by the original <see cref="IProgress{T}"/> instance.</param>
             public void Report(T value)
             {
-                var arguments = new object?[] { this.token, value };
-                var argumentDeclaredTypes = new Type[] { this.token.GetType(), typeof(T) };
-                this.rpc.NotifyAsync(ProgressRequestSpecialMethod, arguments, argumentDeclaredTypes).ContinueWith(
+                Task notifyTask;
+                if (this.useNamedArguments)
+                {
+                    var arguments = new Dictionary<string, object?>
+                    {
+                        { "token",  this.token },
+                        { "value", value },
+                    };
+                    var argumentDeclaredTypes = new Dictionary<string, Type>
+                    {
+                        { "token", this.token.GetType() },
+                        { "value", typeof(T) },
+                    };
+                    notifyTask = this.rpc.NotifyWithParameterObjectAsync(ProgressRequestSpecialMethod, arguments, argumentDeclaredTypes);
+                }
+                else
+                {
+                    var arguments = new object?[] { this.token, value };
+                    var argumentDeclaredTypes = new Type[] { this.token.GetType(), typeof(T) };
+                    notifyTask = this.rpc.NotifyAsync(ProgressRequestSpecialMethod, arguments, argumentDeclaredTypes);
+                }
+
+                notifyTask.ContinueWith(
                     (t, s) => ((JsonRpc)s!).TraceSource.TraceEvent(System.Diagnostics.TraceEventType.Error, (int)JsonRpc.TraceEvents.ProgressNotificationError, "Failed to send progress update. {0}", t.Exception!.InnerException ?? t.Exception),
                     this.rpc,
                     CancellationToken.None,

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -27,6 +27,10 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.get -> bool
+StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.set -> void
+StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId.RequestId.set -> void
@@ -35,6 +39,8 @@ StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.set -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc! rpc, object! token, System.Type! valueType, bool clientRequiresNamedArguments) -> object!
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc! rpc, object! token, bool clientRequiresNamedArguments) -> System.IProgress<T>!
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RequestId.RequestId() -> void
 StreamJsonRpc.TargetMethod

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -27,6 +27,10 @@ StreamJsonRpc.JsonRpc.ExceptionStrategy.get -> StreamJsonRpc.ExceptionProcessing
 StreamJsonRpc.JsonRpc.ExceptionStrategy.set -> void
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotDeserializable = 21 -> StreamJsonRpc.JsonRpc.TraceEvents
 StreamJsonRpc.JsonRpc.TraceEvents.ExceptionNotSerializable = 20 -> StreamJsonRpc.JsonRpc.TraceEvents
+StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.get -> bool
+StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.set -> void
+StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool
+StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId.RequestId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.Protocol.IJsonRpcMessageWithId.RequestId.set -> void
@@ -35,6 +39,8 @@ StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceParent.set -> void
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.get -> string?
 StreamJsonRpc.Protocol.JsonRpcRequest.TraceState.set -> void
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc! rpc, object! token, System.Type! valueType, bool clientRequiresNamedArguments) -> object!
+StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc! rpc, object! token, bool clientRequiresNamedArguments) -> System.IProgress<T>!
 StreamJsonRpc.RemoteInvocationException.RemoteInvocationException(string? message, int errorCode, System.Exception! innerException) -> void
 StreamJsonRpc.RequestId.RequestId() -> void
 StreamJsonRpc.TargetMethod

--- a/test/StreamJsonRpc.Tests/JsonRpcTargetOptionsTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTargetOptionsTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using StreamJsonRpc;
+using Xunit;
+
+public class JsonRpcTargetOptionsTests
+{
+    [Fact]
+    public void CopyConstructor()
+    {
+        JsonRpcTargetOptions options = new();
+        options.AllowNonPublicInvocation = !options.AllowNonPublicInvocation;
+        options.ClientRequiresNamedArguments = !options.ClientRequiresNamedArguments;
+        options.DisposeOnDisconnect = !options.DisposeOnDisconnect;
+        options.EventNameTransform = s => s;
+        options.MethodNameTransform = s => s;
+        options.NotifyClientOfEvents = !options.NotifyClientOfEvents;
+        options.UseSingleObjectParameterDeserialization = !options.UseSingleObjectParameterDeserialization;
+
+        JsonRpcTargetOptions copy = new(options);
+        Assert.Equal(options.AllowNonPublicInvocation, copy.AllowNonPublicInvocation);
+        Assert.Equal(options.ClientRequiresNamedArguments, copy.ClientRequiresNamedArguments);
+        Assert.Equal(options.DisposeOnDisconnect, copy.DisposeOnDisconnect);
+        Assert.Equal(options.EventNameTransform, copy.EventNameTransform);
+        Assert.Equal(options.MethodNameTransform, copy.MethodNameTransform);
+        Assert.Equal(options.NotifyClientOfEvents, copy.NotifyClientOfEvents);
+        Assert.Equal(options.UseSingleObjectParameterDeserialization, copy.UseSingleObjectParameterDeserialization);
+    }
+}


### PR DESCRIPTION
An individual method or entire RPC target object may have this new option applied to get named arguments syntax used for callbacks (e.g. `IProgress<T>.Report` notifications).

This is useful for when the RPC client is LSP, which requires named arguments in the `$/progress` notification.
An LSP server that wishes to opt into this new behavior should add the RPC target option with an additional option:

```diff
 rpc.AddLocalRpcTarget(
   this.server,
   new JsonRpcTargetOptions
   {
     UseSingleObjectParameterDeserialization = true,
+    ClientRequiresNamedArguments = true,
   })
```