### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.5",
+      "version": "7.3.6",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.3",
+      "version": "17.8.6",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,10 @@ indent_size = 2
 indent_size = 2
 indent_style = space
 
+[*.ps1]
+indent_style = space
+indent_size = 4
+
 # Dotnet code style settings:
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,8 @@ updates:
   schedule:
     interval: weekly
   ignore:
+  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+  - dependency-name: dotnet-format
+    versions: ["6.x", "7.x", "8.x"]
   - dependency-name: Newtonsoft.Json # This has to match VS and VS rarely updates it
   - dependency-name: Microsoft.AspNetCore.TestHost # Later versions require .NET Core 3.1, which prevents our testing on net472

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
     <MessagePackVersion>2.5.108</MessagePackVersion>
     <MicroBuildVersion>2.0.146</MicroBuildVersion>
-    <VisualStudioThreadingVersion>17.6.40</VisualStudioThreadingVersion>
+    <VisualStudioThreadingVersion>17.7.35</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2" />
@@ -34,11 +34,11 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit.combinatorial" Version="1.5.25" />
-    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.console" Version="2.5.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
     <PackageVersion Include="xunit.skippablefact" Version="1.4.13" />
     <PackageVersion Include="xunit.stafact" Version="1.1.11" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.5.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <MessagePackVersion>2.5.108</MessagePackVersion>
-    <MicroBuildVersion>2.0.130</MicroBuildVersion>
+    <MicroBuildVersion>2.0.146</MicroBuildVersion>
     <VisualStudioThreadingVersion>17.6.40</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />
@@ -35,10 +35,10 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit.combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="xunit.skippablefact" Version="1.4.13" />
     <PackageVersion Include="xunit.stafact" Version="1.1.11" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -35,7 +35,7 @@ jobs:
 
   - template: install-dependencies.yml
 
-  - script: dotnet tool run nbgv cloud -ca
+  - script: dotnet nbgv cloud -ca
     displayName: ⚙ Set build number
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -11,6 +11,7 @@ steps:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
 
 - task: MicroBuildOptProfPlugin@6
   inputs:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>
     <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -191,7 +191,7 @@ public abstract class AsyncEnumerableTests : TestBase, IAsyncLifetime
                 // Within a batch, the MoveNextAsync call should absolutely complete synchronously.
                 ValueTask<bool> valueTask = enumerator.MoveNextAsync();
                 Assert.True(valueTask.IsCompleted);
-                Assert.True(valueTask.GetAwaiter().GetResult());
+                Assert.True(await valueTask);
             }
 
             int number = enumerator.Current;

--- a/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -291,7 +291,7 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
     public async Task ServerMethodThatReturnsStream()
     {
         using StreamReader result = new StreamReader(await this.clientRpc.InvokeAsync<Stream>(nameof(Server.ServerMethodThatReturnsStream)));
-        string returnedContent = await result.ReadToEndAsync().ConfigureAwait(false);
+        string returnedContent = await result.ReadToEndAsync();
         Assert.Equal("Streamed bits!", returnedContent);
     }
 
@@ -305,11 +305,11 @@ public abstract class DuplexPipeMarshalingTests : TestBase, IAsyncLifetime
         var writeOnlyStream = new StreamWriter(remoteStream);
 
         // Read server message
-        var serverReply = await readOnlyStream.ReadLineAsync().ConfigureAwait(false);
+        var serverReply = await readOnlyStream.ReadLineAsync();
         Assert.Equal("Streamed bits!", serverReply);
 
         // Verify server received client response
-        await writeOnlyStream.WriteLineAsync("Returned bytes").ConfigureAwait(false);
+        await writeOnlyStream.WriteLineAsync("Returned bytes");
         await writeOnlyStream.FlushAsync().WithCancellation(this.TimeoutToken);
 
         Assumes.NotNull(this.server.ChatLaterTask);

--- a/test/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcRemoteTargetTests.cs
@@ -169,8 +169,8 @@ public abstract class JsonRpcRemoteTargetTests : InteropTestBase
 
         await Task.WhenAll(resultLocalTask, resultRemoteTask);
 
