### PR TITLE
Cap the amount of text copied into the stringbuilder in JsonRpcEventSource.Format

### DIFF
--- a/src/StreamJsonRpc/JsonRpcEventSource.cs
+++ b/src/StreamJsonRpc/JsonRpcEventSource.cs
@@ -296,7 +296,7 @@ internal sealed class JsonRpcEventSource : EventSource
                 {
                     if (request.TryGetArgumentByNameOrIndex(null, i, null, out object? value))
                     {
-                        Format(stringBuilder, value);
+                        Format(stringBuilder, value, maxLength);
                         stringBuilder.Append(", ");
                         formatted = true;
                     }
@@ -334,7 +334,7 @@ internal sealed class JsonRpcEventSource : EventSource
                     {
                         stringBuilder.Append(key);
                         stringBuilder.Append(": ");
-                        Format(stringBuilder, value);
+                        Format(stringBuilder, value, maxLength);
                         stringBuilder.Append(", ");
                         formatted = true;
                     }
@@ -360,7 +360,7 @@ internal sealed class JsonRpcEventSource : EventSource
             return stringBuilder.ToString();
         }
 
-        static void Format(StringBuilder builder, object? value)
+        static void Format(StringBuilder builder, object? value, int maxLength)
         {
             switch (value)
             {
@@ -369,11 +369,15 @@ internal sealed class JsonRpcEventSource : EventSource
                     break;
                 case string s:
                     builder.Append('"');
-                    builder.Append(s);
+                    builder.Append(s, 0, Math.Min(s.Length, maxLength));
                     builder.Append('"');
                     break;
                 default:
-                    builder.Append(value);
+                    if (value.ToString() is string str)
+                    {
+                        builder.Append(str, 0, Math.Min(str.Length, maxLength));
+                    }
+
                     break;
             }
         }


### PR DESCRIPTION
Speedometer test shows two LOH allocations occurring in this method when opening a large cs file, when the value passed into JsonRpcEventSource.Format is a JsonDocument.

1) The ToString call on the document
2) The StringBuilder.Append call using the ToString result

It would be non-trivial to get rid of the first allocation, however, the second can be removed by just calling the StringBuilder.Append overload that takes in a range from the given string to copy into the StringBuilder.

Here's is the allocation from the speedometer test that this is attempting to improve:

![image](https://github.com/user-attachments/assets/fa37e9c8-0d73-4d2b-a02e-5dac84f00e6f)