### PR TITLE
Merge latest Library.Template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,7 @@ parameters:
   default: true
 
 variables:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  BuildConfiguration: Release
-  codecov_token: 9a7c2ba3-0a4b-4479-96e8-3bfd01a982f6
-  NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
+- template: /azure-pipelines/BuildStageVariables.yml@self
 
 jobs:
 - template: azure-pipelines/build.yml

--- a/azure-pipelines/BuildStageVariables.yml
+++ b/azure-pipelines/BuildStageVariables.yml
@@ -1,0 +1,5 @@
+variables:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  BuildConfiguration: Release
+  NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
+  codecov_token: 9a7c2ba3-0a4b-4479-96e8-3bfd01a982f6

--- a/azure-pipelines/TSAOptions.json
+++ b/azure-pipelines/TSAOptions.json
@@ -1,0 +1,19 @@
+{
+  "tsaVersion": "TsaV2",
+  "codebase": "NewOrUpdate",
+  "codebaseName": "LibraryName",
+  "tsaStamp": "DevDiv",
+  "tsaEnvironment": "PROD",
+  "notificationAliases": [
+     "vsidemicrobuild@microsoft.com"
+  ],
+  "codebaseAdmins": [
+      "REDMOND\\andarno"
+  ],
+  "instanceUrl": "https://devdiv.visualstudio.com",
+  "projectName": "DevDiv",
+  "areaPath": "DevDiv\\VS Core",
+  "iterationPath": "DevDiv",
+  "alltools": true,
+  "repositoryName": "Library.Template"
+}

--- a/azure-pipelines/TSAOptions.json
+++ b/azure-pipelines/TSAOptions.json
@@ -1,7 +1,7 @@
 {
   "tsaVersion": "TsaV2",
   "codebase": "NewOrUpdate",
-  "codebaseName": "LibraryName",
+  "codebaseName": "StreamJsonRpc",
   "tsaStamp": "DevDiv",
   "tsaEnvironment": "PROD",
   "notificationAliases": [
@@ -12,8 +12,8 @@
   ],
   "instanceUrl": "https://devdiv.visualstudio.com",
   "projectName": "DevDiv",
-  "areaPath": "DevDiv\\VS Core",
+  "areaPath": "DevDiv\\VS Core\\Extensibility\\StreamJsonRpc",
   "iterationPath": "DevDiv",
   "alltools": true,
-  "repositoryName": "Library.Template"
+  "repositoryName": "vs-StreamJsonRpc"
 }

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -74,6 +74,7 @@ jobs:
             displayName: 📢 Publish ${{ artifact_name }}-Windows
             targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact_name }}-Windows
             artifactName: ${{ artifact_name }}-Windows
+            condition: succeededOrFailed()
       - output: pipelineArtifact
         displayName: 📢 Publish VSInsertion-Windows
         targetPath: $(Build.ArtifactStagingDirectory)/VSInsertion-Windows

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -7,7 +7,7 @@ steps:
   displayName: 🔏 Authenticate NuGet feeds
   inputs:
     ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
-      nuGetServiceConnections: azure-public/msft_consumption
+      nuGetServiceConnections: azure-public/msft_consumption # Only necessary for GitHub-hosted repos
     forceReinstallCredentialProvider: true
 
 - powershell: |

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -34,19 +34,6 @@ steps:
       ArtifactType: Container
     displayName: 📢 Publish InsertionOutputs as Azure DevOps artifacts
 
-- task: Ref12Analyze@0
-  displayName: 📑 Ref12 (Codex) Analyze
-  inputs:
-    codexoutputroot: $(Build.ArtifactStagingDirectory)\Codex
-    workflowArguments: |
-      /sourcesDirectory:$(Build.SourcesDirectory)
-      /codexRepoUrl:$(Build.Repository.Uri)
-      /repoName:$(Build.Repository.Name)
-      /additionalCodexArguments:-bld
-      /additionalCodexArguments:$(Build.ArtifactStagingDirectory)/build_logs
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Agent.OS'], 'Windows_NT'))
-  continueOnError: true
-
 - ${{ if eq(parameters.EnableCompliance, 'true') }}:
   - template: secure-development-tools.yml
     parameters:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -5,9 +5,6 @@ parameters:
   default: false
 
 steps:
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 🔍 Component Detection
-
 - task: notice@0
   displayName: 🛠️ Generate NOTICE file
   inputs:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -61,17 +61,18 @@ extends:
     parameters:
       sdl:
         sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+        policheck:
+          enabled: true
+          exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
+        suppression:
+          suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         credscan:
           suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
           debugMode: true # required for whole directory suppressions
       stages:
       - stage: Build
         variables:
-          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-          BuildConfiguration: Release
-          NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
-          Packaging.EnableSBOMSigning: false
-          Codeql.Enabled: true
+        - template: /azure-pipelines/BuildStageVariables.yml@self
         jobs:
         - template: /azure-pipelines/build.yml@self
           parameters:
@@ -99,16 +100,14 @@ extends:
     parameters:
       sdl:
         sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+        suppression:
+          suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         credscan:
           enabled: false
       stages:
       - stage: Build
         variables:
-          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-          BuildConfiguration: Release
-          NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
-          Packaging.EnableSBOMSigning: false
-          Codeql.Enabled: true
+        - template: /azure-pipelines/BuildStageVariables.yml@self
         jobs:
         - template: /azure-pipelines/build.yml@self
           parameters:

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -33,32 +33,33 @@ stages:
           SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
           azureSubscription: Symbols Upload (DevDiv)
 
