### PR TITLE
Stop intercepting Attach calls within StreamJsonRpc itself

### DIFF
--- a/src/AnalyzerUser.targets
+++ b/src/AnalyzerUser.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <EnableStreamJsonRpcInterceptors>true</EnableStreamJsonRpcInterceptors>
+    <EnableStreamJsonRpcInterceptors Condition="'$(EnableStreamJsonRpcInterceptors)'==''">true</EnableStreamJsonRpcInterceptors>
   </PropertyGroup>
   <ItemGroup>
     <AnalyzerProjectReference Include="$(RepoRootPath)src\StreamJsonRpc.Analyzers\StreamJsonRpc.Analyzers.csproj" />

--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn);SYSLIB0050</NoWarn>
     <!-- Enable warnings regarding AOT compatibility. Learn more about testing strategies at https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/ -->
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+    <EnableStreamJsonRpcInterceptors>false</EnableStreamJsonRpcInterceptors>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx" />

--- a/test/StreamJsonRpc.Analyzer.Tests/ProxyGeneratorTests.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/ProxyGeneratorTests.cs
@@ -587,6 +587,14 @@ public class ProxyGeneratorTests
             """);
     }
 
+    /// <summary>
+    /// Tracks the scenario of unknown types being passed to the <c>Attach</c> method.
+    /// </summary>
+    /// <remarks>
+    /// Although the type is unknown, we still want to redirect the API call to
+    /// NativeAOT safe alternatives (that will fail at runtime if the proxy hasn't been generated).
+    /// Projects are required to opt-in to this behavior, so we consider it safe.
+    /// </remarks>
     [Fact]
     public async Task Interceptor_UnknownTypes_Generic()
     {
@@ -602,6 +610,14 @@ public class ProxyGeneratorTests
             """);
     }
 
+    /// <summary>
+    /// Tracks the scenario of unknown types being passed to the <c>Attach</c> method.
+    /// </summary>
+    /// <remarks>
+    /// Although the type is unknown, we still want to redirect the API call to
+    /// NativeAOT safe alternatives (that will fail at runtime if the proxy hasn't been generated).
+    /// Projects are required to opt-in to this behavior, so we consider it safe.
+    /// </remarks>
     [Fact]
     public async Task Interceptor_UnknownTypes_NonGeneric()
     {

--- a/test/StreamJsonRpc.Tests/ArchitectureTests.cs
+++ b/test/StreamJsonRpc.Tests/ArchitectureTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class ArchitectureTests
+{
+    /// <summary>
+    /// Verifies that no interceptors are present in the StreamJsonRpc assembly.
+    /// </summary>
+    /// <remarks>
+    /// Our own library intentionally has NativeAOT safe and unsafe APIs, and the unsafe ones should
+    /// <em>not</em> be rewritten to call the safe APIs, since that can cause runtime exceptions when
+    /// our callers are not prepared for NativeAOT safety's restrictions.
+    /// </remarks>
+    [Fact]
+    public void NoInterceptors()
+    {
+        Assert.DoesNotContain(typeof(JsonRpc).Assembly.GetTypes(), t => t.Namespace == "StreamJsonRpc.Generated");
+    }
+}


### PR DESCRIPTION
This was causing runtime regressions in existing callers that were using the older APIs.

The interceptor was designed for _external_ assemblies. Not StreamJsonRpc itself. 