### PR TITLE
Better handling of serializing exceptions

### DIFF
--- a/src/StreamJsonRpc/ExceptionSettings.cs
+++ b/src/StreamJsonRpc/ExceptionSettings.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc
+{
+    using System;
+    using System.Runtime.Serialization;
+    using Microsoft;
+
+    /// <summary>
+    /// Contains security-related settings that influence how errors are serialized and deserialized.
+    /// </summary>
+    public abstract record ExceptionSettings
+    {
+        /// <summary>
+        /// The recommended settings for use when communicating with a trusted party.
+        /// </summary>
+        public static readonly ExceptionSettings TrustedData = new DefaultExceptionSettings(int.MaxValue, trusted: true);
+
+        /// <summary>
+        /// The recommended settings for use when communicating with an untrusted party.
+        /// </summary>
+        public static readonly ExceptionSettings UntrustedData = new DefaultExceptionSettings(50, trusted: false);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionSettings"/> class.
+        /// </summary>
+        /// <param name="recursionLimit">The maximum number of nested errors to serialize or deserialize.</param>
+        protected ExceptionSettings(int recursionLimit)
+        {
+            Requires.Range(recursionLimit > 0, nameof(recursionLimit));
+            this.RecursionLimit = recursionLimit;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of nested errors to serialize or deserialize.
+        /// </summary>
+        /// <value>The default value is 50.</value>
+        /// <remarks>
+        /// This can help mitigate DoS attacks from unbounded recursion that otherwise error deserialization
+        /// becomes perhaps uniquely vulnerable to since the data structure allows recursion.
+        /// </remarks>
+        public int RecursionLimit { get; init; }
+
+        /// <summary>
+        /// Tests whether a type can be deserialized as part of deserializing an exception.
+        /// </summary>
+        /// <param name="type">The type that may be deserialized.</param>
+        /// <returns><see langword="true" /> if the type is safe to deserialize; <see langword="false" /> otherwise.</returns>
+        /// <remarks>
+        /// <para>
+        /// The default implementation returns <see langword="true" /> for all types in <see cref="TrustedData"/>-based instances;
+        /// or for <see cref="UntrustedData"/>-based instances will return <see langword="true" /> for
+        /// <see cref="Exception"/>-derived types that are expected to be safe to deserialize.
+        /// </para>
+        /// <para>
+        /// <see cref="Exception"/>-derived types that may deserialize data that would be unsafe coming from an untrusted party <em>should</em>
+        /// consider the <see cref="StreamingContext"/> passed to their deserializing constructor and skip deserializing of potentitally
+        /// dangerous data when <see cref="StreamingContext.State"/> includes the <see cref="StreamingContextStates.Remoting"/> flag.
+        /// </para>
+        /// </remarks>
+        public abstract bool CanDeserialize(Type type);
+
+        private record DefaultExceptionSettings : ExceptionSettings
+        {
+            private readonly bool trusted;
+
+            public DefaultExceptionSettings(int recursionLimit, bool trusted)
+                : base(recursionLimit)
+            {
+                this.trusted = trusted;
+            }
+
+            public override bool CanDeserialize(Type type) => this.trusted || typeof(Exception).IsAssignableFrom(type);
+        }
+    }
+}

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -1626,7 +1626,7 @@ namespace StreamJsonRpc
                         }
 
                         JToken? value = reader.TokenType == JsonToken.Null ? null : JToken.Load(reader);
