### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,6 @@
   // Needs to be explicitly configured: https://github.com/Microsoft/azure-pipelines-vscode#document-formatting
   "[azure-pipelines]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": false // enable this when the conform
+    "editor.formatOnSave": false // enable this when they conform
   },
 }

--- a/azure-pipelines/InsertionMetadataPackage.nuspec
+++ b/azure-pipelines/InsertionMetadataPackage.nuspec
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package >
+<package>
+  <!-- This file is only used in repos where OptProf is enabled. -->
   <metadata>
     <id>StreamJsonRpc.VSInsertionMetadata</id>
     <version>$version$</version>

--- a/azure-pipelines/apiscan.yml
+++ b/azure-pipelines/apiscan.yml
@@ -7,6 +7,13 @@ jobs:
   displayName: APIScan
   dependsOn: Windows
   pool: ${{ parameters.windowsPool }}
+  timeoutInMinutes: 120
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: 📢 collect apiscan artifact
+      targetPath: $(Pipeline.Workspace)/.gdn/.r/apiscan/001/Logs
+      artifactName: apiscan-logs
   variables:
   - name: SymbolsFeatureName
     value: $[ dependencies.Windows.outputs['SetPipelineVariables.SymbolsFeatureName'] ]
@@ -14,7 +21,7 @@ jobs:
     value: $[ dependencies.Windows.outputs['nbgv.NBGV_MajorMinorVersion'] ]
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     # https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline
-    - group: VSExtensibility-APIScan # Expected to provide ApiScanClientId, ApiScanSecret, ApiScanTenant
+    - group: VSEng sponsored APIScan # Expected to provide ApiScanClientId
   steps:
     # We need TSAOptions.json
   - checkout: self
@@ -32,8 +39,9 @@ jobs:
       softwareVersionNum: $(NBGV_MajorMinorVersion)
       isLargeApp: false
       toolVersion: Latest
+      preserveLogsFolder: true
     env:
-      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
 
   # File bugs when APIScan finds issues
   - task: TSAUpload@2
@@ -41,3 +49,4 @@ jobs:
     inputs:
       GdnPublishTsaOnboard: True
       GdnPublishTsaConfigFile: $(Build.SourcesDirectory)\azure-pipelines\TSAOptions.json
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/azure-pipelines/artifacts/APIScanInputs.ps1
+++ b/azure-pipelines/artifacts/APIScanInputs.ps1
@@ -2,12 +2,10 @@ $inputs = & "$PSScriptRoot/symbols.ps1"
 
 if (!$inputs) { return }
 
-# Filter out specific files that APIScan does not support.
-# Specifically, APIScan doesn't support Windows ARM64 binaries, nor linux/OSX binaries.
+# Filter out specific files that target OS's that are not subject to APIScan.
+# Files that are subject but are not supported must be scanned and an SEL exception filed.
 $outputs = @{}
 $forbiddenSubPaths = @(
-    , 'arm64'
-    , 'win-arm64'
     , 'linux-*'
     , 'osx*'
 )

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -41,7 +41,7 @@ extends:
     - template: /azure-pipelines/prepare-insertion-stages.yml@self
       parameters:
         ArchiveSymbols: false
-        RealSign: ${{ parameters.RealSign }}
+        RealSign: true
 
     - stage: insertion
       displayName: VS insertion


### PR DESCRIPTION
- fix typo
- Extend default timeout for APIScan job
- Collect APIScan logs as an artifact
- Preserve more apiscan logs
- Stop filtering out win-arm64 binaries from APIScan
- Document use case for nuspec file
- Fix validation pipeline
- Switch APIScan to use a managed identity
