### PR TITLE
Fix deadlocks involving processes where JTF is _not_ present

### DIFF
--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker
+StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker.JoinableTaskTokenTracker() -> void
+StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker!
+StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker
+StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker.JoinableTaskTokenTracker() -> void
+StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableTaskTokenTracker!
+StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void

--- a/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -125,9 +125,16 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
         Assert.Same(completion, this.serverRpc.Completion);
     }
 
-    protected override void InitializeFormattersAndHandlers(bool controlledFlushingClient)
+    protected override void InitializeFormattersAndHandlers(
+        Stream serverStream,
+        Stream clientStream,
+        out IJsonRpcMessageFormatter serverMessageFormatter,
+        out IJsonRpcMessageFormatter clientMessageFormatter,
+        out IJsonRpcMessageHandler serverMessageHandler,
+        out IJsonRpcMessageHandler clientMessageHandler,
+        bool controlledFlushingClient)
     {
-        this.clientMessageFormatter = new JsonMessageFormatter
+        clientMessageFormatter = new JsonMessageFormatter
         {
             JsonSerializer =
             {
@@ -138,7 +145,7 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
                 },
             },
         };
-        this.serverMessageFormatter = new JsonMessageFormatter
+        serverMessageFormatter = new JsonMessageFormatter
         {
             JsonSerializer =
             {
@@ -150,10 +157,10 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
             },
         };
 
-        this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
-        this.clientMessageHandler = controlledFlushingClient
-            ? new DelayedFlushingHandler(this.clientStream, this.clientMessageFormatter)
-            : new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+        serverMessageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, serverMessageFormatter);
+        clientMessageHandler = controlledFlushingClient
+            ? new DelayedFlushingHandler(clientStream, clientMessageFormatter)
+            : new HeaderDelimitedMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
 
     protected class UnserializableTypeConverter : JsonConverter

--- a/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTypeHandlingTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTypeHandlingTests.cs
@@ -3,8 +3,6 @@
 
 using System.Text;
 using Newtonsoft.Json;
