### PR TITLE
Proxies should honor `MethodShapeAttribute.Name`

### DIFF
--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
@@ -167,6 +167,15 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
     internal static MethodModel Create(IMethodSymbol method, KnownSymbols symbols)
     {
         string rpcMethodName = method.Name;
+        if (method.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbols.MethodShapeAttribute)) is { } methodShapeAttribute)
+        {
+            // If the method has a MethodShape attribute, use its name.
+            if (methodShapeAttribute.NamedArguments.FirstOrDefault(a => a.Key == Types.MethodShapeAttribute.NameProperty).Value.Value is string name)
+            {
+                rpcMethodName = name;
+            }
+        }
+
         if (method.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbols.JsonRpcMethodAttribute)) is { } rpcMethodAttribute)
         {
             // If the method has a JsonRpcMethod attribute, use its name.

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -21,6 +21,7 @@ internal record KnownSymbols(
     INamedTypeSymbol ExportRpcContractProxiesAttribute,
     INamedTypeSymbol JsonRpcProxyMappingAttribute,
     INamedTypeSymbol JsonRpcMethodAttribute,
+    INamedTypeSymbol? MethodShapeAttribute,
     INamedTypeSymbol SystemType,
     INamedTypeSymbol Stream)
 {
@@ -40,6 +41,7 @@ internal record KnownSymbols(
         INamedTypeSymbol? exportRpcContractProxiesAttribute = compilation.GetTypeByMetadataName(Types.ExportRpcContractProxiesAttribute.FullName);
         INamedTypeSymbol? rpcProxyMappingAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcProxyMappingAttribute.FullName);
         INamedTypeSymbol? jsonRpcMethodAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcMethodAttribute.FullName);
+        INamedTypeSymbol? methodShapeAttribute = compilation.GetTypeByMetadataName(Types.MethodShapeAttribute.FullName);
         INamedTypeSymbol? systemType = compilation.GetTypeByMetadataName("System.Type");
         INamedTypeSymbol? systemIOStream = compilation.GetTypeByMetadataName("System.IO.Stream");
 
@@ -59,7 +61,7 @@ internal record KnownSymbols(
             return false;
         }
 
-        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcMethodAttribute, systemType, systemIOStream);
+        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcMethodAttribute, methodShapeAttribute, systemType, systemIOStream);
         return true;
     }
 }

--- a/src/StreamJsonRpc.Analyzers/Types.cs
+++ b/src/StreamJsonRpc.Analyzers/Types.cs
@@ -47,4 +47,11 @@ internal static class Types
     {
         internal const string FullName = "StreamJsonRpc.JsonRpcMethodAttribute";
     }
+
+    internal static class MethodShapeAttribute
+    {
+        internal const string FullName = "PolyType.MethodShapeAttribute";
+
+        internal const string NameProperty = "Name";
+    }
 }

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -238,7 +238,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         string rpcMethodName = methodRpcSettings?.Name ?? handler.Name;
         lock (this.SyncObject)
         {
-            MethodSignatureAndTarget methodTarget = new(RpcTargetMetadata.TargetMethodMetadata.From(handler, methodRpcSettings, shape: null), target, attribute: null, synchronizationContext);
+            MethodSignatureAndTarget methodTarget = new(RpcTargetMetadata.TargetMethodMetadata.From(handler, methodRpcSettings, shape: null, methodShapeAttribute: null), target, attribute: null, synchronizationContext);
             this.TraceLocalMethodAdded(rpcMethodName, methodTarget);
             if (this.targetRequestMethodToClrMethodMap.TryGetValue(rpcMethodName, out List<MethodSignatureAndTarget>? existingList))
             {

--- a/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/net8.0/PublicAPI.Unshipped.txt
@@ -124,6 +124,7 @@ StreamJsonRpc.RpcTargetMetadata.RpcTargetMetadata() -> void
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Attribute.get -> StreamJsonRpc.JsonRpcMethodAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodInfo.get -> System.Reflection.MethodInfo!
+StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodShapeAttribute.get -> PolyType.MethodShapeAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Name.get -> string!
 StreamJsonRpc.RpcTargetMetadata.TargetType.get -> System.Type!
 StreamJsonRpc.RpcTargetMetadata.TargetType.init -> void

--- a/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.0/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ StreamJsonRpc.RpcTargetMetadata.RpcTargetMetadata() -> void
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Attribute.get -> StreamJsonRpc.JsonRpcMethodAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodInfo.get -> System.Reflection.MethodInfo!
+StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodShapeAttribute.get -> PolyType.MethodShapeAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Name.get -> string!
 StreamJsonRpc.RpcTargetMetadata.TargetType.get -> System.Type!
 StreamJsonRpc.RpcTargetMetadata.TargetType.init -> void

--- a/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/StreamJsonRpc/netstandard2.1/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ StreamJsonRpc.RpcTargetMetadata.RpcTargetMetadata() -> void
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Attribute.get -> StreamJsonRpc.JsonRpcMethodAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodInfo.get -> System.Reflection.MethodInfo!
+StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.MethodShapeAttribute.get -> PolyType.MethodShapeAttribute?
 StreamJsonRpc.RpcTargetMetadata.TargetMethodMetadata.Name.get -> string!
 StreamJsonRpc.RpcTargetMetadata.TargetType.get -> System.Type!
 StreamJsonRpc.RpcTargetMetadata.TargetType.init -> void


### PR DESCRIPTION
RPC _targets_ already honored this attribute, so it's critical that proxies do as well, so that when proxies send requests, the servers will match them to a method.

Fixes #1267