### PR TITLE
Remove properties inadvertently made public

### DIFF
--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -24,7 +24,7 @@ namespace StreamJsonRpc;
 /// <summary>
 /// A formatter that emits UTF-8 encoded JSON where user data should be serializable via the <see cref="JsonSerializer"/>.
 /// </summary>
-public class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFormatter, IJsonRpcMessageTextFormatter, IJsonRpcInstanceContainer, IJsonRpcFormatterState, IJsonRpcMessageFactory, IJsonRpcFormatterTracingCallbacks
+public class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFormatter, IJsonRpcMessageTextFormatter, IJsonRpcInstanceContainer, IJsonRpcMessageFactory, IJsonRpcFormatterTracingCallbacks
 {
     private static readonly JsonWriterOptions WriterOptions = new() { };
 

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -16,7 +16,6 @@ StreamJsonRpc.FormatterBase.DeserializationTracking
 StreamJsonRpc.FormatterBase.DeserializationTracking.DeserializationTracking() -> void
 StreamJsonRpc.FormatterBase.DeserializationTracking.DeserializationTracking(StreamJsonRpc.FormatterBase! formatter, StreamJsonRpc.Protocol.JsonRpcMessage! message, System.ReadOnlySpan<System.Reflection.ParameterInfo!> parameters) -> void
 StreamJsonRpc.FormatterBase.DeserializationTracking.Dispose() -> void
-StreamJsonRpc.FormatterBase.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.FormatterBase.Dispose() -> void
 StreamJsonRpc.FormatterBase.DuplexPipeTracker.get -> StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker!
 StreamJsonRpc.FormatterBase.EnumerableTracker.get -> StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker!
@@ -44,8 +43,6 @@ StreamJsonRpc.FormatterBase.SerializationTracking
 StreamJsonRpc.FormatterBase.SerializationTracking.Dispose() -> void
 StreamJsonRpc.FormatterBase.SerializationTracking.SerializationTracking() -> void
 StreamJsonRpc.FormatterBase.SerializationTracking.SerializationTracking(StreamJsonRpc.FormatterBase! formatter, StreamJsonRpc.Protocol.JsonRpcMessage! message) -> void
-StreamJsonRpc.FormatterBase.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.FormatterBase.SerializingRequest.get -> bool
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase.OutboundProperties.get -> System.Collections.Generic.Dictionary<string!, (System.Type! DeclaredType, object? Value)>!
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase.TopLevelPropertyBagBase(bool isOutbound) -> void

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -16,7 +16,6 @@ StreamJsonRpc.FormatterBase.DeserializationTracking
 StreamJsonRpc.FormatterBase.DeserializationTracking.DeserializationTracking() -> void
 StreamJsonRpc.FormatterBase.DeserializationTracking.DeserializationTracking(StreamJsonRpc.FormatterBase! formatter, StreamJsonRpc.Protocol.JsonRpcMessage! message, System.ReadOnlySpan<System.Reflection.ParameterInfo!> parameters) -> void
 StreamJsonRpc.FormatterBase.DeserializationTracking.Dispose() -> void
-StreamJsonRpc.FormatterBase.DeserializingMessageWithId.get -> StreamJsonRpc.RequestId
 StreamJsonRpc.FormatterBase.Dispose() -> void
 StreamJsonRpc.FormatterBase.DuplexPipeTracker.get -> StreamJsonRpc.Reflection.MessageFormatterDuplexPipeTracker!
 StreamJsonRpc.FormatterBase.EnumerableTracker.get -> StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker!
@@ -44,8 +43,6 @@ StreamJsonRpc.FormatterBase.SerializationTracking
 StreamJsonRpc.FormatterBase.SerializationTracking.Dispose() -> void
 StreamJsonRpc.FormatterBase.SerializationTracking.SerializationTracking() -> void
 StreamJsonRpc.FormatterBase.SerializationTracking.SerializationTracking(StreamJsonRpc.FormatterBase! formatter, StreamJsonRpc.Protocol.JsonRpcMessage! message) -> void
-StreamJsonRpc.FormatterBase.SerializingMessageWithId.get -> StreamJsonRpc.RequestId
-StreamJsonRpc.FormatterBase.SerializingRequest.get -> bool
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase.OutboundProperties.get -> System.Collections.Generic.Dictionary<string!, (System.Type! DeclaredType, object? Value)>!
 StreamJsonRpc.FormatterBase.TopLevelPropertyBagBase.TopLevelPropertyBagBase(bool isOutbound) -> void


### PR DESCRIPTION
Back in #908 during the refactoring that created a `FormatterBase` class, properties that used to be explicit interface implementations were made public. These properties are of no interest to the standard user of a formatter so I don't want them exposed publicly. They are still exposed via a public interface so that the advanced cases they were introduced to address are still addressed.

This is not a breaking change relative to our last stable release, because the APIs being removed were added only recently.