-                        info.AddValue(name, value);
+                        info.AddSafeValue(name, value);
                     }
                     else
                     {
@@ -1648,7 +1648,7 @@ namespace StreamJsonRpc
                 SerializationInfo info = new SerializationInfo(value.GetType(), new JsonConverterFormatter(serializer));
                 ExceptionSerializationHelpers.Serialize(value, info);
                 writer.WriteStartObject();
-                foreach (SerializationEntry element in info)
+                foreach (SerializationEntry element in info.GetSafeMembers())
                 {
                     writer.WritePropertyName(element.Name);
                     serializer.Serialize(writer, element.Value);

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -129,6 +129,11 @@ namespace StreamJsonRpc
         private ExceptionProcessing exceptionStrategy;
 
         /// <summary>
+        /// Backing field for <see cref="ExceptionOptions"/>.
+        /// </summary>
+        private ExceptionSettings exceptionSettings = ExceptionSettings.UntrustedData;
+
+        /// <summary>
         /// Backing field for the <see cref="IJsonRpcFormatterCallbacks.RequestTransmissionAborted"/> event.
         /// </summary>
         private EventHandler<JsonRpcMessageEventArgs>? requestTransmissionAborted;
@@ -546,6 +551,20 @@ namespace StreamJsonRpc
             {
                 this.ThrowIfConfigurationLocked();
                 this.exceptionStrategy = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the settings to use for serializing/deserializing exceptions.
+        /// </summary>
+        public ExceptionSettings ExceptionOptions
+        {
+            get => this.exceptionSettings;
+            set
+            {
+                Requires.NotNull(value, nameof(value));
+                this.ThrowIfConfigurationLocked();
+                this.exceptionSettings = value;
             }
         }
 

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -16,6 +16,7 @@ namespace StreamJsonRpc
     using System.Runtime.ExceptionServices;
     using System.Runtime.Serialization;
     using System.Text;
+    using System.Threading;
     using MessagePack;
     using MessagePack.Formatters;
     using MessagePack.Resolvers;
@@ -1494,6 +1495,15 @@ namespace StreamJsonRpc
         /// </remarks>
         private class MessagePackExceptionResolver : IFormatterResolver
         {
+            /// <summary>
+            /// Tracks recursion count while serializing or deserializing an exception.
+            /// </summary>
+            /// <devremarks>
+            /// This is placed here (<em>outside</em> the generic <see cref="ExceptionFormatter{T}"/> class)
+            /// so that it's one counter shared across all exception types that may be serialized or deserialized.
+            /// </devremarks>
+            private static ThreadLocal<int> exceptionRecursionCounter = new();
+
             private readonly object[] formatterActivationArgs;
 
             private readonly Dictionary<Type, object?> formatterCache = new Dictionary<Type, object?>();
@@ -1545,24 +1555,42 @@ namespace StreamJsonRpc
                         return null;
                     }
 
-                    var info = new SerializationInfo(typeof(T), new MessagePackFormatterConverter(options));
-                    int memberCount = reader.ReadMapHeader();
-                    for (int i = 0; i < memberCount; i++)
+                    // We have to guard our own recursion because the serializer has no visibility into inner exceptions.
+                    // Each exception in the russian doll is a new serialization job from its perspective.
+                    exceptionRecursionCounter.Value++;
+                    try
                     {
-                        string name = reader.ReadString();
+                        if (exceptionRecursionCounter.Value > this.formatter.rpc.ExceptionOptions.RecursionLimit)
+                        {
+                            // Exception recursion has gone too deep. Skip this value and return null as if there were no inner exception.
+                            // Note that in skipping, the parser may use recursion internally and may still throw if its own limits are exceeded.
+                            reader.Skip();
+                            return null;
+                        }
 
-                        // SerializationInfo.GetValue(string, typeof(object)) does not call our formatter,
-                        // so the caller will get a boxed RawMessagePack struct in that case.
-                        // Although we can't do much about *that* in general, we can at least ensure that null values
-                        // are represented as null instead of this boxed struct.
-                        var value = reader.TryReadNil() ? null : (object)RawMessagePack.ReadRaw(ref reader, false);
+                        var info = new SerializationInfo(typeof(T), new MessagePackFormatterConverter(options));
+                        int memberCount = reader.ReadMapHeader();
+                        for (int i = 0; i < memberCount; i++)
+                        {
+                            string name = reader.ReadString();
 
-                        info.AddSafeValue(name, value);
+                            // SerializationInfo.GetValue(string, typeof(object)) does not call our formatter,
+                            // so the caller will get a boxed RawMessagePack struct in that case.
+                            // Although we can't do much about *that* in general, we can at least ensure that null values
+                            // are represented as null instead of this boxed struct.
+                            var value = reader.TryReadNil() ? null : (object)RawMessagePack.ReadRaw(ref reader, false);
+
+                            info.AddSafeValue(name, value);
+                        }
+
+                        var resolverWrapper = options.Resolver as ResolverWrapper;
+                        Report.If(resolverWrapper is null, "Unexpected resolver type.");
+                        return ExceptionSerializationHelpers.Deserialize<T>(this.formatter.rpc, info, resolverWrapper?.Formatter.rpc?.TraceSource);
                     }
-
-                    var resolverWrapper = options.Resolver as ResolverWrapper;
-                    Report.If(resolverWrapper is null, "Unexpected resolver type.");
-                    return ExceptionSerializationHelpers.Deserialize<T>(this.formatter.rpc, info, resolverWrapper?.Formatter.rpc?.TraceSource);
+                    finally
+                    {
+                        exceptionRecursionCounter.Value--;
+                    }
                 }
 
                 public void Serialize(ref MessagePackWriter writer, T? value, MessagePackSerializerOptions options)
@@ -1573,13 +1601,28 @@ namespace StreamJsonRpc
                         return;
                     }
 
-                    var info = new SerializationInfo(typeof(T), new MessagePackFormatterConverter(options));
-                    ExceptionSerializationHelpers.Serialize(value, info);
-                    writer.WriteMapHeader(info.GetSafeMemberCount());
-                    foreach (SerializationEntry element in info.GetSafeMembers())
+                    exceptionRecursionCounter.Value++;
+                    try
                     {
-                        writer.Write(element.Name);
-                        MessagePackSerializer.Serialize(element.ObjectType, ref writer, element.Value, options);
+                        if (exceptionRecursionCounter.Value > this.formatter.rpc?.ExceptionOptions.RecursionLimit)
+                        {
+                            // Exception recursion has gone too deep. Skip this value and write null as if there were no inner exception.
+                            writer.WriteNil();
+                            return;
+                        }
+
+                        var info = new SerializationInfo(typeof(T), new MessagePackFormatterConverter(options));
+                        ExceptionSerializationHelpers.Serialize(value, info);
+                        writer.WriteMapHeader(info.GetSafeMemberCount());
+                        foreach (SerializationEntry element in info.GetSafeMembers())
+                        {
+                            writer.Write(element.Name);
+                            MessagePackSerializer.Serialize(element.ObjectType, ref writer, element.Value, options);
+                        }
+                    }
+                    finally
+                    {
+                        exceptionRecursionCounter.Value--;
                     }
                 }
             }

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1557,7 +1557,7 @@ namespace StreamJsonRpc
                         // are represented as null instead of this boxed struct.
                         var value = reader.TryReadNil() ? null : (object)RawMessagePack.ReadRaw(ref reader, false);
 
