### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.2",
+      "version": "17.7.3",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.4",
+      "version": "7.3.5",
       "commands": [
         "pwsh"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
-    <PackageVersion Include="Nerdbank.Streams" Version="2.10.66" />
+    <PackageVersion Include="Nerdbank.Streams" Version="2.10.69" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <MessagePackVersion>2.5.108</MessagePackVersion>
-    <MicroBuildVersion>2.0.127</MicroBuildVersion>
+    <MicroBuildVersion>2.0.130</MicroBuildVersion>
     <VisualStudioThreadingVersion>17.6.40</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -155,7 +155,7 @@ if (!$RepoUrl) {
 }
 
 Push-Location $PSScriptRoot
-$versionsObj = dotnet tool run nbgv get-version -f json | ConvertFrom-Json
+$versionsObj = dotnet nbgv get-version -f json | ConvertFrom-Json
 Pop-Location
 
 $ReleaseDateString = $ReleaseDate.ToShortDateString()

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -43,8 +43,13 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $dllPath = "$($_.Directory)/$($_.BaseName).dll"
-    $exePath = "$($_.Directory)/$($_.BaseName).exe"
+    $rootName = "$($_.Directory)/$($_.BaseName)"
+    if ($rootName.EndsWith('.ni')) {
+        $rootName = $rootName.Substring(0, $rootName.Length - 3)
+    }
+
+    $dllPath = "$rootName.dll"
+    $exePath = "$rootName.exe"
     if (Test-Path $dllPath) {
         $BinaryImagePath = $dllPath
     } elseif (Test-Path $exePath) {

--- a/azure-pipelines/Merge-CodeCoverage.ps1
+++ b/azure-pipelines/Merge-CodeCoverage.ps1
@@ -42,7 +42,7 @@ try {
             New-Item -Type Directory -Path (Split-Path $OutputFile) | Out-Null
         }
 
-        & dotnet tool run dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
+        & dotnet dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
     } else {
         Write-Error "No reports found to merge."
     }

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -12,10 +12,10 @@ parameters:
   default: true
 - name: EnableCompliance
   type: boolean
-  default: true
+  default: false
 - name: EnableAPIScan
   type: boolean
-  default: true
+  default: false
 
 jobs:
 - job: Windows

--- a/azure-pipelines/variables/InsertVersionsValues.ps1
+++ b/azure-pipelines/variables/InsertVersionsValues.ps1
@@ -1,5 +1,5 @@
 $MacroName = 'StreamJsonRpcVersion'
 $SampleProject = "$PSScriptRoot\..\..\src\StreamJsonRpc"
 [string]::join(',',(@{
-    ($MacroName) = & { (dotnet tool run nbgv -- get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
+    ($MacroName) = & { (dotnet nbgv get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
 }.GetEnumerator() |% { "$($_.key)=$($_.value)" }))

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -17,8 +17,6 @@ stages:
   jobs:
   - template: build.yml
     parameters:
-      EnableCompliance: false
-      EnableAPIScan: false
       windowsPool: VSEngSS-MicroBuild2022-1ES
       includeMacOS: false
       RunTests: false

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,12 @@
 <Project>
+  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <PropertyGroup>
+    <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Condition="Exists('README.md')" Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>


### PR DESCRIPTION
- Fix symbol file selection for R2R outputs
- Simplify `nbgv` invocation in ps1 scripts
- Skip compliance checks by default for build.yml
- Bump MicroBuild to 2.0.127
- Bump dotnet-coverage to 17.7.2
- Bump StyleCop.Analyzers.Unstable from 1.2.0.435 to 1.2.0.507 (#207)
- Bump dotnet-coverage from 17.7.2 to 17.7.3 (#208)
- Bump MicroBuildVersion to 2.0.130
