### PR TITLE
Test on .NET 6 instead of .NET 5

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
+++ b/test/StreamJsonRpc.Tests/CollectingTraceListener.cs
@@ -77,7 +77,7 @@ public class CollectingTraceListener : TraceListener
         }
     }
 
-    public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string format, params object?[]? args)
+    public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
     {
         lock (this.traceEventIds)
         {
@@ -86,7 +86,7 @@ public class CollectingTraceListener : TraceListener
 
         lock (this.events)
         {
-            this.events.Add((eventType, string.Format(CultureInfo.InvariantCulture, format, args ?? Array.Empty<object?>())));
+            this.events.Add((eventType, format is null ? null : string.Format(CultureInfo.InvariantCulture, format, args ?? Array.Empty<object?>())));
         }
 
         base.TraceEvent(eventCache, source, eventType, id, format, args);

--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace />
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5 is no longer supported by Microsoft. Testing on a runtime that no one should be using is pointless, especially when we could test on a newer runtime that most folks are on.