### PR TITLE
Hopefully stabilize the RpcInterfacesNeedMethodsIncludedInShape_Fixable test

### DIFF
--- a/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
@@ -392,6 +392,7 @@ public class JsonRpcContractAnalyzerTests
     public async Task RpcInterfacesNeedMethodsIncludedInShape_Fixable()
     {
         string source = """
+            using PolyType;
             using StreamJsonRpc;
 
             [JsonRpcContract]


### PR DESCRIPTION
This test has been randomly failing when the two code fixes it applies somehow overlap in a way as to add the `using` directive *twice*. This doesn't seem like a real user scenario, and adding it to the initial source ought to prevent this happening.