### PR TITLE
Allow `null` argument to `As<T>` and `Is(Type)` helper methods

### DIFF
--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/FullModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/FullModel.cs
@@ -115,9 +115,9 @@ internal record FullModel
                     string visibility = iface.IsPublic ? "public" : "internal";
                     writer.WriteLine($$"""
                         /// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-                        {{visibility}} static bool Is(this {{iface.FullName}} self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+                        {{visibility}} static bool Is(this {{iface.FullName}}? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
                         /// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-                        {{visibility}} static T? As<T>(this {{iface.FullName}} self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+                        {{visibility}} static T? As<T>(this {{iface.FullName}}? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
                         """);
                     if (first)
                     {

--- a/src/StreamJsonRpc/JsonRpcExtensions.cs
+++ b/src/StreamJsonRpc/JsonRpcExtensions.cs
@@ -35,8 +35,8 @@ public static class JsonRpcExtensions
     /// In such cases, this method can be used to determine whether the proxy was intentionally created to implement the interface
     /// or not, allowing feature testing to still happen since conditional casting might lead to false positives.
     /// </remarks>
-    public static T? As<T>(this IClientProxy proxy)
-        where T : class => Requires.NotNull(proxy).Is(typeof(T)) ? (T)(object)proxy : null;
+    public static T? As<T>(this IClientProxy? proxy)
+        where T : class => proxy?.Is(typeof(T)) is true ? (T)(object)proxy : null;
 
 #pragma warning disable VSTHRD200 // Use "Async" suffix in names of methods that return an awaitable type.
     /// <summary>

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/OptionalInterfaceExtensions.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/OptionalInterfaceExtensions.g.cs
@@ -12,12 +12,12 @@ using StreamJsonRpc;
 public static partial class StreamJsonRpcOptionalInterfaceAccessors
 {
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	public static bool Is(this SomeExperimentalInterface self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	public static bool Is(this SomeExperimentalInterface? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	public static T? As<T>(this SomeExperimentalInterface self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	public static T? As<T>(this SomeExperimentalInterface? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	public static bool Is(this SomeExperimentalInterface2 self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	public static bool Is(this SomeExperimentalInterface2? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	public static T? As<T>(this SomeExperimentalInterface2 self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	public static T? As<T>(this SomeExperimentalInterface2? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods/OptionalInterfaceExtensions.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods/OptionalInterfaceExtensions.g.cs
@@ -12,12 +12,12 @@ using StreamJsonRpc;
 public static partial class StreamJsonRpcOptionalInterfaceAccessors
 {
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	public static bool Is(this IMarshalable self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	public static bool Is(this IMarshalable? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	public static T? As<T>(this IMarshalable self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	public static T? As<T>(this IMarshalable? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	internal static bool Is(this IOptional self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	internal static bool Is(this IOptional? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	internal static T? As<T>(this IOptional self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	internal static T? As<T>(this IOptional? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods_NestedInClass/OptionalInterfaceExtensions.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods_NestedInClass/OptionalInterfaceExtensions.g.cs
@@ -13,13 +13,13 @@ namespace NS
 	internal static partial class StreamJsonRpcOptionalInterfaceAccessors
 	{
 		/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-		internal static bool Is(this NS.Wrapper.IMarshalable self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+		internal static bool Is(this NS.Wrapper.IMarshalable? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 		/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-		internal static T? As<T>(this NS.Wrapper.IMarshalable self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+		internal static T? As<T>(this NS.Wrapper.IMarshalable? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 
 		/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-		internal static bool Is(this NS.Wrapper.IOptional self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+		internal static bool Is(this NS.Wrapper.IOptional? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 		/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-		internal static T? As<T>(this NS.Wrapper.IOptional self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+		internal static T? As<T>(this NS.Wrapper.IOptional? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods_NotPublic/OptionalInterfaceExtensions.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_OptionalInterfaces_WithExtensionMethods_NotPublic/OptionalInterfaceExtensions.g.cs
@@ -11,12 +11,12 @@ using StreamJsonRpc;
 internal static partial class StreamJsonRpcOptionalInterfaceAccessors
 {
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	public static bool Is(this IMarshalable self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	public static bool Is(this IMarshalable? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	public static T? As<T>(this IMarshalable self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	public static T? As<T>(this IMarshalable? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 
 	/// <inheritdoc cref="global::StreamJsonRpc.IClientProxy.Is(global::System.Type)"/>
-	internal static bool Is(this IOptional self, global::System.Type type) => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.Is(type) : type.IsAssignableFrom(self.GetType());
+	internal static bool Is(this IOptional? self, global::System.Type type) => self switch { null => false, global::StreamJsonRpc.IClientProxy proxy => proxy.Is(type), _ => type.IsAssignableFrom(self.GetType()) };
 	/// <inheritdoc cref="global::StreamJsonRpc.JsonRpcExtensions.As{T}(global::StreamJsonRpc.IClientProxy)"/>
-	internal static T? As<T>(this IOptional self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
+	internal static T? As<T>(this IOptional? self) where T : class => self is global::StreamJsonRpc.IClientProxy proxy ? proxy.As<T>() : self as T;
 }

--- a/test/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcExtensionsTests.cs
@@ -11,6 +11,13 @@ public class JsonRpcExtensionsTests : TestBase
     }
 
     [Fact]
+    public void As_NullArg()
+    {
+        // Non-null tests are exercised elsewhere.
+        Assert.Null(JsonRpcExtensions.As<IDisposable>(null));
+    }
+
+    [Fact]
     public async Task AsAsyncEnumerable()
     {
         await AssertExpectedValues(SmallList.AsAsyncEnumerable());


### PR DESCRIPTION
This makes the methods easier to call, and safe in all contexts where the C# `as` and `is` keywords would have been safe.