### PR TITLE
Avoid 1-2 first chance exceptions on out of order disposal

### DIFF
--- a/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterRpcMarshaledContextTracker.cs
@@ -346,13 +346,16 @@ internal class MessageFormatterRpcMarshaledContextTracker
                 MethodNameTransform = mn => Invariant($"$/invokeProxy/{token.Value.Handle}/{options.MethodNameTransform(mn)}"),
                 OnDispose = token.Value.Lifetime == MarshalLifetime.Call ? null : delegate
                 {
-                    // Only forward the Dispose call if the marshaled interface derives from IDisposable.
-                    if (typeof(IDisposable).IsAssignableFrom(interfaceType))
+                    if (!this.jsonRpc.IsDisposed)
                     {
-                        this.jsonRpc.NotifyAsync(Invariant($"$/invokeProxy/{token.Value.Handle}/{options.MethodNameTransform(nameof(IDisposable.Dispose))}")).Forget();
-                    }
+                        // Only forward the Dispose call if the marshaled interface derives from IDisposable.
+                        if (typeof(IDisposable).IsAssignableFrom(interfaceType))
+                        {
+                            this.jsonRpc.NotifyAsync(Invariant($"$/invokeProxy/{token.Value.Handle}/{options.MethodNameTransform(nameof(IDisposable.Dispose))}")).Forget();
+                        }
 
-                    this.jsonRpc.NotifyWithParameterObjectAsync("$/releaseMarshaledObject", new { handle = token.Value.Handle, ownedBySender = false }).Forget();
+                        this.jsonRpc.NotifyWithParameterObjectAsync("$/releaseMarshaledObject", new { handle = token.Value.Handle, ownedBySender = false }).Forget();
+                    }
                 },
             },
             token.Value.Handle);

--- a/test/StreamJsonRpc.Tests/MarshalableProxyTests.cs
+++ b/test/StreamJsonRpc.Tests/MarshalableProxyTests.cs
@@ -586,6 +586,15 @@ public abstract class MarshalableProxyTests : TestBase
     }
 
     [Fact]
+    public async Task MarshableDisposedAfterConnection()
+    {
+        IMarshalable? proxyMarshalable = await this.client.GetMarshalableAsync().WithCancellation(this.TimeoutToken);
+        Assert.NotNull(proxyMarshalable);
+        this.clientRpc.Dispose();
+        proxyMarshalable.Dispose();
+    }
+
+    [Fact]
     public async Task IMarshalable_MarshaledAndForwarded()
     {
         IMarshalable? proxyMarshalable = await this.client.GetMarshalableAsync().WithCancellation(this.TimeoutToken);


### PR DESCRIPTION
Disposing of a marshaled object throws when the underlying connection has already been disposed of. These exceptions appear to be innocuous but they are at least false causes for alarm when the program is run under a debugger.

The fix is to arrange to skip when we can predict the exception.