### PR TITLE
Fix msbuild analyzer version property

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
 			"allowedVersions": "<2.3"
 		},
 		{
-			"matchJsonata": [ "sharedVariableName='RoslynVersionForAnalyzers'" ],
+			"matchJsonata": [ "sharedVariableName='RoslynVersion'" ],
 			"enabled": false
 		}
 	]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,8 @@
     <MessagePackVersion>2.5.198</MessagePackVersion>
     <MicroBuildVersion>2.0.199</MicroBuildVersion>
     <RoslynVersion>4.14.0</RoslynVersion>
-    <RoslynVersionForAnalyzers>4.14.0</RoslynVersionForAnalyzers>
-    <VisualStudioThreadingVersion>17.14.15</VisualStudioThreadingVersion>
     <CodeAnalysisAnalyzerVersion>4.14.0</CodeAnalysisAnalyzerVersion>
+    <VisualStudioThreadingVersion>17.14.15</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.2" />


### PR DESCRIPTION
We somehow ended up with 3 properties when we only needed and were using 2.