### PR TITLE
Honor ClientRequiresNamedArguments when UseSingleObjectParameterDeserialization is set

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -969,7 +969,9 @@ namespace StreamJsonRpc
                                     obj.Add(new JProperty(property.Key, property.Value));
                                 }
 
+                                this.formatter.deserializingMessage = this;
                                 typedArguments[0] = obj.ToObject(parameters[0].ParameterType, this.formatter.JsonSerializer);
+                                this.formatter.deserializingMessage = null;
                                 return ArgumentMatchResult.Success;
                             }
                         }


### PR DESCRIPTION
Discovered while attempting to use the new attributes added in https://github.com/microsoft/vs-streamjsonrpc/pull/733

Essentially when the client sends a request with a progress token using named parameters *and* the server is using `UseSingleObjectParameterDeserialization`, vs-streamjsonrpc fails to pass along the value of `clientRequiresNamedArguments` to the `JsonProgress` object.

This is exactly the configuration I hit as vscode uses named parameters and we make heavy use of `UseSingleObjectParameterDeserialization` in our lsp server.

The problem was that we essentially have a separate code path for handling RPC server methods that accept all args as a single argument (a special case built for LSP support), and we hadn't updated that code path to propagate the `JsonRpcMethodAttribute` in the special case.