### PR TITLE
Bucket benchmarks among test symbols

### DIFF
--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -18,7 +18,7 @@ Write-Progress -Activity $ActivityName -CurrentOperation "Discovery PDB files"
 $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 
 # Filter PDBs to product OR test related.
-$testregex = "unittest|tests|\.test\."
+$testregex = "unittest|tests|\.test\.|Benchmarks"
 
 Write-Progress -Activity $ActivityName -CurrentOperation "De-duplicating symbols"
 $PDBsByHash = @{}


### PR DESCRIPTION
This should keep it off the radar of the compliance check that we sign all shipping binaries.