### PR TITLE
Start building 2.14 versions

### DIFF
--- a/azure-pipelines/variables/InsertTargetBranch.ps1
+++ b/azure-pipelines/variables/InsertTargetBranch.ps1
@@ -1,2 +1,2 @@
 # This is the default branch of the VS repo that we will use to insert into VS.
-'rel/d17.4'
+'main'

--- a/azure-pipelines/variables/InsertTargetBranch.ps1
+++ b/azure-pipelines/variables/InsertTargetBranch.ps1
@@ -1,2 +1,2 @@
 # This is the default branch of the VS repo that we will use to insert into VS.
-'main'
+'rel/d17.4'

--- a/doc/vs.md
+++ b/doc/vs.md
@@ -25,6 +25,7 @@ When building a Visual Studio extension, you should not include StreamJsonRpc in
 | VS 2022.2 | 1.5.x, 2.11.x
 | VS 2022.3 | 1.5.x, 2.12.x
 | VS 2022.4 | 1.5.x, 2.13.x
+| VS 2022.5 | 1.5.x, 2.14.x
 
 StreamJsonRpc versions are forwards and backwards compatible "over the wire". For example it is perfectly legitimate to use StreamJsonRpc 2.4 on the server-side even if the client only uses 1.0, or vice versa. If an RPC method utilizes a newer StreamJsonRpc feature (e.g. `IAsyncEnumerable<T>` return value) and an older client that doesn't support these specially marshaled objects is used to call that method, a memory leak on the server may result.
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.13",
+  "version": "2.14-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
Note this builds on (and effectively reverts) the new commit added for the v2.13 branch, so that we continue to build and insert into the VS main branch.