-                        info.AddValue(name, value);
+                        info.AddSafeValue(name, value);
                     }
 
                     var resolverWrapper = options.Resolver as ResolverWrapper;
@@ -1575,8 +1575,8 @@ namespace StreamJsonRpc
 
                     var info = new SerializationInfo(typeof(T), new MessagePackFormatterConverter(options));
                     ExceptionSerializationHelpers.Serialize(value, info);
-                    writer.WriteMapHeader(info.MemberCount);
-                    foreach (SerializationEntry element in info)
+                    writer.WriteMapHeader(info.GetSafeMemberCount());
+                    foreach (SerializationEntry element in info.GetSafeMembers())
                     {
                         writer.Write(element.Name);
                         MessagePackSerializer.Serialize(element.ObjectType, ref writer, element.Value, options);

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -15,6 +15,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="MessagePack" Version="2.3.85" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.3.85" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.0.63" />

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+abstract StreamJsonRpc.ExceptionSettings.CanDeserialize(System.Type! type) -> bool
+static readonly StreamJsonRpc.ExceptionSettings.TrustedData -> StreamJsonRpc.ExceptionSettings!
+static readonly StreamJsonRpc.ExceptionSettings.UntrustedData -> StreamJsonRpc.ExceptionSettings!
+StreamJsonRpc.ExceptionSettings
+StreamJsonRpc.ExceptionSettings.ExceptionSettings(int recursionLimit) -> void
+StreamJsonRpc.ExceptionSettings.RecursionLimit.get -> int
+StreamJsonRpc.ExceptionSettings.RecursionLimit.init -> void
+StreamJsonRpc.JsonRpc.ExceptionOptions.get -> StreamJsonRpc.ExceptionSettings!
+StreamJsonRpc.JsonRpc.ExceptionOptions.set -> void
 StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+abstract StreamJsonRpc.ExceptionSettings.CanDeserialize(System.Type! type) -> bool
+static readonly StreamJsonRpc.ExceptionSettings.TrustedData -> StreamJsonRpc.ExceptionSettings!
+static readonly StreamJsonRpc.ExceptionSettings.UntrustedData -> StreamJsonRpc.ExceptionSettings!
+StreamJsonRpc.ExceptionSettings
+StreamJsonRpc.ExceptionSettings.ExceptionSettings(int recursionLimit) -> void
+StreamJsonRpc.ExceptionSettings.RecursionLimit.get -> int
+StreamJsonRpc.ExceptionSettings.RecursionLimit.init -> void
+StreamJsonRpc.JsonRpc.ExceptionOptions.get -> StreamJsonRpc.ExceptionSettings!
+StreamJsonRpc.JsonRpc.ExceptionOptions.set -> void
 StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.get -> bool
 StreamJsonRpc.JsonRpcMethodAttribute.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool

--- a/test/StreamJsonRpc.Tests/ExceptionSettingsTests.cs
+++ b/test/StreamJsonRpc.Tests/ExceptionSettingsTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ExceptionSettingsTests : TestBase
+{
+    public ExceptionSettingsTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void RecursionLimit()
+    {
+        Assert.Equal(int.MaxValue, ExceptionSettings.TrustedData.RecursionLimit);
+        Assert.Equal(50, ExceptionSettings.UntrustedData.RecursionLimit);
+    }
+
+    [Fact]
+    public void CanDeserialize()
+    {
+        Assert.True(ExceptionSettings.TrustedData.CanDeserialize(typeof(AppDomain)));
+        Assert.False(ExceptionSettings.UntrustedData.CanDeserialize(typeof(AppDomain)));
+
+        Assert.True((ExceptionSettings.TrustedData with { RecursionLimit = 3 }).CanDeserialize(typeof(AppDomain)));
+        Assert.False((ExceptionSettings.UntrustedData with { RecursionLimit = 3 }).CanDeserialize(typeof(AppDomain)));
+    }
+}


### PR DESCRIPTION
- Suppress `WatsonBuckets` member from serialization
- Add recursion limit (so many inner exceptions get truncated at some point).
- Add the ability to filter exception types that can be deserialized.