### PR TITLE
Test the .NET 8 build of the library

### DIFF
--- a/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -577,6 +577,9 @@ public class JsonRpcClient20InteropTests : InteropTestBase
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected PrivateSerializableException(
             SerializationInfo info,
             StreamingContext context)

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -4113,6 +4113,9 @@ public abstract class JsonRpcTests : TestBase
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             // Arrange to change the ClassName value.
@@ -4153,12 +4156,18 @@ public abstract class JsonRpcTests : TestBase
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected ThrowOnSerializeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             // Unlikely to ever be called since serialization throws, but complete the pattern so we test exactly what we mean to.
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new InvalidOperationException("This exception always throws when serialized.");
@@ -4194,6 +4203,9 @@ public abstract class JsonRpcTests : TestBase
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected PrivateSerializableException(
           SerializationInfo info,
           StreamingContext context)

--- a/test/StreamJsonRpc.Tests/MarshalableProxyTests.cs
+++ b/test/StreamJsonRpc.Tests/MarshalableProxyTests.cs
@@ -1500,6 +1500,9 @@ public abstract class MarshalableProxyTests : TestBase
             this.Enumerable = enumeration;
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         protected ExceptionWithAsyncEnumerable(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -1508,6 +1511,9 @@ public abstract class MarshalableProxyTests : TestBase
 
         internal IAsyncEnumerable<int>? Enumerable { get; set; }
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace />
   </PropertyGroup>


### PR DESCRIPTION
#1033 added a .NET 8 target to the library. With this change, we also explicitly run tests on it.

Because .NET 8 has removed the `BinaryFormatter`, the tests (which used it as a baseline for testing serializability of types) had to be updated to use a stand-in.