### PR TITLE
Classify UnreachableAssembly symbols as test symbol

### DIFF
--- a/tools/Get-SymbolFiles.ps1
+++ b/tools/Get-SymbolFiles.ps1
@@ -21,7 +21,7 @@ $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 $PDBs = $PDBs | Where-Object { $_.FullName -notmatch "samples" }
 
 # Filter PDBs to product OR test related.
-$testregex = "unittest|tests|\.test\.|Benchmarks"
+$testregex = "unittest|tests|\.test\.|Benchmarks|UnreachableAssembly"
 
 Write-Progress -Activity $ActivityName -CurrentOperation "De-duplicating symbols"
 $PDBsByHash = @{}


### PR DESCRIPTION
This fixes an official build break.