### PR TITLE
Fix exceptions being thrown when ETW attempts to log messages with System.Text.Json

### DIFF
--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -516,6 +516,9 @@ public class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFormatter, 
                     }
 
                     break;
+                case JsonValueKind.Object when name is null && position is 0:
+                    valueElement = this.JsonArguments.Value;
+                    break;
                 case JsonValueKind.Array:
                     int elementIndex = 0;
                     foreach (JsonElement arrayElement in this.JsonArguments.Value.EnumerateArray())

--- a/test/StreamJsonRpc.Tests/SystemTextJsonFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/SystemTextJsonFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -66,6 +67,32 @@ public class SystemTextJsonFormatterTests : FormatterTestBase<SystemTextJsonForm
         using JsonDocument doc = JsonDocument.Parse(sequence);
         this.Logger.WriteLine(doc.RootElement.ToString());
         Assert.Equal(1, doc.RootElement.GetProperty("params")[0].GetProperty("B").GetInt32());
+    }
+
+    [Fact]
+    public void STJPositionalArgsInJsonRpcEventSource()
+    {
+        // Create a mock request.
+        string jsonRequest = """
+            {
+                "jsonrpc":"2.0",
+                "id":3,
+                "method":"someMethod",
+                "params":
+                {
+                    "someValue": 5
+                }
+            }
+            """;
+        ReadOnlySequence<byte> jsonSequence = new ReadOnlySequence<byte>(this.Formatter.Encoding.GetBytes(jsonRequest));
+        var jsonMessage = (JsonRpcRequest)this.Formatter.Deserialize(jsonSequence);
+
+        // JsonRpcEventSource calls TryGetArgumentByNameOrIndex to get a string representation of the message.
+        // It is possible to get a positional parameters message (name is null) with a single arguments represented as a JsonValueKind.Object.
+        Assert.True(jsonMessage.TryGetArgumentByNameOrIndex(null, 0, null, out object? value));
+        Assert.IsType<JsonElement>(value);
+
+        Assert.Equal(5, ((JsonElement)value).GetProperty("someValue").GetInt32());
     }
 
     protected override SystemTextJsonFormatter CreateFormatter() => new();


### PR DESCRIPTION
I took a stab at fixing https://github.com/microsoft/vs-streamjsonrpc/issues/1038

Before my fix, the test I added fails with the same `System.Text.Json.JsonException : Unexpected value kind for arguments: Object` I'm seeing in the roslyn insertion.

I haven't figured out how to test the change in VS however