### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://eng.ms/docs/products/dependabot/configuration/version_updates
+
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: /
+  schedule:
+    interval: monthly

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,13 +15,13 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.0",
+      "version": "17.7.1",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.128",
+      "version": "3.6.133",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.101-jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
 - package-ecosystem: nuget
   directory: /
   schedule:
-    interval: monthly
+    interval: weekly
   ignore:
   - dependency-name: Newtonsoft.Json # This has to match VS and VS rarely updates it
   - dependency-name: Microsoft.AspNetCore.TestHost # Later versions require .NET Core 3.1, which prevents our testing on net472

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "files.trimFinalNewlines": true,
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableImportCompletion": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "omnisharp.enableRoslynAnalyzers": true,
+  "dotnet.defaultSolution": "StreamJsonRpc.sln"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />
@@ -41,11 +41,11 @@
     <PackageVersion Include="xunit" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.329" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <MessagePackVersion>2.5.108</MessagePackVersion>
-    <MicroBuildVersion>2.0.117</MicroBuildVersion>
+    <MicroBuildVersion>2.0.125</MicroBuildVersion>
     <VisualStudioThreadingVersion>17.6.40</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,6 @@ parameters:
   default: true
 
 variables:
-  MSBuildTreatWarningsAsErrors: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   BuildConfiguration: Release
   codecov_token: 9a7c2ba3-0a4b-4479-96e8-3bfd01a982f6

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -135,7 +135,7 @@ if (!$Requester) {
         $Requester = $env:USERNAME
     }
     if (!$Requester) {
-        Write-Error "Unable to determine default value for -Requester."
+        $Requester = $OwnerAlias
     }
 }
 

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -3,7 +3,7 @@ parameters:
 
 steps:
 
-- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
+- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnaserror /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠 dotnet build
 
 - powershell: azure-pipelines/dotnet-test-cloud.ps1 -Configuration $(BuildConfiguration) -Agent $(Agent.JobName) -PublishResults

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -50,7 +50,6 @@ stages:
 
 - stage: Build
   variables:
-    MSBuildTreatWarningsAsErrors: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     BuildConfiguration: Release
     NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -4,13 +4,14 @@ parameters:
   default: true
 
 stages:
-- ${{ if parameters.ArchiveSymbols }}:
-  - stage: symbol_archive
-    displayName: Symbol archival
-    condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
-    jobs:
-    - job: archive
-      pool: VSEng-ReleasePool-1ES
+- stage: release
+  displayName: Publish
+  condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
+  jobs:
+  - ${{ if parameters.ArchiveSymbols }}:
+    - job: symbol_archive
+      displayName: Archive symbols
+      pool: VSEngSS-MicroBuild2022-1ES
       steps:
       - checkout: none
       - download: current
@@ -21,22 +22,20 @@ stages:
       - download: current
         artifact: symbols-legacy
         displayName: 🔻 Download symbols-legacy artifact
-      - task: MicroBuildArchiveSymbols@1
+      - task: MicroBuildArchiveSymbols@4
         displayName: 🔣 Archive symbols to Symweb
         inputs:
           SymbolsFeatureName: $(SymbolsFeatureName)
-          SymbolsSymwebProject: VS
-          SymbolsUncPath: \\cpvsbuild\drops\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildId)\Symbols.Archival
-          SymbolsEmailContacts: vsidemicrobuild
+          SymbolsProject: VS
           SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
+          azureSubscription: Symbols Upload (DevDiv)
       - task: MicroBuildCleanup@1
         displayName: ☎️ Send Telemetry
 
-- stage: azure_public_vssdk_feed
-  displayName: azure-public/vssdk feed
-  condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
-  jobs:
   - job: push
+    displayName: azure-public/vssdk feed
+    ${{ if parameters.ArchiveSymbols }}:
+      dependsOn: symbol_archive
     pool:
       name: AzurePipelines-EO
       vmImage: AzurePipelinesUbuntu20.04compliant

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -28,7 +28,6 @@ steps:
       !**/linux-*/**
       !**/osx*/**
     TargetFolder: $(Build.ArtifactStagingDirectory)/APIScanInputs
-  condition: and(succeeded(), ${{ parameters.EnableAPIScan }}, ne(variables.ApiScanClientId, ''))
 
 - task: BinSkim@4
   displayName: 🔍 Run BinSkim

--- a/azure-pipelines/variables/InsertVersionsValues.ps1
+++ b/azure-pipelines/variables/InsertVersionsValues.ps1
@@ -1,3 +1,5 @@
+$MacroName = 'StreamJsonRpcVersion'
+$SampleProject = "$PSScriptRoot\..\..\src\StreamJsonRpc"
 [string]::join(',',(@{
-    ('StreamJsonRpcVersion') = & { (dotnet tool run nbgv get-version --project "$PSScriptRoot\..\..\src\StreamJsonRpc" --format json | ConvertFrom-Json).AssemblyVersion };
+    ($MacroName) = & { (dotnet tool run nbgv -- get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
 }.GetEnumerator() |% { "$($_.key)=$($_.value)" }))

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.203",
+    "version": "7.0.302",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/init.ps1
+++ b/init.ps1
@@ -102,13 +102,13 @@ Push-Location $PSScriptRoot
 try {
     $HeaderColor = 'Green'
 
-    if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
-        $RestoreArguments = @()
-        if ($Interactive)
-        {
-            $RestoreArguments += '--interactive'
-        }
+    $RestoreArguments = @()
+    if ($Interactive)
+    {
+        $RestoreArguments += '--interactive'
+    }
 
+    if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
         dotnet restore @RestoreArguments
         if ($lastexitcode -ne 0) {


### PR DESCRIPTION
- Update Dockerfile
- Fix placement of $RestoreArguments construction
- Switch from `MSBuildTreatWarningsAsErrors` to `-warnaserror`
- Fix BinSkim when ApiScan won't run
- Bump .NET SDK to 7.0.302
- Parameterize and add diagnostics to InsertVersionsValues.ps1
- Fix schedule triggered source code archival
- Upgrade archive symbols task to v4
-  Consolidate two stages to just one
- Bump NB.GV to 3.6.132
- Bump CSharpIsNullAnalyzer from 0.1.329 to 0.1.495 (#204)
- Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 (#202)
- Bump dotnet-coverage from 17.7.0 to 17.7.1 (#205)
- (Hopefully) fix `nbgv` failures with `--` argument separator
- Fix indentation of commented section
- Bump Nerdbank.GitVersioning to 3.6.133
- Bump Microsoft.NET.Test.Sdk to 17.6.1
- Enable dependabot for Azure Repos
- Bump Microsoft.NET.Test.Sdk to 17.6.2
- Bump MicroBuild to 2.0.125
- Add C# Dev Kit setting
