### PR TITLE
Expose MessageFormatterEnumerableTracker.EnumeratorResults as public

### DIFF
--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks.Dataflow;
@@ -216,6 +217,29 @@ public class MessageFormatterEnumerableTracker
                 this.generatorTokensByRequestId.Remove(outboundRequestId);
             }
         }
+    }
+
+    /// <summary>
+    /// A slice of results from an <see cref="IAsyncEnumerable{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of element in the enumeration.</typeparam>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class EnumeratorResults<T>
+    {
+        /// <summary>
+        /// Gets the slice of values in this segment.
+        /// </summary>
+        [DataMember(Name = ValuesPropertyName, Order = 0)]
+        [STJ.JsonPropertyName(ValuesPropertyName), STJ.JsonPropertyOrder(0)]
+        public IReadOnlyList<T>? Values { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether this is definitely the last slice.
+        /// </summary>
+        [DataMember(Name = FinishedPropertyName, Order = 1)]
+        [STJ.JsonPropertyName(FinishedPropertyName), STJ.JsonPropertyOrder(1)]
+        public bool Finished { get; init; }
     }
 
     private class GeneratingEnumeratorTracker<T> : IGeneratingEnumeratorTracker
@@ -524,17 +548,5 @@ public class MessageFormatterEnumerableTracker
                 writer.Advance(values.Count);
             }
         }
-    }
-
-    [DataContract]
-    private class EnumeratorResults<T>
-    {
-        [DataMember(Name = ValuesPropertyName, Order = 0)]
-        [STJ.JsonPropertyName(ValuesPropertyName), STJ.JsonPropertyOrder(0)]
-        public IReadOnlyList<T>? Values { get; set; }
-
-        [DataMember(Name = FinishedPropertyName, Order = 1)]
-        [STJ.JsonPropertyName(FinishedPropertyName), STJ.JsonPropertyOrder(1)]
-        public bool Finished { get; set; }
     }
 }

--- a/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.EnumeratorResults() -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.get -> bool
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.init -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.get -> System.Collections.Generic.IReadOnlyList<T>?
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.init -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.EnumeratorResults() -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.get -> bool
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.init -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.get -> System.Collections.Generic.IReadOnlyList<T>?
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.init -> void

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 StreamJsonRpc.JsonRpc.Attach(System.ReadOnlySpan<System.Type!> interfaceTypes, StreamJsonRpc.JsonRpcProxyOptions? options) -> object!
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.EnumeratorResults() -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.get -> bool
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Finished.init -> void
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.get -> System.Collections.Generic.IReadOnlyList<T>?
+StreamJsonRpc.Reflection.MessageFormatterEnumerableTracker.EnumeratorResults<T>.Values.init -> void


### PR DESCRIPTION
This allows source generators, like System.Text.Json, to generate serialization logic for IAsyncEnumerable objects. This is necessary for support native AOT.

cc @aarnott