### PR TITLE
Eliminate over-build from the `dotnet publish` "test"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,19 @@
     <LangVersion Condition="'$(MSBuildProjectExtension)'=='.vbproj'">16.9</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('Windows'))">win</RidOsPrefix>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('Linux'))">linux</RidOsPrefix>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('OSX'))">osx</RidOsPrefix>
+
+    <RidOsArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'x64'">x64</RidOsArchitecture>
+    <RidOsArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64'">arm64</RidOsArchitecture>
+
+    <DefaultRuntimeIdentifier>$(RidOsPrefix)-$(RidOsArchitecture)</DefaultRuntimeIdentifier>
+    <!-- <AvailableRuntimeIdentifiers>$(RidOsPrefix)-arm64;$(RidOsPrefix)-x64</AvailableRuntimeIdentifiers> -->
+    <AvailableRuntimeIdentifiers>$(DefaultRuntimeIdentifier)</AvailableRuntimeIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="$(RepoRootPath)obj/NOTICE" Pack="true" PackagePath="" Visible="false" Condition=" Exists('$(RepoRootPath)obj/NOTICE') " />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,6 @@
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
+
+  <Import Project="Directory.Traversal.targets" Condition="'$(IsTraversal)'=='true'" />
 </Project>

--- a/Directory.Traversal.targets
+++ b/Directory.Traversal.targets
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <PackInParallel>true</PackInParallel>
+
+    <TestX64Binaries>false</TestX64Binaries>
+    <TestArm64Binaries>false</TestArm64Binaries>
+    <TestX64Binaries Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'x64'">true</TestX64Binaries>
+    <TestArm64Binaries Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64'">true</TestArm64Binaries>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(RidOsPrefix)-x64" Test="$(TestX64Binaries)" />
+    <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(RidOsPrefix)-arm64" Test="$(TestArm64Binaries)" /> -->
+    <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(DefaultRuntimeIdentifier)" Test="true" />
+  </ItemGroup>
+</Project>

--- a/StreamJsonRpc.slnx
+++ b/StreamJsonRpc.slnx
@@ -9,10 +9,12 @@
     <File Path="global.json" />
     <File Path="nuget.config" />
     <File Path="stylecop.json" />
+    <File Path="tools/dirs.proj" />
     <File Path="version.json" />
   </Folder>
   <Folder Name="/src/">
     <File Path="src/.editorconfig" />
+    <File Path="src/dirs.proj" />
     <File Path="src/Analyzers.props" />
     <File Path="src/AnalyzerUser.targets" />
     <File Path="src/Directory.Build.props" />
@@ -23,6 +25,7 @@
   </Folder>
   <Folder Name="/test/">
     <File Path="test/.editorconfig" />
+    <File Path="test/dirs.proj" />
     <File Path="test/Directory.Build.props" />
     <File Path="test/Directory.Build.targets" />
     <Project Path="samples/Samples.csproj" />

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -13,7 +13,7 @@ parameters:
 
 steps:
 
-- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904,LOCTASK002 /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
+- script: dotnet build tools/dirs.proj -t:build,pack,publish --no-restore -c $(BuildConfiguration) -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904,LOCTASK002 /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠 dotnet build
   ${{ if parameters.BuildRequiresAccessToken }}:
     env:
@@ -47,10 +47,6 @@ steps:
 - ${{ if parameters.IsOptProf }}:
   - script: dotnet pack src\VSInsertionMetadata -c $(BuildConfiguration) -warnaserror /bl:"$(Build.ArtifactStagingDirectory)/build_logs/VSInsertion-Pack.binlog"
     displayName: 🔧 dotnet pack VSInsertionMetadata
-
-- script: dotnet publish -r ${{ parameters.osRID }}-x64 -warnaserror
-  displayName: 🧪 NativeAOT test
-  workingDirectory: test/NativeAOTCompatibility.Test
 
 - powershell: tools/variables/_define.ps1
   failOnStderr: true

--- a/global.json
+++ b/global.json
@@ -5,6 +5,7 @@
     "allowPrerelease": false
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.56"
+    "Microsoft.Build.NoTargets": "3.7.56",
+    "Microsoft.Build.Traversal": "4.1.82"
   }
 }

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="**\*.csproj" Publish="false" />
+  </ItemGroup>
+</Project>

--- a/test/AOT.props
+++ b/test/AOT.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <RuntimeIdentifiers>$(AvailableRuntimeIdentifiers)</RuntimeIdentifiers>
+    <RuntimeIdentifier>$(DefaultRuntimeIdentifier)</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <!-- Suppress spreading the RID being built here to RID-neutral projects. -->
+      <GlobalPropertiesToRemove>RuntimeIdentifier</GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+</Project>

--- a/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
+++ b/test/NativeAOTCompatibility.Test/NativeAOTCompatibility.Test.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\AOT.props" />
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnableStreamJsonRpcInterceptors>true</EnableStreamJsonRpcInterceptors>

--- a/test/dirs.proj
+++ b/test/dirs.proj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="**\*.csproj" Exclude="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" Publish="false" />
+
+    <MultiRIDProjectReference Include="NativeAOTCompatibility.Test\NativeAOTCompatibility.Test.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/dirs.proj
+++ b/tools/dirs.proj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRootPath)samples\Samples.csproj" />
+    <ProjectReference Include="$(RepoRootPath)src\dirs.proj" />
+    <ProjectReference Include="$(RepoRootPath)test\dirs.proj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The NativeAOTCompatibility.Test project is published as part of our build pipeline as a test. Yes, the publish itself is the test, because in publishing, extra validation is performed by the .NET SDK to ensure that the code is NativeAOT-safe.
But in process of publishing it, we were also *re*-building its dependencies. Not only was this redundant, it was very slow on signed builds. Most importantly, it caused us to ship one set of binaries but archive symbols for an alternate set.

The problem was that we were building and packing first, then we were publishing which re-built but didn't re-pack. As a result, the nupkg packages were stale relative to the pdb's that were on disk from the later build. So we archived symbols based on the loose pdb files, but then we deploy the nupkg binaries.

With this fix, our build gets significantly faster and we only have one set of binaries, so we archive the right symbols.

Fixes devdiv-2557744