### PR TITLE
Avoid producing a new proxy 'group' that is redundant with the first

### DIFF
--- a/src/StreamJsonRpc.Analyzers/ProxyGenerator.cs
+++ b/src/StreamJsonRpc.Analyzers/ProxyGenerator.cs
@@ -396,7 +396,10 @@ public partial class ProxyGenerator : IIncrementalGenerator
             yield return [primary];
 
             // And if RpcMarshalable optional interfaces were specified, add them to another group.
-            yield return [primary, .. optionalMarshalableInterfaces];
+            if (optionalMarshalableInterfaces.Count > 0)
+            {
+                yield return [primary, .. optionalMarshalableInterfaces];
+            }
         }
     }
 


### PR DESCRIPTION
The code comment that was already there seemed to suggest the intent, but that intent wasn't matched with code.