### PR TITLE
Enable generation of proxies that implement multiple interfaces

### DIFF
--- a/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
@@ -309,7 +309,7 @@ internal class MessageFormatterRpcMarshaledContextTracker
         {
             CallScopedLifetime = token.Value.Lifetime == MarshalLifetime.Call,
         };
-        List<(TypeInfo Type, int Code)>? optionalInterfaces = null;
+        List<(Type Type, int Code)>? optionalInterfaces = null;
         if (token.Value.OptionalInterfacesCodes?.Length > 0)
         {
             // We ignore unknown optional interface codes

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -384,4 +384,7 @@
   <data name="UsableOnceOnly" xml:space="preserve">
     <value>This operation can only be performed once on this object.</value>
   </data>
+  <data name="InterfacesMustBeUnique" xml:space="preserve">
+    <value>Proxy requested with non-unique set of interfaces.</value>
+  </data>
 </root>

--- a/src/StreamJsonRpc/net6.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!

--- a/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!


### PR DESCRIPTION
Previous to this, generated proxies allowed only one (primary) RPC contract interface.
They could also support "optional" interfaces to support `[RpcMarshalable]` scenarios, but this included a wire protocol difference (the optional interfaces would invoke methods with an integer prefix on each method name), and it wasn't exposed for direct use either.

Going forward for brokered services, we'd like to enable optional interfaces on them (https://github.com/microsoft/vs-servicehub/issues/225). The ideal way to expose this is for the brokered service *client* (that somehow knows which interfaces are supported by the service) to receive a proxy that implements all the right interfaces. 
*This* change will allow such a client to accomplish the proxy side of the work. The part about the client somehow knowing which interfaces the service supports is outside the scope of this change and probably outside the scope of this library altogether.

I also improved the "skip visibility checks" method to consider _all_ the interfaces the proxy must cover rather than just the primary one.

This is required for microsoft/vs-servicehub#231, which targets the scenario described by microsoft/vs-servicehub#225.

**Tips for code reviewers**

- Use [this view](https://github.dev/microsoft/vs-streamjsonrpc/pull/1066/files) instead of the default github code review UI, since the suggested view will make it clearer which code _changed_ vs. just had indentation changes.