### PR TITLE
Only use credscan suppressions for Windows build

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -136,6 +136,10 @@ jobs:
         - ${{ if parameters.EnableOptProf }}:
           - powershell: Write-Host "##vso[task.setvariable variable=PROFILINGINPUTSDROPNAME]$(azure-pipelines/variables/ProfilingInputsDropName.ps1)"
             displayName: ⚙ Set ProfilingInputsDropName for optprof
+      sdl:
+        credscan:
+          suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
+          debugMode: true # required for whole directory suppressions
 
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -71,9 +71,6 @@ extends:
           suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         sbom:
           enabled: true
-        #credscan:
-        #  suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
-        #  debugMode: true # required for whole directory suppressions
       stages:
       - stage: Build
         variables:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -71,9 +71,9 @@ extends:
           suppressionFile: $(System.DefaultWorkingDirectory)\azure-pipelines\falsepositives.gdnsuppress
         sbom:
           enabled: true
-        credscan:
-          suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
-          debugMode: true # required for whole directory suppressions
+        #credscan:
+        #  suppressionsFile: $(Build.SourcesDirectory)/azure-pipelines/CredScanSuppressions.json
+        #  debugMode: true # required for whole directory suppressions
       stages:
       - stage: Build
         variables:


### PR DESCRIPTION
This avoids a build error when running credscan for the package publishing, since the suppression file is not available during that job.