### PR TITLE
Defend against mutable statics causing JSON serialization failures

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,0 +1,5 @@
+M:Newtonsoft.Json.JsonSerializer.CreateDefault(); depends on JsonConvert.DefaultSettings
+M:Newtonsoft.Json.Linq.JObject.FromObject(System.Object); depends on JsonConvert.DefaultSettings
+M:Newtonsoft.Json.Linq.JToken.FromObject(System.Object); depends on JsonConvert.DefaultSettings
+M:Newtonsoft.Json.Linq.JToken.ToObject(System.Type); depends on JsonConvert.DefaultSettings
+M:Newtonsoft.Json.Linq.JToken.ToObject``1; depends on JsonConvert.DefaultSettings

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
@@ -36,6 +37,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" Link="BannedSymbols.txt" />
   </ItemGroup>
 
   <ItemDefinitionGroup>

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -69,9 +69,10 @@ namespace StreamJsonRpc
         /// </summary>
         /// <remarks>
         /// This is useful when calling such APIs as <see cref="JToken.FromObject(object, JsonSerializer)"/>
-        /// because <see cref="JToken.FromObject(object)"/> allocates a new serializer with each invocation.
+        /// to avoid the simpler overloads that rely on <see cref="JsonConvert.DefaultSettings"/> which is a mutable static.
+        /// By sharing this reliably untainted instance, we avoid allocating a new serializer with each invocation.
         /// </remarks>
-        private static readonly JsonSerializer DefaultSerializer = JsonSerializer.CreateDefault();
+        private static readonly JsonSerializer DefaultSerializer = JsonSerializer.Create();
 
         private readonly IReadOnlyDictionary<Type, RpcMarshalableImplicitConverter> implicitlyMarshaledTypes;
 
@@ -701,7 +702,7 @@ namespace StreamJsonRpc
         {
             Requires.NotNull(json, nameof(json));
 
-            RequestId id = json["id"]?.ToObject<RequestId>() ?? default;
+            RequestId id = json["id"]?.ToObject<RequestId>(DefaultSerializer) ?? default;
 
             // We leave arguments as JTokens at this point, so that we can try deserializing them
             // to more precise .NET types as required by the method we're invoking.
@@ -798,7 +799,7 @@ namespace StreamJsonRpc
                 throw this.CreateProtocolNonComplianceException(json, "\"id\" property missing.");
             }
 
-            RequestId id = this.NormalizeId(idToken.ToObject<RequestId>());
+            RequestId id = this.NormalizeId(idToken.ToObject<RequestId>(DefaultSerializer));
             return id;
         }
 

--- a/test/StreamJsonRpc.Tests/InteropTestBase.cs
+++ b/test/StreamJsonRpc.Tests/InteropTestBase.cs
@@ -35,7 +35,7 @@ public class InteropTestBase : TestBase
     {
         Requires.NotNull(message, nameof(message));
 
-        var json = JToken.FromObject(message);
+        var json = JToken.FromObject(message, new JsonSerializer());
         this.messageHandler.MessagesToRead.Enqueue(json);
     }
 

--- a/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -145,16 +145,18 @@ public class JsonMessageFormatterTests : TestBase
     public void ServerReturnsErrorWithNullId()
     {
         var formatter = new JsonMessageFormatter();
-        JsonRpcMessage? message = formatter.Deserialize(JObject.FromObject(new
-        {
-            jsonrpc = "2.0",
-            error = new
+        JsonRpcMessage? message = formatter.Deserialize(JObject.FromObject(
+            new
             {
-                code = -1,
-                message = "Some message",
+                jsonrpc = "2.0",
+                error = new
+                {
+                    code = -1,
+                    message = "Some message",
+                },
+                id = (object?)null,
             },
-            id = (object?)null,
-        }));
+            new JsonSerializer()));
         var error = Assert.IsAssignableFrom<JsonRpcError>(message);
         Assert.True(error.RequestId.IsNull);
     }
