### PR TITLE
Fix unescaped newline in bad rpc header message

### DIFF
--- a/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
+++ b/src/StreamJsonRpc/HeaderDelimitedMessageHandler.cs
@@ -455,7 +455,7 @@ public class HeaderDelimitedMessageHandler : PipeMessageHandler
             SequencePosition? cr = line.PositionOf((byte)'\r');
             if (!cr.HasValue || !line.GetPosition(1, cr.Value).Equals(lf))
             {
-                throw new BadRpcHeaderException("Header does not end with expected \r\n character sequence: " + HeaderEncoding.GetString(line.ToArray()));
+                throw new BadRpcHeaderException(@"Header does not end with expected \r\n character sequence: " + HeaderEncoding.GetString(line.ToArray()));
             }
 
             // Trim off the \r now that we confirmed it was there.


### PR DESCRIPTION
This string had \r\n in it, which just caused a newline to print, leading to a very confusing error message. I believe the intent was to print \r\n literally rather than a newline.

Discovered while working on [a pr for another project](https://github.com/ionide/LanguageServerProtocol/pull/51)