### PR TITLE
Use JsonElement.Clone instead of Deserialize

### DIFF
--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -852,7 +852,7 @@ public class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFormatter, 
                 if (wrapper.RootElement.TryGetProperty(MessageFormatterEnumerableTracker.TokenPropertyName, out JsonElement enumToken))
                 {
                     // Copy the token so we can retain it and replay it later.
-                    handle = enumToken.Deserialize<JsonElement>();
+                    handle = enumToken.Clone();
                 }
 
                 IReadOnlyList<T>? prefetchedItems = null;


### PR DESCRIPTION
The existing code is using Deserialize to make a copy of the JsonElement in order to hold on to it past the usage of the parent JsonDocument. The problem is that the call to Deserialize isn't passing the JsonSerializerOptions. Thus when this code executes in a trimmed/aot'd app it will fail since reflection is disabled in System.Text.Json.

The fix could be to pass the options into the call, but a better fix all around is to use the Clone method, which is faster than calling Deserialize<JsonElement>.

cc @AArnott

Using this benchmark:

```C#
[MemoryDiagnoser]
public class Benchmarks
{
    private JsonDocument? data;
    private JsonElement element;

    private static JsonDocument ConstructDoc()
    {
        // Create a random JSON string
        string json = @"
        {
            ""id"": 123,
            ""name"": ""Test Item"",
            ""tags"": [""alpha"", ""beta"", ""gamma""],
            ""active"": true,
            ""created"": ""2025-06-13T14:30:00Z"",
            ""metadata"": {
                ""owner"": ""eric"",
                ""priority"": 5
            }
        }";

        // Parse it into a JsonDocument
        return JsonDocument.Parse(json);
    }

    [GlobalSetup]
    public void Setup()
    {
        data = ConstructDoc();
        element = data.RootElement;
    }

    [Benchmark]
    public JsonElement Clone()
    {
        return element.Clone();
    }

    [Benchmark]
    public JsonElement Deserialize()
    {
        return element.Deserialize<JsonElement>();
    }
}
```

on my machine produces:

```
BenchmarkDotNet v0.13.8, Windows 11 (10.0.26100.4349)
Unknown processor
.NET SDK 10.0.100-preview.4.25258.110
  [Host]     : .NET 9.0.5 (9.0.525.21509), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.5 (9.0.525.21509), X64 RyuJIT AVX2


| Method      | Mean      | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|------------ |----------:|---------:|---------:|-------:|-------:|----------:|
| Clone       |  39.67 ns | 0.242 ns | 0.214 ns | 0.0374 | 0.0001 |     704 B |
| Deserialize | 808.06 ns | 4.036 ns | 3.578 ns | 0.0372 |      - |     704 B |
```