### PR TITLE
Trim and update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   ignore:
   - dependency-name: Newtonsoft.Json # This has to match VS and VS rarely updates it
   - dependency-name: Microsoft.AspNetCore.TestHost # Later versions require .NET Core 3.1, which prevents our testing on net472
+  # We want to match the minimum target .NET runtime
+  - dependency-name: System.Threading.Tasks.Dataflow
+  - dependency-name: System.Collections.Immutable
+  - dependency-name: System.Diagnostics.DiagnosticSource
+  - dependency-name: System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MessagePackVersion>2.5.108</MessagePackVersion>
     <MicroBuildVersion>2.0.149</MicroBuildVersion>
-    <VisualStudioThreadingVersion>17.9.28</VisualStudioThreadingVersion>
+    <VisualStudioThreadingVersion>17.10.48</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
@@ -22,15 +22,14 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
-    <PackageVersion Include="Nerdbank.Streams" Version="2.11.72" />
+    <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageVersion Include="System.IO.Pipelines" Version="7.0.0" />
+    <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.IO.Pipes" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit.combinatorial" Version="1.6.24" />

--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -51,7 +51,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
     <PackageReference Include="System.IO.Pipes" />
     <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="xunit.combinatorial" />


### PR DESCRIPTION
This gets StreamJsonRpc nuget dependencies down to a minimum when targeting .NET 6 and 8.