-using StreamJsonRpc;
-using Xunit.Abstractions;
 
 public class JsonRpcJsonHeadersTypeHandlingTests : JsonRpcJsonHeadersTests
 {
@@ -13,13 +11,20 @@ public class JsonRpcJsonHeadersTypeHandlingTests : JsonRpcJsonHeadersTests
     {
     }
 
-    protected override void InitializeFormattersAndHandlers(bool controlledFlushingClient)
+    protected override void InitializeFormattersAndHandlers(
+        Stream serverStream,
+        Stream clientStream,
+        out IJsonRpcMessageFormatter serverMessageFormatter,
+        out IJsonRpcMessageFormatter clientMessageFormatter,
+        out IJsonRpcMessageHandler serverMessageHandler,
+        out IJsonRpcMessageHandler clientMessageHandler,
+        bool controlledFlushingClient)
     {
-        this.serverMessageFormatter = new JsonMessageFormatter(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+        serverMessageFormatter = new JsonMessageFormatter(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
         {
             JsonSerializer =
             {
-                TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Objects,
+                TypeNameHandling = TypeNameHandling.Objects,
                 TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
                 Converters =
                 {
@@ -29,11 +34,11 @@ public class JsonRpcJsonHeadersTypeHandlingTests : JsonRpcJsonHeadersTests
             },
         };
 
-        this.clientMessageFormatter = new JsonMessageFormatter(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+        clientMessageFormatter = new JsonMessageFormatter(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
         {
             JsonSerializer =
             {
-                TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Objects,
+                TypeNameHandling = TypeNameHandling.Objects,
                 TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
                 Converters =
                 {
@@ -43,9 +48,9 @@ public class JsonRpcJsonHeadersTypeHandlingTests : JsonRpcJsonHeadersTests
             },
         };
 
-        this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
-        this.clientMessageHandler = controlledFlushingClient
-            ? new DelayedFlushingHandler(this.clientStream, this.clientMessageFormatter)
-            : new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+        serverMessageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, serverMessageFormatter);
+        clientMessageHandler = controlledFlushingClient
+            ? new DelayedFlushingHandler(clientStream, clientMessageFormatter)
+            : new HeaderDelimitedMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
 }

--- a/test/StreamJsonRpc.Tests/JsonRpcSystemTextJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcSystemTextJsonHeadersTests.cs
@@ -25,9 +25,16 @@ public class JsonRpcSystemTextJsonHeadersTests : JsonRpcTests
         Assert.StrictEqual(COR_E_UNAUTHORIZEDACCESS, errorData.HResult);
     }
 
-    protected override void InitializeFormattersAndHandlers(bool controlledFlushingClient)
+    protected override void InitializeFormattersAndHandlers(
+        Stream serverStream,
+        Stream clientStream,
+        out IJsonRpcMessageFormatter serverMessageFormatter,
+        out IJsonRpcMessageFormatter clientMessageFormatter,
+        out IJsonRpcMessageHandler serverMessageHandler,
+        out IJsonRpcMessageHandler clientMessageHandler,
+        bool controlledFlushingClient)
     {
-        this.clientMessageFormatter = new SystemTextJsonFormatter
+        clientMessageFormatter = new SystemTextJsonFormatter
         {
             JsonSerializerOptions =
             {
@@ -37,7 +44,7 @@ public class JsonRpcSystemTextJsonHeadersTests : JsonRpcTests
                 },
             },
         };
-        this.serverMessageFormatter = new SystemTextJsonFormatter
+        serverMessageFormatter = new SystemTextJsonFormatter
         {
             JsonSerializerOptions =
             {
@@ -48,10 +55,10 @@ public class JsonRpcSystemTextJsonHeadersTests : JsonRpcTests
             },
         };
 
-        this.serverMessageHandler = new HeaderDelimitedMessageHandler(this.serverStream, this.serverStream, this.serverMessageFormatter);
-        this.clientMessageHandler = controlledFlushingClient
-            ? new DelayedFlushingHandler(this.clientStream, this.clientMessageFormatter)
-            : new HeaderDelimitedMessageHandler(this.clientStream, this.clientStream, this.clientMessageFormatter);
+        serverMessageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, serverMessageFormatter);
+        clientMessageHandler = controlledFlushingClient
+            ? new DelayedFlushingHandler(clientStream, clientMessageFormatter)
+            : new HeaderDelimitedMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
 
     protected class DelayedFlushingHandler : HeaderDelimitedMessageHandler, IControlledFlushHandler

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -2964,7 +2964,23 @@ public abstract class JsonRpcTests : TestBase
         base.Dispose(disposing);
     }
 
-    protected abstract void InitializeFormattersAndHandlers(bool controlledFlushingClient = false);
+    protected void InitializeFormattersAndHandlers(bool controlledFlushingClient = false) => this.InitializeFormattersAndHandlers(
+        this.serverStream,
+        this.clientStream,
+        out this.serverMessageFormatter,
+        out this.clientMessageFormatter,
+        out this.serverMessageHandler,
+        out this.clientMessageHandler,
+        controlledFlushingClient);
+
+    protected abstract void InitializeFormattersAndHandlers(
+        Stream serverStream,
+        Stream clientStream,
+        out IJsonRpcMessageFormatter serverMessageFormatter,
+        out IJsonRpcMessageFormatter clientMessageFormatter,
+        out IJsonRpcMessageHandler serverMessageHandler,
+        out IJsonRpcMessageHandler clientMessageHandler,
+        bool controlledFlushingClient);
 
     protected override Task CheckGCPressureAsync(Func<Task> scenario, int maxBytesAllocated = -1, int iterations = 100, int allowedAttempts = 10)
     {


### PR DESCRIPTION
The bug description is found in #983.

The fix is simply to share the `JoinableTask` "token" across `JsonRpc` instances. We correlate `JoinableTask` tokens across `JsonRpc` instances (by default).
    
Mutable statics are more or less likely to cause problems with testing or advanced product scenarios. In this case though, it seems *very* likely that every shipping scenario will be drastically simpler by defaulting to sharing state across instances, so that is the default. Advanced cases can opt into isolating those instances however, and I have a test to verify this.    

Fixes #983