### PR TITLE
Fix proxies with derived interfaces

### DIFF
--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -101,16 +101,6 @@ internal static class ProxyGeneration
                 rpcInterfaces.Add((type.GetTypeInfo(), code));
             }
 
-            // Ensure types are not specified multiple times anywhere.
-            HashSet<TypeInfo> seenTypes = new();
-            foreach ((TypeInfo type, _) in rpcInterfaces)
-            {
-                if (!seenTypes.Add(type))
-                {
-                    throw new ArgumentException(Resources.InterfacesMustBeUnique);
-                }
-            }
-
             // Rpc interfaces must be sorted so that we implement methods from base interfaces before those from their derivations.
             SortRpcInterfaces(rpcInterfaces);
 

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -384,7 +384,4 @@
   <data name="UsableOnceOnly" xml:space="preserve">
     <value>This operation can only be performed once on this object.</value>
   </data>
-  <data name="InterfacesMustBeUnique" xml:space="preserve">
-    <value>Proxy requested with non-unique set of interfaces.</value>
-  </data>
 </root>

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -226,8 +226,8 @@ public class JsonRpcProxyGenerationTests : TestBase
     {
         var streams = FullDuplexStream.CreateStreams();
         var rpc = new JsonRpc(streams.Item1);
-        var ex = Assert.Throws<ArgumentException>(() => rpc.Attach([typeof(IServer), typeof(IServer)], null));
-        this.Logger.WriteLine($"{ex.ParamName}: {ex.Message}");
+        object proxy = rpc.Attach([typeof(IServer), typeof(IServer)], null);
+        Assert.IsAssignableFrom<IServer>(proxy);
     }
 
     [Fact]

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -231,6 +231,16 @@ public class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    public void Attach_BaseAndDerivedTypes()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        var rpc = new JsonRpc(streams.Item1);
+        object proxy = rpc.Attach([typeof(IServer), typeof(IServerDerived)], null);
+        Assert.IsAssignableFrom<IServer>(proxy);
+        Assert.IsAssignableFrom<IServerDerived>(proxy);
+    }
+
+    [Fact]
     public void ProxyTypeIsReused()
     {
         var streams = FullDuplexStream.CreateStreams();


### PR DESCRIPTION
### Fix proxy generation for interfaces A, B when B : A

When multiple interfaces are expressly implemented, and one derives from another, it led to over-subscription of the events on the base interface, causing failures at runtime.
The fix is to ensure we only visit each member once, by visiting each *type* once, regardless of the number of times it is referenced directly or indirectly in the list of types to implement.

###  Allow non-unique interfaces to be requested

Now that we can handle interfaces being referenced twice *indirectly*, we might as well not throw when interfaces are referenced twice *directly*.

### Tips for reviewers

Use a diff view that doesn't call out whitespace changes, since some indentation-only changes have been made that clutters up the diff.