### PR TITLE
Allow users to pass in an ActivitySource to be used for generating a new Activity

### DIFF
--- a/src/StreamJsonRpc/ActivityTracingStrategy.cs
+++ b/src/StreamJsonRpc/ActivityTracingStrategy.cs
@@ -12,7 +12,7 @@ namespace StreamJsonRpc;
 /// <seealso cref="CorrelationManagerTracingStrategy"/>
 public class ActivityTracingStrategy : IActivityTracingStrategy
 {
-    private readonly ActivitySource activitySource;
+    private readonly ActivitySource? activitySource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ActivityTracingStrategy"/> class.
@@ -26,7 +26,7 @@ public class ActivityTracingStrategy : IActivityTracingStrategy
     /// Initializes a new instance of the <see cref="ActivityTracingStrategy"/> class.
     /// </summary>
     /// <param name="activitySource">The <see cref="ActivitySource"/> to use for creating activities.</param>
-    public ActivityTracingStrategy(ActivitySource activitySource)
+    public ActivityTracingStrategy(ActivitySource? activitySource)
     {
         this.activitySource = activitySource;
     }

--- a/src/StreamJsonRpc/ActivityTracingStrategy.cs
+++ b/src/StreamJsonRpc/ActivityTracingStrategy.cs
@@ -59,21 +59,7 @@ public class ActivityTracingStrategy : IActivityTracingStrategy
         return state;
     }
 
-    private Activity CreateNewActivity(string name)
-    {
-        Activity? activity = null;
-        if (this.activitySource is object)
-        {
-            activity = this.activitySource.StartActivity(name);
-        }
-
-        if (activity is null)
-        {
-            activity = new Activity(name);
-        }
-
-        return activity;
-    }
+    private Activity CreateNewActivity(string name) => this.activitySource?.StartActivity(name) ?? new Activity(name);
 
     private class State : IDisposable
     {

--- a/src/StreamJsonRpc/ActivityTracingStrategy.cs
+++ b/src/StreamJsonRpc/ActivityTracingStrategy.cs
@@ -12,6 +12,25 @@ namespace StreamJsonRpc;
 /// <seealso cref="CorrelationManagerTracingStrategy"/>
 public class ActivityTracingStrategy : IActivityTracingStrategy
 {
+    private readonly ActivitySource activitySource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivityTracingStrategy"/> class.
+    /// </summary>
+    public ActivityTracingStrategy()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivityTracingStrategy"/> class.
+    /// </summary>
+    /// <param name="activitySource">The <see cref="ActivitySource"/> to use for creating activities.</param>
+    public ActivityTracingStrategy(ActivitySource activitySource)
+    {
+        this.activitySource = activitySource;
+    }
+
     /// <inheritdoc/>
     public void ApplyOutboundActivity(JsonRpcRequest request)
     {
@@ -29,7 +48,7 @@ public class ActivityTracingStrategy : IActivityTracingStrategy
     {
         Requires.NotNull(request, nameof(request));
 
-        var state = new State(new Activity(request.Method!));
+        var state = new State(this.CreateNewActivity(request.Method!));
         state.NewActivity.TraceStateString = request.TraceState;
         if (request.TraceParent is object)
         {
@@ -38,6 +57,22 @@ public class ActivityTracingStrategy : IActivityTracingStrategy
 
         state.NewActivity.Start();
         return state;
+    }
+
+    private Activity CreateNewActivity(string name)
+    {
+        Activity? activity = null;
+        if (this.activitySource is object)
+        {
+            activity = this.activitySource.StartActivity(name);
+        }
+
+        if (activity is null)
+        {
+            activity = new Activity(name);
+        }
+
+        return activity;
     }
 
     private class State : IDisposable

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource! activitySource) -> void
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource! activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource activitySource) -> void
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource? activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource! activitySource) -> void
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource! activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource activitySource) -> void
+StreamJsonRpc.ActivityTracingStrategy.ActivityTracingStrategy(System.Diagnostics.ActivitySource? activitySource) -> void
 StreamJsonRpc.BadRpcHeaderException
 StreamJsonRpc.BadRpcHeaderException.BadRpcHeaderException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 StreamJsonRpc.DisconnectedReason


### PR DESCRIPTION
If there is no listener attached to the activity source, the activity will not be created, so fallback to create the Activity using the constructor