### PR TITLE
Add SendAsync virtual method to JsonRpc

### DIFF
--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -13,3 +13,4 @@ StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc! rpc, object! token, System.Type! valueType, bool clientRequiresNamedArguments) -> object!
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc! rpc, object! token, bool clientRequiresNamedArguments) -> System.IProgress<T>!
+virtual StreamJsonRpc.JsonRpc.SendAsync(StreamJsonRpc.Protocol.JsonRpcMessage! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -13,3 +13,4 @@ StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.get -> bool
 StreamJsonRpc.JsonRpcTargetOptions.ClientRequiresNamedArguments.set -> void
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc! rpc, object! token, System.Type! valueType, bool clientRequiresNamedArguments) -> object!
 StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress<T>(StreamJsonRpc.JsonRpc! rpc, object! token, bool clientRequiresNamedArguments) -> System.IProgress<T>!
+virtual StreamJsonRpc.JsonRpc.SendAsync(StreamJsonRpc.Protocol.JsonRpcMessage! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask


### PR DESCRIPTION
Add a new SendAsync virtual method to JsonRpc to enable custom implementations to modify outgoing messages, such as adding top level properties.