-  - job: push
-    displayName: azure-public/vssdk feed
-    ${{ if parameters.ArchiveSymbols }}:
-      dependsOn: symbol_archive
-    pool:
-      name: AzurePipelines-EO
-      demands:
-      - ImageOverride -equals AzurePipelinesUbuntu20.04compliantGPT
-      os: Linux
-    templateContext:
-      outputParentDirectory: $(Pipeline.Workspace)
-      outputs:
-      - output: nuget
-        displayName: 📦 Push nuget packages
-        packagesToPush: '(Pipeline.Workspace)/deployables-Windows/NuGet/*.nupkg'
-        packageParentPath: (Pipeline.Workspace)/deployables-Windows/NuGet
-        allowPackageConflicts: true
-        nuGetFeedType: external
-        publishFeedCredentials: azure-public/vssdk
-    steps:
-    - checkout: none
-    - download: current
-      artifact: Variables-Windows
-      displayName: 🔻 Download Variables-Windows artifact
-    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
-      displayName: ⚙️ Set pipeline variables based on artifacts
-    - download: current
-      artifact: deployables-Windows
-      displayName: 🔻 Download deployables-Windows artifact
+  - ${{ if true }}: # leave the condition to avoid merge conflicts later.
+    - job: push
+      displayName: azure-public/vssdk feed
+      ${{ if parameters.ArchiveSymbols }}:
+        dependsOn: symbol_archive
+      pool:
+        name: AzurePipelines-EO
+        demands:
+        - ImageOverride -equals AzurePipelinesUbuntu20.04compliantGPT
+        os: Linux
+      templateContext:
+        outputParentDirectory: $(Pipeline.Workspace)
+        outputs:
+        - output: nuget
+          displayName: 📦 Push nuget packages
+          packagesToPush: '$(Pipeline.Workspace)/deployables-Windows/NuGet/*.nupkg'
+          packageParentPath: $(Pipeline.Workspace)/deployables-Windows/NuGet
+          allowPackageConflicts: true
+          nuGetFeedType: external
+          publishFeedCredentials: azure-public/vssdk
+      steps:
+      - checkout: none
+      - download: current
+        artifact: Variables-Windows
+        displayName: 🔻 Download Variables-Windows artifact
+      - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+        displayName: ⚙️ Set pipeline variables based on artifacts
+      - download: current
+        artifact: deployables-Windows
+        displayName: 🔻 Download deployables-Windows artifact

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -6,13 +6,6 @@ steps:
 - powershell: echo "##vso[build.addbuildtag]compliance"
   displayName: 🏷️ Tag run with 'compliance'
 
-- task: PoliCheck@2
-  displayName: 🔍 Run PoliCheck
-  inputs:
-    targetType: F
-    targetArgument: $(System.DefaultWorkingDirectory)
-    optionsUEPATH: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
-
 - task: CopyFiles@2
   displayName: 📂 Collect APIScan inputs
   inputs:
@@ -37,3 +30,11 @@ steps:
   condition: and(succeeded(), ${{ parameters.EnableAPIScan }}, ne(variables.ApiScanClientId, ''))
   env:
     AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+
+# File bugs when APIScan finds issues
+- task: TSAUpload@2
+  displayName: 🪳 TSA upload
+  inputs:
+    GdnPublishTsaOnboard: True
+    GdnPublishTsaConfigFile: $(Build.SourcesDirectory)\azure-pipelines\TSAOptions.json
+  condition: false # enable in individual repos only AFTER updating TSAOptions.json with your own values

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -37,4 +37,4 @@ steps:
   inputs:
     GdnPublishTsaOnboard: True
     GdnPublishTsaConfigFile: $(Build.SourcesDirectory)\azure-pipelines\TSAOptions.json
-  condition: false # enable in individual repos only AFTER updating TSAOptions.json with your own values
+  condition: true

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -50,6 +50,8 @@ extends:
         - task: MicroBuildInsertVsPayload@4
           displayName: 🏭 Insert VS Payload
           inputs:
+            TeamName: $(TeamName)
+            TeamEmail: $(TeamEmail)
             InsertionPayloadName: $(Build.Repository.Name) $(Build.BuildNumber)
             InsertionBuildPolicy: Request Perf DDRITs
             AutoCompletePR: true

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -70,6 +70,8 @@ extends:
         - task: MicroBuildInsertVsPayload@4
           displayName: 🏭 Insert VS Payload
           inputs:
+            TeamName: $(TeamName)
+            TeamEmail: $(TeamEmail)
             InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
             InsertionDescription: |
               This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.


### PR DESCRIPTION
- Drop Codeql.Enabled variable
- File bugs for APIScan issues
- Move Policheck to the 1ES PT
- Disable Policheck on non-compliance runs
- Fix missing TeamEmail and TeamName in insertVS task
- Drop ComponentGovernance from the pipeline
- Add missing $ characters in pipeline
- Publish artifacts even on failed pipelines
- Switch job disabling style
- Remove `EnableSBOMSigning` variable
- Share variables across all entrypoints
- Fix Expand-Template.ps1
- Clarify purpose of nuGetServiceConnection
- Drop Ref12Analyze task
