### PR TITLE
Fix System.Text.Json formatter's support for named arguments object

### DIFF
--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -487,9 +487,8 @@ public class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFormatter, 
             using (this.formatter.TrackDeserialization(this, parameters))
             {
                 // Support for opt-in to deserializing all named arguments into a single parameter.
-                if (parameters.Length == 1 && this.formatter.ApplicableMethodAttributeOnDeserializingMethod?.UseSingleObjectParameterDeserialization is true)
+                if (parameters.Length == 1 && this.formatter.ApplicableMethodAttributeOnDeserializingMethod?.UseSingleObjectParameterDeserialization is true && this.JsonArguments is not null)
                 {
-                    Assumes.NotNull(this.JsonArguments);
                     typedArguments[0] = this.JsonArguments.Value.Deserialize(parameters[0].ParameterType, this.formatter.massagedUserDataSerializerOptions);
                     return ArgumentMatchResult.Success;
                 }

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1454,6 +1454,13 @@ public abstract class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task InvokeWithSingleObjectParameter_SupplyNoArgument()
+    {
+        int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(Server.MethodWithSingleObjectParameterWithDefaultValue), cancellationToken: this.TimeoutToken);
+        Assert.Equal(-1, sum);
+    }
+
+    [Fact]
     public async Task InvokeWithSingleObjectParameter_SendingExpectedObjectAndCancellationToken_InterfaceMethodAttributed()
     {
         int sum = await this.clientRpc.InvokeWithParameterObjectAsync<int>(nameof(IServer.InstanceMethodWithSingleObjectParameterAndCancellationToken), new XAndYProperties { x = 2, y = 5 }, this.TimeoutToken);
@@ -3335,6 +3342,12 @@ public abstract class JsonRpcTests : TestBase
         public static int MethodWithSingleObjectParameterAndCancellationToken(XAndYProperties fields, CancellationToken token)
         {
             return fields.x + fields.y;
+        }
+
+        [JsonRpcMethod(UseSingleObjectParameterDeserialization = true)]
+        public static int MethodWithSingleObjectParameterWithDefaultValue(XAndYProperties? arg = null)
+        {
+            return arg is not null ? arg.x + arg.y : -1;
         }
 
         [JsonRpcMethod("test/MethodWithSingleObjectParameterWithProgress", UseSingleObjectParameterDeserialization = true)]


### PR DESCRIPTION
Replacing the `Assumes.NotNull` with a non-throwing null check brings this formatter in line with the other formatters. 
The added unit test applies to _all_ formatters and demonstrated before the fix that only System.Text.Json failed the test. After the fix all formatters pass.

Fixes #1028