@@ -183,14 +185,16 @@ public class JsonMessageFormatterTests : TestBase
     public void DeserializingResultWithMissingIdFails()
     {
         var formatter = new JsonMessageFormatter();
-        var resultWithNoId = JObject.FromObject(new
-        {
-            jsonrpc = "2.0",
-            result = new
+        var resultWithNoId = JObject.FromObject(
+            new
             {
-                asdf = "abc",
+                jsonrpc = "2.0",
+                result = new
+                {
+                    asdf = "abc",
+                },
             },
-        });
+            new JsonSerializer());
         var message = Assert.Throws<JsonSerializationException>(() => formatter.Deserialize(resultWithNoId)).InnerException?.Message;
         Assert.Contains("\"id\" property missing.", message);
     }
@@ -199,15 +203,17 @@ public class JsonMessageFormatterTests : TestBase
     public void DeserializingErrorWithMissingIdFails()
     {
         var formatter = new JsonMessageFormatter();
-        var errorWithNoId = JObject.FromObject(new
-        {
-            jsonrpc = "2.0",
-            error = new
+        var errorWithNoId = JObject.FromObject(
+            new
             {
-                code = -1,
-                message = "Some message",
+                jsonrpc = "2.0",
+                error = new
+                {
+                    code = -1,
+                    message = "Some message",
+                },
             },
-        });
+            new JsonSerializer());
         var message = Assert.Throws<JsonSerializationException>(() => formatter.Deserialize(errorWithNoId)).InnerException?.Message;
         Assert.Contains("\"id\" property missing.", message);
     }

--- a/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -303,7 +303,7 @@ public class JsonRpcClient20InteropTests : InteropTestBase
         };
         this.Send(errorObject);
         var ex = await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
-        var commonErrorData = ((JToken)ex.ErrorData!).ToObject<CommonErrorData>();
+        var commonErrorData = ((JToken)ex.ErrorData!).ToObject<CommonErrorData>(new JsonSerializer());
         Assert.Equal(errorObject.error.data.stack, commonErrorData?.StackTrace);
     }
 
@@ -329,7 +329,7 @@ public class JsonRpcClient20InteropTests : InteropTestBase
         };
         this.Send(errorObject);
         var ex = await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
-        var commonErrorData = ((JToken?)ex.ErrorData)!.ToObject<CommonErrorData>();
+        var commonErrorData = ((JToken?)ex.ErrorData)!.ToObject<CommonErrorData>(new JsonSerializer());
         Assert.Equal(errorObject.error.data.stack, commonErrorData?.StackTrace);
         Assert.Equal(-2147467261, commonErrorData?.HResult);
     }
@@ -358,7 +358,7 @@ public class JsonRpcClient20InteropTests : InteropTestBase
         this.Send(errorObject);
         var ex = await Assert.ThrowsAsync<RemoteInvocationException>(() => requestTask);
         JToken errorDataToken = (JToken)ex.ErrorData!;
-        Assert.Throws<JsonReaderException>(() => errorDataToken.ToObject<CommonErrorData>());
+        Assert.Throws<JsonReaderException>(() => errorDataToken.ToObject<CommonErrorData>(new JsonSerializer()));
         Assert.Equal(errorData.stack.foo, errorDataToken["stack"]?.Value<int>("foo"));
     }
 

--- a/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -177,7 +177,7 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
 
         var errorDataJToken = (JToken?)exception.ErrorData;
         Assert.NotNull(errorDataJToken);
-        var errorData = errorDataJToken!.ToObject<CommonErrorData>();
+        var errorData = errorDataJToken!.ToObject<CommonErrorData>(new JsonSerializer());
         Assert.NotNull(errorData?.StackTrace);
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData?.HResult);
     }


### PR DESCRIPTION
This removes all dependencies on JsonConvert.DefaultSettings

- It updates the tests to make sure all tests run with a poison pill set so that if any code in the library depends on this mutable static, it will result in a test failure.
- It also adds a banned APIs analyzer to further help prevent introducing code that depends on this mutable static.
- We then remove all use of Newtonsoft.Json APIs that ended up invoking this mutable static delegate.