### PR TITLE
Replace tedious GenerateShapeFor attributes with method shapes

### DIFF
--- a/test/StreamJsonRpc.Tests/AsyncEnumerableNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/AsyncEnumerableNerdbankMessagePackTests.cs
@@ -16,10 +16,6 @@ public partial class AsyncEnumerableNerdbankMessagePackTests : AsyncEnumerableTe
         this.clientMessageFormatter = new NerdbankMessagePackFormatter() { TypeShapeProvider = Witness.ShapeProvider };
     }
 
-    [GenerateShapeFor<IReadOnlyList<int>>]
-    [GenerateShapeFor<IReadOnlyList<string>>]
-    [GenerateShapeFor<IReadOnlyList<CompoundEnumerableResult>>]
-    [GenerateShapeFor<IAsyncEnumerable<string>>]
-    [GenerateShapeFor<CompoundEnumerableResult>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -11,6 +11,7 @@ using MessagePack.Formatters;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
 using Newtonsoft.Json;
+using PolyType;
 using NBMP = Nerdbank.MessagePack;
 
 public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime

--- a/test/StreamJsonRpc.Tests/DisposableProxyNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/DisposableProxyNerdbankMessagePackTests.cs
@@ -10,9 +10,6 @@ public partial class DisposableProxyNerdbankMessagePackTests(ITestOutputHelper l
 
     protected override IJsonRpcMessageFormatter CreateFormatter() => new NerdbankMessagePackFormatter() { TypeShapeProvider = Witness.ShapeProvider };
 
-    [GenerateShapeFor<ProxyContainer>]
-    [GenerateShapeFor<DataContainer>]
-    [GenerateShapeFor<Data>]
-    [GenerateShapeFor<IDisposableObservable>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/DisposableProxyTests.cs
+++ b/test/StreamJsonRpc.Tests/DisposableProxyTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
+using PolyType;
 
 #pragma warning disable CA2214 // Do not call virtual methods in constructors
 

--- a/test/StreamJsonRpc.Tests/DuplexPipeMarshalingNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/DuplexPipeMarshalingNerdbankMessagePackTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO.Pipelines;
 using PolyType;
 
 public partial class DuplexPipeMarshalingNerdbankMessagePackTests : DuplexPipeMarshalingTests
@@ -29,9 +28,6 @@ public partial class DuplexPipeMarshalingNerdbankMessagePackTests : DuplexPipeMa
         this.clientMessageFormatter = clientFormatter;
     }
 
-    [GenerateShapeFor<IDuplexPipe>]
-    [GenerateShapeFor<Stream>]
-    [GenerateShapeFor<PipeReader>]
-    [GenerateShapeFor<PipeWriter>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -764,7 +764,8 @@ public abstract partial class DuplexPipeMarshalingTests : TestBase, IAsyncLifeti
     }
 
 #pragma warning disable SA1202 // Elements should be ordered by access
-    public class Server
+    [GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+    public partial class Server
 #pragma warning restore SA1202 // Elements should be ordered by access
     {
         internal Task? ChatLaterTask { get; private set; }

--- a/test/StreamJsonRpc.Tests/JsonRpcNerdbankMessagePackLengthTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcNerdbankMessagePackLengthTests.cs
@@ -105,22 +105,6 @@ public partial class JsonRpcNerdbankMessagePackLengthTests(ITestOutputHelper log
         }
     }
 
-    [GenerateShapeFor<System.Collections.IDictionary>]
-    [GenerateShapeFor<int?>]
-    [GenerateShapeFor<double>]
-    [GenerateShapeFor<Guid>]
-    [GenerateShapeFor<InternalClass>]
-    [GenerateShapeFor<Server.CustomErrorData>]
-    [GenerateShapeFor<IProgress<int>>]
-    [GenerateShapeFor<IProgress<TypeThrowsWhenSerialized>>]
-    [GenerateShapeFor<IProgress<UnionBaseClass>>]
-    [GenerateShapeFor<IProgress<CustomSerializedType>>]
-    [GenerateShapeFor<IAsyncEnumerable<UnionBaseClass>>]
-    [GenerateShapeFor<TypeThrowsWhenSerialized>]
-    [GenerateShapeFor<TypeThrowsWhenDeserialized>]
-    [GenerateShapeFor<StrongTypedProgressType>]
-    [GenerateShapeFor<XAndYPropertiesWithProgress>]
-    [GenerateShapeFor<VAndWProperties>]
-    [GenerateShapeFor<Exception>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -3357,6 +3357,7 @@ public abstract partial class JsonRpcTests : TestBase
     }
 
 #pragma warning disable CA1801 // use all parameters
+    [GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     public partial class Server : BaseClass, IServerDerived
     {
         internal const string ExceptionMessage = "some message";
@@ -4424,4 +4425,9 @@ public abstract partial class JsonRpcTests : TestBase
 
         public override bool CanDeserialize(Type type) => typeof(Exception).IsAssignableFrom(type) && !typeof(TaskCanceledException).IsAssignableFrom(type);
     }
+
+    [GenerateShapeFor<StrongTypedProgressType>] // used on client side only
+    [GenerateShapeFor<InternalClass>] // Implementation detail of the server method
+    [GenerateShapeFor<TypeThrowsWhenSerialized>] // this isn't in any API, but a client tries to serialize it.
+    private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/MarshalableProxyNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/MarshalableProxyNerdbankMessagePackTests.cs
@@ -15,29 +15,6 @@ public partial class MarshalableProxyNerdbankMessagePackTests : MarshalableProxy
 
     protected override IJsonRpcMessageFormatter CreateFormatter() => new NerdbankMessagePackFormatter() { TypeShapeProvider = Witness.ShapeProvider };
 
-    [GenerateShapeFor<Data>]
-    [GenerateShapeFor<DataContainer>]
-    [GenerateShapeFor<IMarshalable>]
-    [GenerateShapeFor<ProxyContainer<IMarshalable>>]
-    [GenerateShapeFor<ProxyContainer<IMarshalableAndSerializable>>]
-    [GenerateShapeFor<ProxyContainer<IGenericMarshalable<int>>>]
-    [GenerateShapeFor<IMarshalableWithProperties>]
-    [GenerateShapeFor<IMarshalableWithEvents>]
-    [GenerateShapeFor<IMarshalableAndSerializable>]
-    [GenerateShapeFor<IMarshalableWithCallScopedLifetime>]
-    [GenerateShapeFor<INonDisposableMarshalable>]
-    [GenerateShapeFor<IMarshalableSubType1>]
-    [GenerateShapeFor<IMarshalableSubType2>]
-    [GenerateShapeFor<IMarshalableSubType1Extended>]
-    [GenerateShapeFor<IMarshalableNonExtendingBase>]
-    [GenerateShapeFor<IMarshalableSubTypesCombined>]
-    [GenerateShapeFor<IMarshalableSubTypeWithIntermediateInterface>]
-    [GenerateShapeFor<IMarshalableSubTypeWithIntermediateInterface2>]
-    [GenerateShapeFor<IMarshalableWithOptionalInterfaces>]
-    [GenerateShapeFor<IMarshalableWithOptionalInterfaces2>]
-    [GenerateShapeFor<IMarshalableSubType2Extended>]
-    [GenerateShapeFor<IGenericMarshalable<int>>]
-    [GenerateShapeFor<IAsyncEnumerable<int>>]
-    [GenerateShapeFor<IAsyncEnumerable<string>>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/ObserverMarshalingNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/ObserverMarshalingNerdbankMessagePackTests.cs
@@ -7,7 +7,6 @@ public partial class ObserverMarshalingNerdbankMessagePackTests(ITestOutputHelpe
 {
     protected override IJsonRpcMessageFormatter CreateFormatter() => new NerdbankMessagePackFormatter { TypeShapeProvider = Witness.ShapeProvider };
 
-    [GenerateShapeFor<ApplicationException>]
-    [GenerateShapeFor<IObserver<int>>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/RpcTargetMetadataTests.cs
+++ b/test/StreamJsonRpc.Tests/RpcTargetMetadataTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.ComponentModel.DataAnnotations;
 using PolyType;
 
 public partial class RpcTargetMetadataTests
@@ -130,6 +129,6 @@ public partial class RpcTargetMetadataTests
         internal void OnDerivedEvent(MyEventArgs e) => this.DerivedEvent?.Invoke(this, e);
     }
 
-    [GenerateShapeFor<IShapedContract>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
+++ b/test/StreamJsonRpc.Tests/StreamJsonRpc.Tests.csproj
@@ -12,6 +12,8 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <!-- PolyType generated code constructs a ProgressWithCompletion<T> without a JTF, but for tests we don't care. -->
     <NoWarn>$(NoWarn);VSTHRD012</NoWarn>
+    <!-- This warning cannot be suppressed via #pragma https://github.com/eiriktsarpalis/PolyType/issues/196#issuecomment-3194972366 -->
+    <NoWarn>$(NoWarn);PT0021</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/StreamJsonRpc.Tests/TargetObjectEventsNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/TargetObjectEventsNerdbankMessagePackTests.cs
@@ -11,7 +11,6 @@ public partial class TargetObjectEventsNerdbankMessagePackTests(ITestOutputHelpe
         this.clientMessageHandler = new LengthHeaderMessageHandler(this.clientStream, this.clientStream, clientMessageFormatter);
     }
 
-    [GenerateShapeFor<EventArgs>]
-    [GenerateShapeFor<MessageEventArgs<string>>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
+++ b/test/StreamJsonRpc.Tests/TargetObjectEventsTests.cs
@@ -506,4 +506,7 @@ public abstract partial class TargetObjectEventsTests : TestBase
         public event MyDelegate? MyEvent;
 #pragma warning restore CS0067
     }
+
+    [GenerateShapeFor<MessageEventArgs<string>>] // internal member on Client class.
+    private partial class Witness;
 }

--- a/test/StreamJsonRpc.Tests/WebSocketMessageHandlerNerdbankMessagePackTests.cs
+++ b/test/StreamJsonRpc.Tests/WebSocketMessageHandlerNerdbankMessagePackTests.cs
@@ -7,6 +7,6 @@ public partial class WebSocketMessageHandlerNerdbankMessagePackTests : WebSocket
     {
     }
 
-    [GenerateShapeFor<int>]
+    [GenerateShapeFor<bool>]
     private partial class Witness;
 }


### PR DESCRIPTION
We now can use method shapes (RPC contracts with `[GenerateShape(Methods)]` on them) to ensure that we have type shapes for all the RPC methods' parameter and return types.

We still need a `Witness` class in a few cases, including just a stub to reach the ShapeProvider to pass to the formatter.

Closes #1269