### PR TITLE
Fix connection hang upon failure to deserialize result values

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2658,6 +2658,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
                 catch
                 {
                     this.OnResponseReceived(rpc);
+                    throw;
                 }
             }
             else


### PR DESCRIPTION
When a formatter throws an exception from `SetExpectedDataType`, the exception was being swallowed, and the request just dangled at the client without ever completing. With this fix, it completes with the exception. Since being unable to serialize a result is a fatal exception, this leads to the connection dying. This is preferable to a hang, and the exception is captured as the cause of the disconnect for later analysis.

There is no test because the existing formatters don't throw in this code path. A new formatter might (like the one we're creating for Nerdbank.MessagePack).