### PR TITLE
Fix failure in design-time builds when working in a clean repo

### DIFF
--- a/test/UnreachableAssembly.targets
+++ b/test/UnreachableAssembly.targets
@@ -8,7 +8,10 @@
   <Target Name="PlaceMissingAssembly" AfterTargets="ResolveReferences">
     <ItemGroup>
       <DivertedProjectReferenceOutputs Include="@(ReferencePath)" Condition=" '%(FileName)' == 'UnreachableAssembly' " />
+      <Content Include="@(DivertedProjectReferenceOutputs)">
+        <Link>hidden\%(FileName)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
-    <Copy SourceFiles="@(DivertedProjectReferenceOutputs)" DestinationFolder="$(OutputPath)hidden" SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
We were seeing errors in the Error List from the inability to copy a dll that had not been built yet.