### PR TITLE
Skip collection of symbols from samples project

### DIFF
--- a/tools/Get-SymbolFiles.ps1
+++ b/tools/Get-SymbolFiles.ps1
@@ -17,6 +17,9 @@ $ActivityName = "Collecting symbols from $Path"
 Write-Progress -Activity $ActivityName -CurrentOperation "Discovery PDB files"
 $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 
+# Remove samples
+$PDBs = $PDBs | Where-Object { $_.FullName -notmatch "samples" }
+
 # Filter PDBs to product OR test related.
 $testregex = "unittest|tests|\.test\.|Benchmarks"
 


### PR DESCRIPTION
We aren't signing the samples, so it was causing a compliance break to collect their symbols.
