### PR TITLE
Honor user-provided Json IContractResolver while maintaining marshaling capabilities

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -85,7 +85,7 @@ namespace StreamJsonRpc
         private readonly SequenceTextReader sequenceTextReader = new SequenceTextReader();
 
         /// <summary>
-        /// Object used to lock when running mutually exclusive operations related to this <see cref="JsonMessageFormatter" instance./>.
+        /// Object used to lock when running mutually exclusive operations related to this <see cref="JsonMessageFormatter"/> instance.
         /// </summary>
         private readonly object syncObject = new();
 

--- a/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
@@ -37,7 +37,7 @@ public partial class JsonContractResolverTest : TestBase
         this.serverRpc.StartListening();
     }
 
-    private interface IServer : IDisposable
+    protected interface IServer : IDisposable
     {
         Task GiveObserver(IObserver<int> observer);
 
@@ -57,7 +57,7 @@ public partial class JsonContractResolverTest : TestBase
     }
 
     [RpcMarshalable]
-    private interface IMarshalable : IDisposable
+    protected interface IMarshalable : IDisposable
     {
         void DoSomething();
     }
@@ -134,6 +134,14 @@ public partial class JsonContractResolverTest : TestBase
         return formatter;
     }
 
+    [DataContract]
+    protected class Container<T>
+    where T : class
+    {
+        [DataMember]
+        public T? Field { get; set; }
+    }
+
     private class Server : IServer
     {
         internal MockObserver Observer { get; } = new MockObserver();
@@ -175,14 +183,6 @@ public partial class JsonContractResolverTest : TestBase
         void IDisposable.Dispose()
         {
         }
-    }
-
-    [DataContract]
-    private class Container<T>
-        where T : class
-    {
-        [DataMember]
-        public T? Field { get; set; }
     }
 
     private class MockObserver : IObserver<int>

--- a/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Newtonsoft.Json.Serialization;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+public partial class JsonContractResolverTest : TestBase
+{
+    protected readonly Server server = new Server();
+    protected readonly JsonRpc serverRpc;
+    protected readonly JsonRpc clientRpc;
+    protected readonly IServer client;
+
+    private const string ExceptionMessage = "Some exception";
+
+    public JsonContractResolverTest(ITestOutputHelper logger)
+        : base(logger)
+    {
+        var pipes = FullDuplexStream.CreatePipePair();
+
+        this.client = JsonRpc.Attach<IServer>(new LengthHeaderMessageHandler(pipes.Item1, this.CreateFormatter()));
+        this.clientRpc = ((IJsonRpcClientProxy)this.client).JsonRpc;
+
+        this.serverRpc = new JsonRpc(new LengthHeaderMessageHandler(pipes.Item2, this.CreateFormatter()));
+        this.serverRpc.AddLocalRpcTarget(this.server);
+
+        this.serverRpc.TraceSource = new TraceSource("Server", SourceLevels.Verbose);
+        this.clientRpc.TraceSource = new TraceSource("Client", SourceLevels.Verbose);
+
+        this.serverRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        this.clientRpc.TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+
+        this.serverRpc.StartListening();
+    }
+
+    protected interface IServer : IDisposable
+    {
+        Task PushCompleteAndReturn(IObserver<int> observer);
+    }
+
+    [Fact]
+    public async Task PushCompleteAndReturn()
+    {
+        var observer = new MockObserver<int>();
+        await Task.Run(() => this.client.PushCompleteAndReturn(observer)).WithCancellation(this.TimeoutToken);
+        await observer.Completion.WithCancellation(this.TimeoutToken);
+        ImmutableList<int> result = await observer.Completion;
+    }
+
+    protected IJsonRpcMessageFormatter CreateFormatter()
+    {
+        var formatter = new JsonMessageFormatter();
+        formatter.JsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+        return formatter;
+    }
+
+    protected class Server : IServer
+    {
+        public Task PushCompleteAndReturn(IObserver<int> observer)
+        {
+            for (int i = 1; i <= 3; i++)
+            {
+                observer.OnNext(i);
+            }
+
+            observer.OnCompleted();
+            return Task.CompletedTask;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+
+    protected class MockObserver<T> : IObserver<T>
+    {
+        private readonly TaskCompletionSource<ImmutableList<T>> completed = new TaskCompletionSource<ImmutableList<T>>();
+
+        internal event EventHandler<T>? Next;
+
+        [System.Runtime.Serialization.IgnoreDataMember]
+        internal ImmutableList<T> ReceivedValues { get; private set; } = ImmutableList<T>.Empty;
+
+        [System.Runtime.Serialization.IgnoreDataMember]
+        internal Task<ImmutableList<T>> Completion => this.completed.Task;
+
+        internal AsyncAutoResetEvent ItemReceived { get; } = new AsyncAutoResetEvent();
+
+        public void OnCompleted() => this.completed.SetResult(this.ReceivedValues);
+
+        public void OnError(Exception error) => this.completed.SetException(error);
+
+        public void OnNext(T value)
+        {
+            Assert.False(this.completed.Task.IsCompleted);
+            this.ReceivedValues = this.ReceivedValues.Add(value);
+            this.Next?.Invoke(this, value);
+            this.ItemReceived.Set();
+        }
+    }
+}

--- a/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonContractResolverTests.cs
@@ -189,8 +189,6 @@ public partial class JsonContractResolverTest : TestBase
     {
         private readonly TaskCompletionSource<bool> completed = new TaskCompletionSource<bool>();
 
-        internal event EventHandler<int>? Next;
-
         internal Task Completion => this.completed.Task;
 
         public void OnCompleted() => this.completed.SetResult(true);

--- a/test/StreamJsonRpc.Tests/ObserverMarshalingTests.cs
+++ b/test/StreamJsonRpc.Tests/ObserverMarshalingTests.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
@@ -362,10 +359,8 @@ public abstract partial class ObserverMarshalingTests : TestBase
 
         internal event EventHandler<T>? Next;
 
-        [System.Runtime.Serialization.IgnoreDataMember]
         internal ImmutableList<T> ReceivedValues { get; private set; } = ImmutableList<T>.Empty;
 
-        [System.Runtime.Serialization.IgnoreDataMember]
         internal Task<ImmutableList<T>> Completion => this.completed.Task;
 
         internal AsyncAutoResetEvent ItemReceived { get; } = new AsyncAutoResetEvent();


### PR DESCRIPTION
Addressing failures similar to
```
StreamJsonRpc.RemoteMethodNotFoundException : Unable to find method 'xxx' on {no object} for the following reasons: Deserializing JSON-RPC argument with name "observer" and position 1 to type "xxx" failed: Could not create an instance of type xxx. Type is an interface or abstract class and cannot be instantiated. Path 'params[1].__jsonrpc_marshaled'.
```
when calling APIs under the following conditions:
- using Newtonsoft.Json
- the API has marshalable (`IObserver<>`, `IDisposable` or interfaces with `RpcMarshalableAttribute`) objects as parameters or return values
- the user replaces `JsonMessageFormatter`'s `ContractResolver`.

This issue has worsened since https://github.com/microsoft/vs-streamjsonrpc/pull/777 due to more behavior being delegated to the `ContractResolver`

This PR integrates the `ContractResolver` provided by the user with `MarshalContractResolver` before the first serialization or deserialization.