-        Assert.Equal(5, resultLocalTask.Result);
-        Assert.Equal(2, resultRemoteTask.Result);
+        Assert.Equal(5, await resultLocalTask);
+        Assert.Equal(2, await resultRemoteTask);
     }
 
     [Fact]
@@ -215,8 +215,8 @@ public abstract class JsonRpcRemoteTargetTests : InteropTestBase
         await Task.WhenAll(relaySleepCallTask, remoteCallTask);
 
         Assert.Equal(1, LocalOriginTarget.InvokeCount);
-        Assert.Equal(2, relaySleepCallTask.Result);
-        Assert.Equal(3, remoteCallTask.Result);
+        Assert.Equal(2, await relaySleepCallTask);
+        Assert.Equal(3, await remoteCallTask);
     }
 
     [Fact(Skip = "Unstable. See https://github.com/microsoft/vs-streamjsonrpc/issues/336")]
@@ -240,8 +240,8 @@ public abstract class JsonRpcRemoteTargetTests : InteropTestBase
         await Task.WhenAll(relayDelayCallTask, remoteCallTask);
 
         Assert.Equal(1, LocalOriginTarget.InvokeCount);
-        Assert.Equal(3, relayDelayCallTask.Result);
-        Assert.Equal(2, remoteCallTask.Result);
+        Assert.Equal(3, await relayDelayCallTask);
+        Assert.Equal(2, await remoteCallTask);
     }
 
     protected virtual IJsonRpcMessageHandler CreateHandler(Stream sending, Stream receiving) => new HeaderDelimitedMessageHandler(sending, receiving, this.CreateFormatter());

--- a/test/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
+++ b/test/StreamJsonRpc.Tests/StreamMessageHandlerTests.cs
@@ -82,7 +82,7 @@ public class StreamMessageHandlerTests : TestBase
     {
         await this.handler.DisposeAsync();
         ValueTask result = this.handler.WriteAsync(CreateNotifyMessage(), this.TimeoutToken);
-        Assert.Throws<ObjectDisposedException>(() => result.GetAwaiter().GetResult());
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await result);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public class StreamMessageHandlerTests : TestBase
     public async Task WriteAsync_PreferOperationCanceledException_AtEntry()
     {
         await this.handler.DisposeAsync();
-        Assert.Throws<OperationCanceledException>(() => this.handler.WriteAsync(CreateNotifyMessage(), PrecanceledToken).GetAwaiter().GetResult());
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await this.handler.WriteAsync(CreateNotifyMessage(), PrecanceledToken));
     }
 
     /// <summary>
@@ -143,8 +143,8 @@ public class StreamMessageHandlerTests : TestBase
     {
         await this.handler.DisposeAsync();
         ValueTask<JsonRpcMessage?> result = this.handler.ReadAsync(this.TimeoutToken);
-        Assert.Throws<ObjectDisposedException>(() => result.GetAwaiter().GetResult());
-        Assert.Throws<OperationCanceledException>(() => this.handler.ReadAsync(PrecanceledToken).GetAwaiter().GetResult());
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await result);
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await this.handler.ReadAsync(PrecanceledToken));
     }
 
     /// <summary>
@@ -155,7 +155,7 @@ public class StreamMessageHandlerTests : TestBase
     public async Task ReadAsync_PreferOperationCanceledException_AtEntry()
     {
         await this.handler.DisposeAsync();
-        Assert.Throws<OperationCanceledException>(() => this.handler.ReadAsync(PrecanceledToken).GetAwaiter().GetResult());
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await this.handler.ReadAsync(PrecanceledToken));
     }
 
     /// <summary>


### PR DESCRIPTION
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump MicroBuildVersion to 2.0.131
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
- Dependabot to ignore dotnet-format
- Set tab settings for .ps1 files
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
- Bump dotnet-coverage to 17.8.2
- Bump MicroBuild version to 2.0.134
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microbuild version to 2.0.137
- Tolerate NOTICE file task network failures
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Fix typo in comment
- Bump MicroBuildVersion to 2.0.146
- Bump dotnet-coverage to 17.8.6
- Bump more dependency versions
