### PR TITLE
Fix race condition in async enum tracker

### DIFF
--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -241,9 +241,12 @@ public class MessageFormatterEnumerableTracker
                                 T element = await this.readAheadElements.ReceiveAsync(cancellationToken).ConfigureAwait(false);
                                 results.Add(element);
                             }
-                            catch (InvalidOperationException) when (this.readAheadElements.Completion.IsCompleted)
+                            catch (InvalidOperationException)
                             {
                                 // Race condition. The sequence is over.
+                                // Per https://github.com/microsoft/vs-streamjsonrpc/issues/867, we do *not* confirm this
+                                // block has completed because in fact the completion signal can come in asynchronously.
+                                // But per API documentation on the block, this exception should only be thrown in this case.
                                 finished = true;
                                 break;
                             }


### PR DESCRIPTION
Calling `BufferBlock<T>.Complete()` can set its own `Completion` property to complete asynchronously. If `ReceiveAsync()` can throw due to completion *before* its `Completion.IsCompleted` is set to `true`, that would repro this problem. I haven't been able to confirm by code inspection or debugger that the `BufferBlock` could do this, but based on the exception you report, I can come to no other conclusion. Based on the documentation of the API, it appears that it's safe to assume than any `InvalidOperationException` is thrown only in the case of a completed block though, so to fix this, I will remove the `when` clause.

Fixes #867