### PR TITLE
Expose metadata about `TargetMethod` publicly

### DIFF
--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -71,6 +71,20 @@ public sealed class TargetMethod
     }
 
     /// <summary>
+    /// Gets the runtime type of the target object, if there is one.
+    /// </summary>
+    /// <remarks>
+    /// Even when a matching target method is found, there may not be a target <em>object</em>
+    /// if the target method is <see langword="static" />.
+    /// </remarks>
+    public Type? TargetObjectType => this.target?.GetType();
+
+    /// <summary>
+    /// Gets the <see cref="MethodInfo"/> that will be invoked to handle the request, if one was found.
+    /// </summary>
+    public MethodInfo? TargetMethodInfo => this.signature?.MethodInfo;
+
+    /// <summary>
     /// Gets all the exceptions thrown while trying to deserialize arguments to candidate parameter types.
     /// </summary>
     internal AggregateException? ArgumentDeserializationFailures { get; }

--- a/src/StreamJsonRpc/net6.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net6.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableT
 StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.get -> bool
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.init -> void
+StreamJsonRpc.TargetMethod.TargetMethodInfo.get -> System.Reflection.MethodInfo?
+StreamJsonRpc.TargetMethod.TargetObjectType.get -> System.Type?

--- a/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableT
 StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.get -> bool
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.init -> void
+StreamJsonRpc.TargetMethod.TargetMethodInfo.get -> System.Reflection.MethodInfo?
+StreamJsonRpc.TargetMethod.TargetObjectType.get -> System.Type?

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableT
 StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.get -> bool
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.init -> void
+StreamJsonRpc.TargetMethod.TargetMethodInfo.get -> System.Reflection.MethodInfo?
+StreamJsonRpc.TargetMethod.TargetObjectType.get -> System.Type?

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ StreamJsonRpc.JsonRpc.JoinableTaskTracker.get -> StreamJsonRpc.JsonRpc.JoinableT
 StreamJsonRpc.JsonRpc.JoinableTaskTracker.set -> void
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.get -> bool
 StreamJsonRpc.RpcMarshalableAttribute.CallScopedLifetime.init -> void
+StreamJsonRpc.TargetMethod.TargetMethodInfo.get -> System.Reflection.MethodInfo?
+StreamJsonRpc.TargetMethod.TargetObjectType.get -> System.Type?


### PR DESCRIPTION
This allows logging based on overridding `DispatchRequestAsync` to know what the target method is.