### PR TITLE
Don't reference M.Bcl.AsyncInterfaces on netstandard2.1

### DIFF
--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MessagePack" />
     <PackageReference Include="MessagePackAnalyzer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" PrivateAssets="compile" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" PrivateAssets="compile" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />


### PR DESCRIPTION
Microsoft.Bcl.AsyncInterfaces provides API that is already inbox on netstandard2.1. Don't reference the package for that framework to reduce the dependency graph.