### PR TITLE
Suppress credscan on test logs

### DIFF
--- a/azure-pipelines/CredScanSuppressions.json
+++ b/azure-pipelines/CredScanSuppressions.json
@@ -1,0 +1,13 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "folder": "testResults-Windows",
+      "_justification": "Test logs never include credentials, but false positives abound."
+    },
+    {
+      "folder": "test_logs",
+      "_justification": "Test logs never include credentials, but false positives abound."
+    }
+ ]
+}

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -61,6 +61,9 @@ extends:
     parameters:
       sdl:
         sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+        credscan:
+          suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
+          debugMode: true # required for whole directory suppressions
       stages:
       - stage: Build
         variables:


### PR DESCRIPTION
This gets our official pipelines running again.
The 'debug' mode we're putting credscan into isn't an acceptable long-term solution, but it allows us to exclude test log outputs from blocking the pipeline. I've reached out to the credscan team for a better solution.