### PR TITLE
Allow `JsonElement` as the `params` object in the `SystemTextJsonFormatter`

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1529,7 +1529,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
             object? argument = arguments;
             if (arguments is not null)
             {
-                if (arguments.Count != 1 || arguments[0] is null || !arguments[0]!.GetType().GetTypeInfo().IsClass)
+                if (arguments.Count != 1 || arguments[0] is null)
                 {
                     throw new ArgumentException(Resources.ParameterNotObject);
                 }

--- a/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcJsonHeadersTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 public class JsonRpcJsonHeadersTests : JsonRpcTests
 {
@@ -162,6 +163,9 @@ public class JsonRpcJsonHeadersTests : JsonRpcTests
             ? new DelayedFlushingHandler(clientStream, clientMessageFormatter)
             : new HeaderDelimitedMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
+
+    protected override object[] CreateFormatterIntrinsicParamsObject(string arg) =>
+        [new JObject { ["arg"] = arg }];
 
     protected class UnserializableTypeConverter : JsonConverter
     {

--- a/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcMessagePackLengthTests.cs
@@ -409,6 +409,8 @@ public class JsonRpcMessagePackLengthTests : JsonRpcTests
             : new LengthHeaderMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
 
+    protected override object[] CreateFormatterIntrinsicParamsObject(string arg) => [];
+
     [MessagePackObject]
     [Union(0, typeof(UnionDerivedClass))]
     public abstract class UnionBaseClass

--- a/test/StreamJsonRpc.Tests/JsonRpcSystemTextJsonHeadersTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcSystemTextJsonHeadersTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
 
 public class JsonRpcSystemTextJsonHeadersTests : JsonRpcTests
 {
@@ -60,6 +62,12 @@ public class JsonRpcSystemTextJsonHeadersTests : JsonRpcTests
             ? new DelayedFlushingHandler(clientStream, clientMessageFormatter)
             : new HeaderDelimitedMessageHandler(clientStream, clientStream, clientMessageFormatter);
     }
+
+    protected override object[] CreateFormatterIntrinsicParamsObject(string arg) =>
+    [
+        new JsonObject { ["arg"] = JsonValue.Create(arg) },
+        JsonDocument.Parse($$"""{ "arg": "{{arg}}" }""").RootElement, // JsonElement
+    ];
 
     protected class DelayedFlushingHandler : HeaderDelimitedMessageHandler, IControlledFlushHandler
     {


### PR DESCRIPTION
Fixes #1073