### PR TITLE
Remove Dependency on Newtonsoft.Json From Protocol objects

### DIFF
--- a/src/StreamJsonRpc/Protocol/JsonRpcError.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcError.cs
@@ -3,8 +3,8 @@
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using System.Text.Json.Nodes;
 using StreamJsonRpc.Reflection;
-using JsonNET = Newtonsoft.Json.Linq;
 using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
@@ -51,15 +51,15 @@ public class JsonRpcError : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JsonNET.JObject
+        return new JsonObject
         {
-            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
-            new JsonNET.JProperty("error", new JsonNET.JObject
+            ["id"] = this.RequestId.AsJsonValue(),
+            ["error"] = new JsonObject
             {
-                new JsonNET.JProperty("code", this.Error?.Code),
-                new JsonNET.JProperty("message", this.Error?.Message),
-            }),
-        }.ToString(Newtonsoft.Json.Formatting.None);
+                ["code"] = this.Error?.Code is not null ? JsonValue.Create(this.Error?.Code) : null,
+                ["message"] = this.Error?.Message,
+            },
+        }.ToJsonString();
     }
 
     /// <summary>

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Serialization;
-using JsonNET = Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
@@ -285,10 +285,10 @@ public class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JsonNET.JObject
+        return new JsonObject
         {
-            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
-            new JsonNET.JProperty("method", this.Method),
-        }.ToString(Newtonsoft.Json.Formatting.None);
+            ["id"] = this.RequestId.AsJsonValue(),
+            ["method"] = this.Method,
+        }.ToJsonString();
     }
 }

--- a/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcResult.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using JsonNET = Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using STJ = System.Text.Json.Serialization;
 
 namespace StreamJsonRpc.Protocol;
@@ -71,10 +71,10 @@ public class JsonRpcResult : JsonRpcMessage, IJsonRpcMessageWithId
     /// <inheritdoc/>
     public override string ToString()
     {
-        return new JsonNET.JObject
+        return new JsonObject
         {
-            new JsonNET.JProperty("id", this.RequestId.ObjectValue),
-        }.ToString(Newtonsoft.Json.Formatting.None);
+            ["id"] = this.RequestId.AsJsonValue(),
+        }.ToJsonString();
     }
 
     /// <summary>

--- a/src/StreamJsonRpc/RequestId.cs
+++ b/src/StreamJsonRpc/RequestId.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.Json.Nodes;
 using Newtonsoft.Json;
 
 namespace StreamJsonRpc;
@@ -122,4 +123,8 @@ public struct RequestId : IEquatable<RequestId>
             value is int i ? new RequestId(i) :
             throw new JsonSerializationException("Unexpected type for id property: " + value.GetType().Name);
     }
+
+    internal JsonValue? AsJsonValue() =>
+        this.Number is not null ? JsonValue.Create(this.Number.Value) :
+        JsonValue.Create(this.String);
 }

--- a/test/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
+++ b/test/StreamJsonRpc.Tests/Protocol/JsonRpcRequestTests.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using StreamJsonRpc.Protocol;
-using Xunit;
-
 public class JsonRpcRequestTests
 {
     private static readonly IReadOnlyList<object> ArgumentsAsList = new List<object> { 4, 6, 8 };
@@ -81,4 +78,45 @@ public class JsonRpcRequestTests
         Assert.False(request.TryGetTopLevelProperty<string>("test", out string? value));
     }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+    [Fact]
+    public void ToString_Works()
+    {
+        var data = new JsonRpcRequest
+        {
+            RequestId = new RequestId(10),
+            Method = "t",
+        };
+
+        Assert.Equal(
+            """{"id":10,"method":"t"}""",
+            data.ToString());
+    }
+
+    [Fact]
+    public void JsonRpcError_ToString_Works()
+    {
+        var data = new JsonRpcError
+        {
+            RequestId = new RequestId(1),
+            Error = new JsonRpcError.ErrorDetail { Code = JsonRpcErrorCode.InternalError, Message = "some error" },
+        };
+
+        Assert.Equal(
+            """{"id":1,"error":{"code":-32603,"message":"some error"}}""",
+            data.ToString());
+    }
+
+    [Fact]
+    public void JsonRpcResult_ToString_Works()
+    {
+        var data = new JsonRpcResult
+        {
+            RequestId = new RequestId("id"),
+        };
+
+        Assert.Equal(
+            """{"id":"id"}""",
+            data.ToString());
+    }
 }


### PR DESCRIPTION
When trimming or native AOT'ing an app, we want to remove Newtonsoft.Json dependencies when possible because it brings in a lot of AOT warnings and adds a lot of size to the final app.

Begin by removing these simple cases in the ToStrings of JsonRpcError, Request, and Result. ToString methods of instantiated types can never be trimmed, so the code in them is always preserved.

cc @AArnott 