### PR TITLE
Remove DataContract attribute support from the STJ formatter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -164,6 +164,9 @@ csharp_prefer_braces = true:silent
 # SA1130: Use lambda syntax
 dotnet_diagnostic.SA1130.severity = silent
 
+# SA1133: Do not combine attributes
+dotnet_diagnostic.SA1133.severity = silent
+
 # IDE1006: Naming Styles - StyleCop handles these for us
 dotnet_diagnostic.IDE1006.severity = none
 

--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -90,9 +90,7 @@ StreamJsonRpc includes the following `IJsonRpcMessageFormatter` implementations:
 
 1. `SystemTextJsonFormatter` - Uses the [`System.Text.Json` library][SystemTextJson] to serialize each
     JSON-RPC message as UTF-8 encoded JSON. 
-    All RPC method parameters and return types must be serializable by System.Text.Json,
-    with the additional benefit of `DataContract` and `DataMember` attributes being supported by default
-    within StreamJsonRpc where System.Text.Json alone does not support them.
+    All RPC method parameters and return types must be serializable by System.Text.Json.
     You can leverage `JsonConverter<T>` and add your custom converters via attributes or by
     contributing them to the `SystemTextJsonFormatter.JsonSerializerOptions.Converters` collection.
 

--- a/src/StreamJsonRpc/Protocol/CommonErrorData.cs
+++ b/src/StreamJsonRpc/Protocol/CommonErrorData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
 
@@ -37,29 +38,34 @@ public class CommonErrorData
     /// Gets or sets the type of error (e.g. the full type name of the exception thrown).
     /// </summary>
     [DataMember(Order = 0, Name = "type")]
+    [STJ.JsonPropertyName("type"), STJ.JsonPropertyOrder(0)]
     public string? TypeName { get; set; }
 
     /// <summary>
     /// Gets or sets the message associated with this error.
     /// </summary>
     [DataMember(Order = 1, Name = "message")]
+    [STJ.JsonPropertyName("message"), STJ.JsonPropertyOrder(1)]
     public string? Message { get; set; }
 
     /// <summary>
     /// Gets or sets the stack trace associated with the error.
     /// </summary>
     [DataMember(Order = 2, Name = "stack")]
+    [STJ.JsonPropertyName("stack"), STJ.JsonPropertyOrder(2)]
     public string? StackTrace { get; set; }
 
     /// <summary>
     /// Gets or sets the application error code or HRESULT of the failure.
     /// </summary>
     [DataMember(Order = 3, Name = "code")]
+    [STJ.JsonPropertyName("code"), STJ.JsonPropertyOrder(3)]
     public int HResult { get; set; }
 
     /// <summary>
     /// Gets or sets the inner error information, if any.
     /// </summary>
     [DataMember(Order = 4, Name = "inner")]
+    [STJ.JsonPropertyName("inner"), STJ.JsonPropertyOrder(4)]
     public CommonErrorData? Inner { get; set; }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -3,8 +3,9 @@
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using Newtonsoft.Json.Linq;
 using StreamJsonRpc.Reflection;
+using JsonNET = Newtonsoft.Json.Linq;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
 
@@ -19,6 +20,7 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets the detail about the error.
     /// </summary>
     [DataMember(Name = "error", Order = 2, IsRequired = true)]
+    [STJ.JsonPropertyName("error"), STJ.JsonPropertyOrder(2), STJ.JsonRequired]
     public ErrorDetail? Error { get; set; }
 
     /// <summary>
