### PR TITLE
Fix optprof pipeline

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.1.46" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.113" />
-    <PackageVersion Include="Nerdbank.Streams" Version="2.9.112" />
+    <PackageVersion Include="Nerdbank.Streams" Version="2.9.109" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />

--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -92,9 +92,9 @@ stages:
       inputs:
         SkipCreatePR: true
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-      displayName: Trigger a new build of DD-CB-PR
+      displayName: Trigger a new build of DD-CB-TestSignVS-devCI
       inputs:
-        buildDefinition: DD-CB-PR
+        buildDefinition: DD-CB-TestSignVS-devCI
         useSameBranch: false
         branchToUse: $(InsertTopicBranch)
         storeInEnvironmentVariable: true

--- a/azure-pipelines/OptProf_part2.yml
+++ b/azure-pipelines/OptProf_part2.yml
@@ -4,7 +4,7 @@ pr: none
 resources:
   pipelines:
   - pipeline: VisualStudioBuildUnderTest
-    source: DD-CB-PR
+    source: DD-CB-TestSignVS-devCI
     trigger:
       tags:
       - vs-StreamJsonRpc-insertion


### PR DESCRIPTION
VS Eng wants us to avoid using DD-CB-PR for non-PR builds, such as optprof runs.

I also had to revert a dependency upgrade to match what Dev17.4 ships to get the pipeline to run.