### PR TITLE
Dynamically generated proxies reliably invoke with non-aliased method names

### DIFF
--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -284,7 +284,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
 
         lock (this.SyncObject)
         {
-            foreach (KeyValuePair<string, IReadOnlyList<RpcTargetMetadata.TargetMethodMetadata>> item in targetType.Methods)
+            foreach (KeyValuePair<string, IReadOnlyList<RpcTargetMetadata.TargetMethodMetadata>> item in targetType.Methods.Concat(targetType.AliasedMethods))
             {
                 string rpcMethodName = options.MethodNameTransform is not null ? options.MethodNameTransform(item.Key) : item.Key;
                 Requires.Argument(rpcMethodName is not null, nameof(options), nameof(JsonRpcTargetOptions.MethodNameTransform) + " delegate returned a value that is not a legal RPC method name.");

--- a/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
@@ -96,6 +96,8 @@ StreamJsonRpc.Reflection.ProxyInputs.Options.get -> StreamJsonRpc.JsonRpcProxyOp
 StreamJsonRpc.Reflection.ProxyInputs.Options.init -> void
 StreamJsonRpc.Reflection.ProxyInputs.ProxyInputs() -> void
 StreamJsonRpc.RpcTargetMetadata
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata!>!>!
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.init -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.Add(System.Type! iface) -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.ClassAndInterfaces(System.Type! classType) -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -94,6 +94,8 @@ StreamJsonRpc.Reflection.ProxyInputs.Options.get -> StreamJsonRpc.JsonRpcProxyOp
 StreamJsonRpc.Reflection.ProxyInputs.Options.init -> void
 StreamJsonRpc.Reflection.ProxyInputs.ProxyInputs() -> void
 StreamJsonRpc.RpcTargetMetadata
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata!>!>!
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.init -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.Add(System.Type! iface) -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.ClassAndInterfaces(System.Type! classType) -> void

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -94,6 +94,8 @@ StreamJsonRpc.Reflection.ProxyInputs.Options.get -> StreamJsonRpc.JsonRpcProxyOp
 StreamJsonRpc.Reflection.ProxyInputs.Options.init -> void
 StreamJsonRpc.Reflection.ProxyInputs.ProxyInputs() -> void
 StreamJsonRpc.RpcTargetMetadata
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata!>!>!
+StreamJsonRpc.RpcTargetMetadata.AliasedMethods.init -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.Add(System.Type! iface) -> void
 StreamJsonRpc.RpcTargetMetadata.ClassAndInterfaces.ClassAndInterfaces(System.Type! classType) -> void

--- a/test/StreamJsonRpc.Tests/RpcTargetMetadataTests.cs
+++ b/test/StreamJsonRpc.Tests/RpcTargetMetadataTests.cs
@@ -49,7 +49,7 @@ public partial class RpcTargetMetadataTests
         RpcTargetMetadata metadata = RpcTargetMetadata.FromShape<IShapedContract>(Witness.ShapeProvider);
 
         var addAsync = Assert.Single(metadata.Methods["AddAsync"]);
-        var add = Assert.Single(metadata.Methods["Add"]);
+        var add = Assert.Single(metadata.AliasedMethods["Add"]);
         Assert.Same(addAsync, add);
 
         var subtract = Assert.Single(metadata.Methods["Subtract"]);
@@ -59,7 +59,8 @@ public partial class RpcTargetMetadataTests
         var multiply = Assert.Single(metadata.Methods["Times"]);
 
         // Fail the test when support for events is added so we can update the test.
-        Assert.Equal(4, metadata.Methods.Count);
+        Assert.Equal(3, metadata.Methods.Count);
+        Assert.Single(metadata.AliasedMethods);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1266