@@ -27,6 +29,7 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
     /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <see langword="null"/>.</value>
     [Obsolete("Use " + nameof(RequestId) + " instead.")]
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public object? Id
     {
         get => this.RequestId.ObjectValue;
@@ -37,6 +40,7 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets an identifier established by the client if a response to the request is expected.
     /// </summary>
     [DataMember(Name = "id", Order = 1, IsRequired = true, EmitDefaultValue = true)]
+    [STJ.JsonPropertyName("id"), STJ.JsonPropertyOrder(1), STJ.JsonRequired]
     public RequestId RequestId { get; set; }
 
     /// <summary>
@@ -47,13 +51,13 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JObject
+        return new JsonNET.JObject
         {
-            new JProperty("id", this.RequestId.ObjectValue),
-            new JProperty("error", new JObject
+            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
+            new JsonNET.JProperty("error", new JsonNET.JObject
             {
-                new JProperty("code", this.Error?.Code),
-                new JProperty("message", this.Error?.Message),
+                new JsonNET.JProperty("code", this.Error?.Code),
+                new JsonNET.JProperty("message", this.Error?.Message),
             }),
         }.ToString(Newtonsoft.Json.Formatting.None);
     }
@@ -74,6 +78,7 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
         /// Codes outside that range are available for app-specific error codes.
         /// </value>
         [DataMember(Name = "code", Order = 0, IsRequired = true)]
+        [STJ.JsonPropertyName("code"), STJ.JsonPropertyOrder(0), STJ.JsonRequired]
         public JsonRpcErrorCode Code { get; set; }
 
         /// <summary>
@@ -83,6 +88,7 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
         /// The message SHOULD be limited to a concise single sentence.
         /// </remarks>
         [DataMember(Name = "message", Order = 1, IsRequired = true)]
+        [STJ.JsonPropertyName("message"), STJ.JsonPropertyOrder(1), STJ.JsonRequired]
         public string? Message { get; set; }
 
         /// <summary>
@@ -90,9 +96,8 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
         /// </summary>
         [DataMember(Name = "data", Order = 2, IsRequired = false)]
         [Newtonsoft.Json.JsonProperty(DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Ignore)]
-#pragma warning disable CA1721 // Property names should not match get methods
+        [STJ.JsonPropertyName("data"), STJ.JsonPropertyOrder(2)]
         public object? Data { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets the value of the <see cref="Data"/>, taking into account any possible type coercion.

--- a/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcMessage.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
-using Microsoft;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
 
@@ -21,6 +21,7 @@ public abstract class JsonRpcMessage
     /// </summary>
     /// <value>Defaults to "2.0".</value>
     [DataMember(Name = "jsonrpc", Order = 0, IsRequired = true)]
+    [STJ.JsonPropertyName("jsonrpc"), STJ.JsonPropertyOrder(0), STJ.JsonRequired]
     public string Version { get; set; } = "2.0";
 
     /// <summary>

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -4,7 +4,8 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Serialization;
-using Newtonsoft.Json.Linq;
+using JsonNET = Newtonsoft.Json.Linq;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
 
@@ -45,6 +46,7 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets the name of the method to be invoked.
     /// </summary>
     [DataMember(Name = "method", Order = 2, IsRequired = true)]
+    [STJ.JsonPropertyName("method"), STJ.JsonPropertyOrder(2), STJ.JsonRequired]
     public string? Method { get; set; }
 
     /// <summary>
@@ -58,6 +60,7 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// If neither of these, <see cref="ArgumentCount"/> and <see cref="TryGetArgumentByNameOrIndex(string, int, Type, out object)"/> should be overridden.
     /// </value>
     [DataMember(Name = "params", Order = 3, IsRequired = false, EmitDefaultValue = false)]
+    [STJ.JsonPropertyName("params"), STJ.JsonPropertyOrder(3), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingNull)]
     public object? Arguments { get; set; }
 
     /// <summary>
@@ -66,6 +69,7 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <see langword="null"/>.</value>
     [Obsolete("Use " + nameof(RequestId) + " instead.")]
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public object? Id
     {
         get => this.RequestId.ObjectValue;
@@ -76,30 +80,35 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets an identifier established by the client if a response to the request is expected.
     /// </summary>
     [DataMember(Name = "id", Order = 1, IsRequired = false, EmitDefaultValue = false)]
+    [STJ.JsonPropertyName("id"), STJ.JsonPropertyOrder(1), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingDefault)]
     public RequestId RequestId { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether a response to this request is expected.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public bool IsResponseExpected => !this.RequestId.IsEmpty;
 
     /// <summary>
     /// Gets a value indicating whether this is a notification, and no response is expected.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public bool IsNotification => this.RequestId.IsEmpty;
 
     /// <summary>
     /// Gets the number of arguments supplied in the request.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public virtual int ArgumentCount => this.NamedArguments?.Count ?? this.ArgumentsList?.Count ?? 0;
 
     /// <summary>
     /// Gets or sets the dictionary of named arguments, if applicable.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public IReadOnlyDictionary<string, object?>? NamedArguments
     {
         get => this.Arguments as IReadOnlyDictionary<string, object?>;
@@ -117,12 +126,14 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// This list is used for purposes of aiding the <see cref="IJsonRpcMessageFormatter"/> in serialization.
     /// </remarks>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public IReadOnlyDictionary<string, Type>? NamedArgumentDeclaredTypes { get; set; }
 
     /// <summary>
     /// Gets or sets an array of arguments, if applicable.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     [Obsolete("Use " + nameof(ArgumentsList) + " instead.")]
 #pragma warning disable CA1819 // Properties should not return arrays
     public object?[]? ArgumentsArray
@@ -136,6 +147,7 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets a read only list of arguments, if applicable.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public IReadOnlyList<object?>? ArgumentsList
     {
         get => this.Arguments as IReadOnlyList<object?>;
@@ -155,24 +167,28 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// This list is used for purposes of aiding the <see cref="IJsonRpcMessageFormatter"/> in serialization.
     /// </remarks>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public IReadOnlyList<Type>? ArgumentListDeclaredTypes { get; set; }
 
     /// <summary>
     /// Gets the sequence of argument names, if applicable.
     /// </summary>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public virtual IEnumerable<string>? ArgumentNames => this.NamedArguments?.Keys;
 
     /// <summary>
     /// Gets or sets the data for the <see href="https://www.w3.org/TR/trace-context/">W3C Trace Context</see> <c>traceparent</c> value.
     /// </summary>
     [DataMember(Name = "traceparent", EmitDefaultValue = false)]
+    [STJ.JsonPropertyName("traceparent"), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingNull)]
     public string? TraceParent { get; set; }
 
     /// <summary>
     /// Gets or sets the data for the <see href="https://www.w3.org/TR/trace-context/">W3C Trace Context</see> <c>tracestate</c> value.
     /// </summary>
     [DataMember(Name = "tracestate", EmitDefaultValue = false)]
+    [STJ.JsonPropertyName("tracestate"), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingNull)]
     public string? TraceState { get; set; }
 
     /// <summary>
@@ -271,10 +287,10 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JObject
+        return new JsonNET.JObject
         {
-            new JProperty("id", this.RequestId.ObjectValue),
-            new JProperty("method", this.Method),
+            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
+            new JsonNET.JProperty("method", this.Method),
         }.ToString(Newtonsoft.Json.Formatting.None);
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -3,7 +3,8 @@
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using Newtonsoft.Json.Linq;
+using JsonNET = Newtonsoft.Json.Linq;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
 
@@ -18,9 +19,8 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets the value of the result of an invocation, if any.
     /// </summary>
     [DataMember(Name = "result", Order = 2, IsRequired = true, EmitDefaultValue = true)]
-#pragma warning disable CA1721 // Property names should not match get methods
+    [STJ.JsonPropertyName("result"), STJ.JsonPropertyOrder(2), STJ.JsonRequired]
     public object? Result { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
 
     /// <summary>
     /// Gets or sets the declared type of the return value.
@@ -29,6 +29,7 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// This value is not serialized, but is used by the RPC server to assist in serialization where necessary.
     /// </remarks>
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public Type? ResultDeclaredType { get; set; }
 
     /// <summary>
@@ -37,6 +38,7 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// <value>A <see cref="string"/>, an <see cref="int"/>, a <see cref="long"/>, or <see langword="null"/>.</value>
     [Obsolete("Use " + nameof(RequestId) + " instead.")]
     [IgnoreDataMember]
+    [STJ.JsonIgnore]
     public object? Id
     {
         get => this.RequestId.ObjectValue;
@@ -47,6 +49,7 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// Gets or sets an identifier established by the client if a response to the request is expected.
     /// </summary>
     [DataMember(Name = "id", Order = 1, IsRequired = true)]
+    [STJ.JsonPropertyName("id"), STJ.JsonPropertyOrder(1), STJ.JsonRequired]
     public RequestId RequestId { get; set; }
 
     /// <summary>
@@ -68,9 +71,9 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JObject
+        return new JsonNET.JObject
         {
-            new JProperty("id", this.RequestId.ObjectValue),
+            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
         }.ToString(Newtonsoft.Json.Formatting.None);
     }
 

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
 using StreamJsonRpc.Protocol;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Reflection;
 
@@ -496,9 +497,11 @@ public class MessageFormatterEnumerableTracker
     private class EnumeratorResults<T>
     {
         [DataMember(Name = ValuesPropertyName, Order = 0)]
-        internal IReadOnlyList<T>? Values { get; set; }
+        [STJ.JsonPropertyName(ValuesPropertyName), STJ.JsonPropertyOrder(0)]
+        public IReadOnlyList<T>? Values { get; set; }
 
         [DataMember(Name = FinishedPropertyName, Order = 1)]
-        internal bool Finished { get; set; }
+        [STJ.JsonPropertyName(FinishedPropertyName), STJ.JsonPropertyOrder(1)]
+        public bool Finished { get; set; }
     }
 }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.Threading;
 using static System.FormattableString;
+using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Reflection;
 
@@ -391,15 +392,19 @@ internal class MessageFormatterRpcMarshaledContextTracker
         }
 
         [DataMember(Name = "__jsonrpc_marshaled", IsRequired = true)]
+        [STJ.JsonPropertyName("__jsonrpc_marshaled"), STJ.JsonRequired]
         public int Marshaled { get; set; }
 
         [DataMember(Name = "handle", IsRequired = true)]
+        [STJ.JsonPropertyName("handle"), STJ.JsonRequired]
         public long Handle { get; set; }
 
         [DataMember(Name = "lifetime", EmitDefaultValue = false)]
+        [STJ.JsonPropertyName("lifetime"), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingNull)]
         public string? Lifetime { get; set; }
 
         [DataMember(Name = "optionalInterfaces", EmitDefaultValue = false)]
