### PR TITLE
Remove Dependency on Newtonsoft.Json from JsonRpc

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1575,7 +1575,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
             }
             else
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resources.ResponseUnexpectedFormat, JsonConvert.SerializeObject(response)));
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resources.ResponseUnexpectedFormat, response?.GetType().FullName ?? "(null)"));
             }
         }
         else

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -288,8 +288,8 @@
     <value>Failed to serialize the response.</value>
   </data>
   <data name="ResponseUnexpectedFormat" xml:space="preserve">
-    <value>Response is in an unexpected format.  Only error and result are supported: {0}</value>
-    <comment>{0} is the response message.</comment>
+    <value>Response is in an unexpected format.  Only error and result are supported, but received type: {0}</value>
+    <comment>{0} is the response object type.</comment>
   </data>
   <data name="RpcMarshalableDuplicatedOptionalInterface" xml:space="preserve">
     <value>Optional interface declarations should be unique. {0} has the same optional interface declared multiple times.</value>


### PR DESCRIPTION
The call to JsonConvert from JsonRpc.InvokeCoreAsync is unconditionally preserving Newtonsoft.Json in trimmed/aot'd apps.

Inspecting the current code, I am not sure how this error case ever happens. The call to InvokeCoreAsync only returns JsonRpcError or JsonRpcResult objects. The else shouldn't ever be taken.

Instead of serializing the object using Newtonsoft.Json, simply put the object's Type into the exception message to indicate what the unexpected object was.

cc @AArnott