### PR TITLE
Intern strings when using the MessagePackFormatter

### DIFF
--- a/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/MessagePackFormatterTests.cs
@@ -413,6 +413,38 @@ public class MessagePackFormatterTests : TestBase
         Assert.Null(value);
     }
 
+    [Fact]
+    public void StringsInUserDataAreInterned()
+    {
+        var dynamic = new
+        {
+            jsonrpc = "2.0",
+            method = "something",
+            extra = (object?)null,
+            @params = new object[] { "hi" },
+        };
+        var request1 = this.Read<JsonRpcRequest>(dynamic);
+        var request2 = this.Read<JsonRpcRequest>(dynamic);
+        Assert.True(request1.TryGetArgumentByNameOrIndex(null, 0, typeof(string), out object? arg1));
+        Assert.True(request2.TryGetArgumentByNameOrIndex(null, 0, typeof(string), out object? arg2));
+        Assert.Same(arg2, arg1); // reference equality to ensure it was interned.
+    }
+
+    [Fact]
+    public void StringValuesOfStandardPropertiesAreInterned()
+    {
+        var dynamic = new
+        {
+            jsonrpc = "2.0",
+            method = "something",
+            extra = (object?)null,
+            @params = Array.Empty<object?>(),
+        };
+        var request1 = this.Read<JsonRpcRequest>(dynamic);
+        var request2 = this.Read<JsonRpcRequest>(dynamic);
+        Assert.Same(request1.Method, request2.Method); // reference equality to ensure it was interned.
+    }
+
     private T Read<T>(object anonymousObject)
         where T : JsonRpcMessage
     {


### PR DESCRIPTION
This feature is available in MessagePack but not on by default because it has a (small) perf cost when deserializing. But we want it on for RPC by default.

String interning means that we reuse string objects that are equal by value rather than creating new ones. We *don't* use `string.Intern` here because that keeps them in memory forever, and because that requires allocating a string before switching it for the long-lived instance. The way MessagePack (and this PR) does it requires no allocations at all if the string has been interned before. And the interning collection (which comes from MSBuild) is a weak intern, meaning string will not be held in memory for the life of the process.

I also use my `CommonString` type in a few more places. This has the effect of never deserializing even the first string, nor taking the perf hit of an interned string lookup. It memorizes the encoding and decoding between chars and bytes and reuses them each time.