### PR TITLE
Refactor code and annotations to fix all warnings in NativeAOTCompatibility.

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -984,7 +984,6 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
     /// <summary>
     /// Converts an instance of <see cref="IProgress{T}"/> to a progress token.
     /// </summary>
-    [RequiresUnreferencedCode(RuntimeReasons.Formatters)]
     private class JsonProgressClientConverter : JsonConverter
     {
         private readonly JsonMessageFormatter formatter;
@@ -1046,7 +1045,6 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
     /// Converts an enumeration token to an <see cref="IAsyncEnumerable{T}"/>.
     /// </summary>
     [RequiresDynamicCode(RuntimeReasons.CloseGenerics)]
-    [RequiresUnreferencedCode(RuntimeReasons.Formatters)]
     private class AsyncEnumerableConsumerConverter : JsonConverter
     {
         private static readonly MethodInfo ReadJsonOpenGenericMethod = typeof(AsyncEnumerableConsumerConverter).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic).Single(m => m.Name == nameof(ReadJson) && m.IsGenericMethod);
@@ -1067,7 +1065,7 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
                 return null;
             }
 
-            Type? iface = TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(objectType);
+            Type? iface = TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(objectType);
             Assumes.NotNull(iface);
             MethodInfo genericMethod = ReadJsonOpenGenericMethod.MakeGenericMethod(iface.GenericTypeArguments[0]);
             try
@@ -1106,7 +1104,6 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
     /// Converts an instance of <see cref="IAsyncEnumerable{T}"/> to an enumeration token.
     /// </summary>
     [RequiresDynamicCode(RuntimeReasons.CloseGenerics)]
-    [RequiresUnreferencedCode(RuntimeReasons.ExtractTypes)]
     private class AsyncEnumerableGeneratorConverter : JsonConverter
     {
         private static readonly MethodInfo WriteJsonOpenGenericMethod = typeof(AsyncEnumerableGeneratorConverter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Single(m => m.Name == nameof(WriteJson) && m.IsGenericMethod);
@@ -1127,7 +1124,7 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
 
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            Type? iface = TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(value!.GetType());
+            Type? iface = TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(value!.GetType());
             Assumes.NotNull(iface);
             MethodInfo genericMethod = WriteJsonOpenGenericMethod.MakeGenericMethod(iface.GenericTypeArguments[0]);
             try

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -804,7 +804,6 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
         }
     }
 
-    [RequiresUnreferencedCode(RuntimeReasons.Formatters)]
     [RequiresDynamicCode(RuntimeReasons.CloseGenerics)]
     private class ProgressFormatterResolver : IFormatterResolver
     {
@@ -914,7 +913,7 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
         }
     }
 