+        [STJ.JsonPropertyName("optionalInterfaces"), STJ.JsonIgnore(Condition = STJ.JsonIgnoreCondition.WhenWritingNull)]
         public int[]? OptionalInterfacesCodes { get; set; }
     }
 

--- a/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -6,12 +6,9 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.Serialization;
 using System.Text;
-using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
-using StreamJsonRpc;
-using Xunit;
-using Xunit.Abstractions;
+using STJ = System.Text.Json.Serialization;
 
 public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
 {
@@ -1107,6 +1104,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
             this.innerStream = innerStream;
         }
 
+        [STJ.JsonPropertyName("innerStream")]
         public Stream InnerStream => this.innerStream;
     }
 }

--- a/test/StreamJsonRpc.Tests/SystemTextJsonFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/SystemTextJsonFormatterTests.cs
@@ -5,9 +5,6 @@ using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nerdbank.Streams;
-using Newtonsoft.Json.Linq;
-using StreamJsonRpc;
-using Xunit.Abstractions;
 
 public class SystemTextJsonFormatterTests : FormatterTestBase<SystemTextJsonFormatter>
 {
@@ -16,10 +13,31 @@ public class SystemTextJsonFormatterTests : FormatterTestBase<SystemTextJsonForm
     {
     }
 
-    protected new SystemTextJsonFormatter Formatter => (SystemTextJsonFormatter)base.Formatter;
+    ////[Fact]
+    ////public void DataContractAttributesWinOverSTJAttributes()
+    ////{
+    ////    this.Formatter = new SystemTextJsonFormatter
+    ////    {
+    ////        JsonSerializerOptions =
+    ////        {
+    ////            TypeInfoResolver = new SystemTextJsonFormatter.DataContractResolver(),
+    ////        },
+    ////    };
+    ////    IJsonRpcMessageFactory messageFactory = this.Formatter;
+    ////    JsonRpcRequest requestMessage = messageFactory.CreateRequestMessage();
+    ////    requestMessage.Method = "test";
+    ////    requestMessage.Arguments = new[] { new DCSClass { C = 1 } };
+
+    ////    using Sequence<byte> sequence = new();
+    ////    this.Formatter.Serialize(sequence, requestMessage);
+
+    ////    using JsonDocument doc = JsonDocument.Parse(sequence);
+    ////    this.Logger.WriteLine(doc.RootElement.ToString());
+    ////    Assert.Equal(1, doc.RootElement.GetProperty("params")[0].GetProperty("A").GetInt32());
+    ////}
 
     [Fact]
-    public void DataContractAttributesWinOverSTJAttributes()
+    public void STJAttributesWinOverDataContractAttributesByDefault()
     {
         IJsonRpcMessageFactory messageFactory = this.Formatter;
         JsonRpcRequest requestMessage = messageFactory.CreateRequestMessage();
@@ -31,7 +49,7 @@ public class SystemTextJsonFormatterTests : FormatterTestBase<SystemTextJsonForm
 
         using JsonDocument doc = JsonDocument.Parse(sequence);
         this.Logger.WriteLine(doc.RootElement.ToString());
-        Assert.Equal(1, doc.RootElement.GetProperty("params")[0].GetProperty("A").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("params")[0].GetProperty("B").GetInt32());
     }
 
     [Fact]


### PR DESCRIPTION
It probably will meet more customer expectations (at least in the long term) if the default behavior of our System.Text.Json formatter matches the default behavior of the System.Text.Json serializer.

Also, @matteo-prosperi pointed out we do a lot of boxing in this implementation, which is something we should try to avoid in our official implementation.
Finally, it seems like if folks are looking for DCS compatibility, they may want to match behavior of unattributed types as well, but it turns out that in that mode, our class breaks on the simplest cases. This should probably also be fixed. But in the meantime, I've removed that option from what is now dead code.

We might bring it back, but it should be opt-in instead of opt-out, and it should ideally be more thoroughly tested and perf-optimized to avoid boxing as far as possible.
For now, I'm leaning toward leaving the 'dead code' that provides the DCS compatibility in place till we're more settled on what to do with it.