### PR TITLE
Only suppress diagnostics when the interceptor is running

### DIFF
--- a/src/StreamJsonRpc.Analyzers/AttachAOTDiagnosticSuppressor.cs
+++ b/src/StreamJsonRpc.Analyzers/AttachAOTDiagnosticSuppressor.cs
@@ -37,6 +37,12 @@ public class AttachAOTDiagnosticSuppressor : DiagnosticSuppressor
     /// <inheritdoc/>
     public override void ReportSuppressions(SuppressionAnalysisContext context)
     {
+        // Don't suppress diagnostics unless the interceptor is running.
+        if (!ProxyGenerator.AreInterceptorsEnabled(context.Options.AnalyzerConfigOptionsProvider.GlobalOptions))
+        {
+            return;
+        }
+
         if (!KnownSymbols.TryCreate(context.Compilation, out KnownSymbols? symbols))
         {
             return;


### PR DESCRIPTION
In #1223 I added a source generator with an interceptor capability and a diagnostic suppressor. But the diagnostic suppressor ran unconditionally while the interceptor required opt-in, which would hide trim/dynamic code warnings inappropriately.
This fixes that.