-    [RequiresDynamicCode(RuntimeReasons.CloseGenerics), RequiresUnreferencedCode(RuntimeReasons.Formatters)]
+    [RequiresDynamicCode(RuntimeReasons.CloseGenerics)]
     private class AsyncEnumerableFormatterResolver : IFormatterResolver
     {
         private readonly MessagePackFormatter mainFormatter;
@@ -932,11 +931,11 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
             {
                 if (!this.enumerableFormatters.TryGetValue(typeof(T), out IMessagePackFormatter? formatter))
                 {
-                    if (TrackerHelpers<IAsyncEnumerable<int>>.IsActualInterfaceMatch(typeof(T)))
+                    if (TrackerHelpers.IsIAsyncEnumerable(typeof(T)))
                     {
                         formatter = (IMessagePackFormatter<T>?)Activator.CreateInstance(typeof(PreciseTypeFormatter<>).MakeGenericType(typeof(T).GenericTypeArguments[0]), new object[] { this.mainFormatter });
                     }
-                    else if (TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(typeof(T)) is { } iface)
+                    else if (TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(typeof(T)) is { } iface)
                     {
                         formatter = (IMessagePackFormatter<T>?)Activator.CreateInstance(typeof(GeneratorFormatter<,>).MakeGenericType(typeof(T), iface.GenericTypeArguments[0]), new object[] { this.mainFormatter });
                     }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks.Dataflow;
@@ -104,7 +102,7 @@ public class MessageFormatterEnumerableTracker
     /// <devremarks>
     /// We use <see langword="int"/> as a generic type argument in this because what we use doesn't matter, but we must use *something*.
     /// </devremarks>
-    public static bool CanSerialize([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] Type objectType) => TrackerHelpers<IAsyncEnumerable<int>>.CanSerialize(objectType);
+    public static bool CanSerialize(Type objectType) => TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(objectType) is not null;
 
     /// <summary>
     /// Checks if a given <see cref="Type"/> is exactly some closed generic type based on <see cref="IAsyncEnumerable{T}"/>.
@@ -114,7 +112,7 @@ public class MessageFormatterEnumerableTracker
     /// <devremarks>
     /// We use <see langword="int"/> as a generic type argument in this because what we use doesn't matter, but we must use *something*.
     /// </devremarks>
-    public static bool CanDeserialize(Type objectType) => TrackerHelpers<IAsyncEnumerable<int>>.CanDeserialize(objectType);
+    public static bool CanDeserialize(Type objectType) => TrackerHelpers.IsIAsyncEnumerable(objectType);
 
     /// <summary>
     /// Used by the generator to assign a handle to the given <see cref="IAsyncEnumerable{T}"/>.

--- a/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
@@ -70,8 +70,8 @@ public class MessageFormatterProgressTracker
     /// </summary>
     /// <param name="objectType">The type which may implement <see cref="IProgress{T}"/>.</param>
     /// <returns>The <see cref="IProgress{T}"/> from given <see cref="Type"/> object, or <see langword="null"/>  if no such interface was found in the given <paramref name="objectType" />.</returns>
-    public static Type? FindIProgressOfT([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type objectType)
-        => TrackerHelpers<IProgress<int>>.FindInterfaceImplementedBy(objectType);
+    public static Type? FindIProgressOfT(Type objectType)
+        => TrackerHelpers.FindIProgressInterfaceImplementedBy(objectType);
 
     /// <summary>
     /// Checks if a given <see cref="Type"/> implements <see cref="IProgress{T}"/>.
@@ -79,21 +79,21 @@ public class MessageFormatterProgressTracker
     /// <param name="objectType">The type which may implement <see cref="IProgress{T}"/>.</param>
     /// <returns>true if given <see cref="Type"/> implements <see cref="IProgress{T}"/>; otherwise, false.</returns>
     [Obsolete($"Use {nameof(CanSerialize)} instead.")]
-    public static bool IsSupportedProgressType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] Type objectType) => CanSerialize(objectType);
+    public static bool IsSupportedProgressType(Type objectType) => CanSerialize(objectType);
 
     /// <summary>
     /// Checks if a given <see cref="Type"/> implements <see cref="IProgress{T}"/>.
     /// </summary>
     /// <param name="objectType">The type which may implement <see cref="IProgress{T}"/>.</param>
     /// <returns>true if given <see cref="Type"/> implements <see cref="IProgress{T}"/>; otherwise, false.</returns>
-    public static bool CanSerialize([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] Type objectType) => TrackerHelpers<IProgress<int>>.CanSerialize(objectType);
+    public static bool CanSerialize(Type objectType) => FindIProgressOfT(objectType) is not null;
 
     /// <summary>
     /// Checks if a given <see cref="Type"/> is a closed generic of <see cref="IProgress{T}"/>.
     /// </summary>
     /// <param name="objectType">The type which may be <see cref="IProgress{T}"/>.</param>
     /// <returns>true if given <see cref="Type"/> is <see cref="IProgress{T}"/>; otherwise, false.</returns>
-    public static bool CanDeserialize(Type objectType) => TrackerHelpers<IProgress<int>>.CanDeserialize(objectType);
+    public static bool CanDeserialize(Type objectType) => TrackerHelpers.IsIProgress(objectType);
 
     /// <summary>
     /// Gets a <see cref="long"/> type token to use as replacement of an <see cref="object"/> implementing <see cref="IProgress{T}"/> in the JSON message.
@@ -240,10 +240,7 @@ public class MessageFormatterProgressTracker
         {
             Requires.NotNull(progressObject, nameof(progressObject));
 
-            [UnconditionalSuppressMessage("Trimming", "IL2072:RequiresUnreferencedCode", Justification = "The 'IProgress<>' Type must exist and so trimmer kept it. In which case it also kept it on any type which implements it.")]
-            static Type? FindIProgress(object progressObject) => FindIProgressOfT(progressObject.GetType());
-
-            Type? iProgressOfTType = FindIProgress(progressObject);
+            Type? iProgressOfTType = FindIProgressOfT(progressObject.GetType());
 
             Verify.Operation(iProgressOfTType is not null, Resources.FindIProgressOfTError);
 

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -365,14 +365,15 @@ internal class RpcTargetInfo : System.IAsyncDisposable
             }
         }
 
+#if !NET10_0_OR_GREATER
         [UnconditionalSuppressMessage("Trimming", "IL2062:UnrecognizedReflectionPattern", Justification = "exposedMembersOnType is annotated as preserve All members, so any Types returned from GetInterfaces should be preserved as well. See https://github.com/dotnet/linker/issues/1731.")]
+#endif
         void ActOnInterfaces([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type exposedMembersOnType)
         {
-            foreach (Type iface in exposedMembersOnType.GetInterfaces())
+            Type[] interfaces = exposedMembersOnType.GetInterfaces();
+            for (int i = 0; i < interfaces.Length; i++)
             {
-#pragma warning disable IL2072 // The Roslyn analyzer warns a different error code than the ilc compiler.
-                ActOn(iface.GetTypeInfo());
-#pragma warning restore IL2072
+                ActOn(interfaces[i].GetTypeInfo());
             }
         }
 
@@ -493,8 +494,9 @@ internal class RpcTargetInfo : System.IAsyncDisposable
     /// </summary>
     /// <param name="exposedMembersOnType">Type to reflect over and analyze its events.</param>
     /// <returns>A list of EventInfos found.</returns>
+#if !NET10_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2065:UnrecognizedReflectionPattern", Justification = "false positive: https://github.com/dotnet/linker/issues/1731")]
-    [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern", Justification = "false positive: https://github.com/dotnet/linker/issues/1731")]
+#endif
     private static IReadOnlyList<EventInfo> GetEventInfos([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TypeInfo exposedMembersOnType)
     {
         List<EventInfo> eventInfos = new List<EventInfo>();
@@ -512,9 +514,10 @@ internal class RpcTargetInfo : System.IAsyncDisposable
 
         if (exposedMembersOnType.IsInterface)
         {
-            foreach (Type iface in exposedMembersOnType.GetInterfaces())
+            Type[] interfaces = exposedMembersOnType.GetInterfaces();
+            for (int i = 0; i < interfaces.Length; i++)
             {
-                foreach (EventInfo evt in iface.GetTypeInfo().DeclaredEvents)
+                foreach (EventInfo evt in interfaces[i].GetTypeInfo().DeclaredEvents)
                 {
                     if (evt.AddMethod is object && !evt.AddMethod.IsStatic)
                     {

--- a/src/StreamJsonRpc/Reflection/TrackerHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/TrackerHelpers.cs
@@ -9,41 +9,40 @@ namespace StreamJsonRpc.Reflection;
 /// <summary>
 /// Helper methods for message formatter tracker classes.
 /// </summary>
-/// <typeparam name="TInterface">A generic interface. We only need the generic type definition, but since C# doesn't let us pass in open generic types, use <see cref="int"/> as a generic type argument.</typeparam>
-internal static class TrackerHelpers<TInterface>
-    where TInterface : class
+internal static class TrackerHelpers
 {
     /// <summary>
-    /// Dictionary to record the calculation made in <see cref="FindInterfaceImplementedBy(Type)"/> to obtain the <typeparamref name="TInterface"/> type from a given <see cref="Type"/>.
+    /// Dictionary to record the calculation made in <see cref="FindIProgressInterfaceImplementedBy(Type)"/> to obtain the IProgress{T} type from a given <see cref="Type"/>.
     /// </summary>
-    private static readonly Dictionary<Type, Type?> TypeToImplementedInterfaceMap = new();
+    private static readonly Dictionary<Type, Type?> TypeToIProgressMap = new();
 
     /// <summary>
-    /// Gets the generic type definition for whatever type parameter was given by <typeparamref name="TInterface" />.
+    /// Dictionary to record the calculation made in <see cref="FindIAsyncEnumerableInterfaceImplementedBy(Type)"/> to obtain the IAsyncEnumerable{T} type from a given <see cref="Type"/>.
     /// </summary>
-    private static readonly Type InterfaceGenericTypeDefinition = typeof(TInterface).GetGenericTypeDefinition();
+    private static readonly Dictionary<Type, Type?> TypeToIAsyncEnumerableMap = new();
 
     /// <summary>
-    /// Extracts some interface from a given <see cref="Type"/>, if it is implemented.
+    /// Extracts the IProgress{T} interface from a given <see cref="Type"/>, if it is implemented.
     /// </summary>
-    /// <param name="objectType">The type which may implement <typeparamref name="TInterface"/>.</param>
-    /// <returns>The <typeparamref name="TInterface"/> type from given <see cref="Type"/> object, or <see langword="null"/>  if no such interface was found in the given <paramref name="objectType" />.</returns>
-    internal static Type? FindInterfaceImplementedBy([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type objectType)
+    /// <param name="objectType">The type which may implement IProgress{T}.</param>
+    /// <returns>The IProgress{T} type from given <see cref="Type"/> object, or <see langword="null"/>  if no such interface was found in the given <paramref name="objectType" />.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern", Justification = "The 'IProgress<>' Type must exist and so trimmer kept it. In which case It also kept it on any type which implements it. The below call to GetInterfaces may return fewer results when trimmed but it will return 'IProgress<>' if the type implemented it, even after trimming.")]
+    internal static Type? FindIProgressInterfaceImplementedBy(Type objectType)
     {
         Requires.NotNull(objectType, nameof(objectType));
 
-        if (objectType.IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(InterfaceGenericTypeDefinition))
+        if (objectType.IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(typeof(IProgress<>)))
         {
             return objectType;
         }
 
         Type? interfaceFromType;
-        lock (TypeToImplementedInterfaceMap)
+        lock (TypeToIProgressMap)
         {
-            if (!TypeToImplementedInterfaceMap.TryGetValue(objectType, out interfaceFromType))
+            if (!TypeToIProgressMap.TryGetValue(objectType, out interfaceFromType))
             {
-                interfaceFromType = objectType.GetTypeInfo().GetInterfaces().FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == InterfaceGenericTypeDefinition);
-                TypeToImplementedInterfaceMap.Add(objectType, interfaceFromType);
+                interfaceFromType = objectType.GetTypeInfo().GetInterfaces().FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IProgress<>));
+                TypeToIProgressMap.Add(objectType, interfaceFromType);
             }
         }
 
@@ -51,23 +50,44 @@ internal static class TrackerHelpers<TInterface>
     }
 
     /// <summary>
-    /// Checks if a given <see cref="Type"/> implements <typeparamref name="TInterface"/>.
+    /// Checks whether the given type is the IProgress{T} interface.
     /// </summary>
-    /// <param name="objectType">The type which may implement <typeparamref name="TInterface"/>.</param>
-    /// <returns>true if given <see cref="Type"/> implements <typeparamref name="TInterface"/>; otherwise, false.</returns>
-    internal static bool CanSerialize([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] Type objectType) => FindInterfaceImplementedBy(objectType) is not null;
+    /// <param name="objectType">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="objectType"/> is a closed generic form of IProgress{T}; <see langword="false"/> otherwise.</returns>
+    internal static bool IsIProgress(Type objectType) => Requires.NotNull(objectType, nameof(objectType)).IsConstructedGenericType && objectType.GetGenericTypeDefinition() == typeof(IProgress<>);
 
     /// <summary>
-    /// Checks whether the given type is an interface compatible with <typeparamref name="TInterface"/>.
+    /// Extracts the IAsyncEnumerable{T} interface from a given <see cref="Type"/>, if it is implemented.
     /// </summary>
-    /// <param name="objectType">The type that may be deserialized.</param>
-    /// <returns><see langword="true"/> if <paramref name="objectType"/> is a closed generic form of <typeparamref name="TInterface"/>; <see langword="false"/> otherwise.</returns>
-    internal static bool CanDeserialize(Type objectType) => IsActualInterfaceMatch(objectType);
+    /// <param name="objectType">The type which may implement IAsyncEnumerable{T}.</param>
+    /// <returns>The IAsyncEnumerable{T} type from given <see cref="Type"/> object, or <see langword="null"/>  if no such interface was found in the given <paramref name="objectType" />.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern", Justification = "The 'IAsyncEnumerable<>' Type must exist and so trimmer kept it. In which case It also kept it on any type which implements it. The below call to GetInterfaces may return fewer results when trimmed but it will return 'IAsyncEnumerable<>' if the type implemented it, even after trimming.")]
+    internal static Type? FindIAsyncEnumerableInterfaceImplementedBy(Type objectType)
+    {
+        Requires.NotNull(objectType, nameof(objectType));
+
+        if (objectType.IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(typeof(IAsyncEnumerable<>)))
+        {
+            return objectType;
+        }
+
+        Type? interfaceFromType;
+        lock (TypeToIAsyncEnumerableMap)
+        {
+            if (!TypeToIAsyncEnumerableMap.TryGetValue(objectType, out interfaceFromType))
+            {
+                interfaceFromType = objectType.GetTypeInfo().GetInterfaces().FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
+                TypeToIAsyncEnumerableMap.Add(objectType, interfaceFromType);
+            }
+        }
+
+        return interfaceFromType;
+    }
 
     /// <summary>
-    /// Checks whether the given type is an interface compatible with <typeparamref name="TInterface"/>.
+    /// Checks whether the given type is the IAsyncEnumerable{T} interface.
     /// </summary>
-    /// <param name="objectType">The type that may be deserialized.</param>
-    /// <returns><see langword="true"/> if <paramref name="objectType"/> is a closed generic form of <typeparamref name="TInterface"/>; <see langword="false"/> otherwise.</returns>
-    internal static bool IsActualInterfaceMatch(Type objectType) => Requires.NotNull(objectType, nameof(objectType)).IsConstructedGenericType && objectType.GetGenericTypeDefinition().Equals(InterfaceGenericTypeDefinition);
+    /// <param name="objectType">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="objectType"/> is a closed generic form of IAsyncEnumerable{T}; <see langword="false"/> otherwise.</returns>
+    internal static bool IsIAsyncEnumerable(Type objectType) => Requires.NotNull(objectType, nameof(objectType)).IsConstructedGenericType && objectType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
 }

--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -773,7 +773,7 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
         }
     }
 
-    [RequiresDynamicCode(RuntimeReasons.Formatters), RequiresUnreferencedCode(RuntimeReasons.Formatters)]
+    [RequiresDynamicCode(RuntimeReasons.Formatters)]
     private class ProgressConverterFactory : JsonConverterFactory
     {
         private readonly SystemTextJsonFormatter formatter;
@@ -783,11 +783,11 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
             this.formatter = formatter;
         }
 
-        public override bool CanConvert(Type typeToConvert) => TrackerHelpers<IProgress<int>>.FindInterfaceImplementedBy(typeToConvert) is not null;
+        public override bool CanConvert(Type typeToConvert) => TrackerHelpers.FindIProgressInterfaceImplementedBy(typeToConvert) is not null;
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
-            Type? iface = TrackerHelpers<IProgress<int>>.FindInterfaceImplementedBy(typeToConvert);
+            Type? iface = TrackerHelpers.FindIProgressInterfaceImplementedBy(typeToConvert);
             Assumes.NotNull(iface);
             Type genericTypeArg = iface.GetGenericArguments()[0];
             Type converterType = typeof(Converter<>).MakeGenericType(genericTypeArg);
@@ -835,11 +835,11 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
             this.formatter = formatter;
         }
 
-        public override bool CanConvert(Type typeToConvert) => TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(typeToConvert) is not null;
+        public override bool CanConvert(Type typeToConvert) => TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(typeToConvert) is not null;
 
         public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
-            Type? iface = TrackerHelpers<IAsyncEnumerable<int>>.FindInterfaceImplementedBy(typeToConvert);
+            Type? iface = TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(typeToConvert);
             Assumes.NotNull(iface);
             Type genericTypeArg = iface.GetGenericArguments()[0];
             Type converterType = typeof(Converter<>).MakeGenericType(genericTypeArg);

--- a/test/NativeAOTCompatibility/Program.cs
+++ b/test/NativeAOTCompatibility/Program.cs
@@ -4,6 +4,7 @@
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Nerdbank.Streams;
 using StreamJsonRpc;
@@ -24,14 +25,12 @@ Console.WriteLine($"2 + 5 = {sum}");
 
 // When properly configured, this formatter is safe in Native AOT scenarios for
 // the very limited use case shown in this program.
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Using the Json source generator.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Using the Json source generator.")]
 IJsonRpcMessageFormatter CreateFormatter() => new SystemTextJsonFormatter()
 {
     JsonSerializerOptions = { TypeInfoResolver = SourceGenerationContext.Default },
 };
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 
 internal class Server
 {


### PR DESCRIPTION
There are a couple patterns here:

- Use GetMemberWithSameMetadataDefinitionAs to reflect on generic types/methods in a statically verifiable fashion. This method only exists in .NET 6+.
- Suppress warnings when using GetInterfaces when the Type is annotated as preserve 'All'. https://github.com/dotnet/linker/issues/1731
- When looking for a hard-coded interface like IProgress<T>, any preserved Type that implements the interface won't have the interface trimmed.
- MethodNameMap uses GetInterfaceMap, which may not work in all cases. See https://github.com/dotnet/runtime/issues/89157

cc @AArnott 

FYI - @agocke @MichalStrehovsky - would you mind checking the suppressions I needed to add here? The biggest one is the GetInterfaceMap issue.