### PR TITLE
Share more with `FormatterBase`

### DIFF
--- a/src/StreamJsonRpc/CompatibilitySuppressions.xml
+++ b/src/StreamJsonRpc/CompatibilitySuppressions.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc,System.Object,System.Type)</Target>
+    <Left>lib/net8.0/StreamJsonRpc.dll</Left>
+    <Right>lib/net8.0/StreamJsonRpc.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc,System.Object,System.Type)</Target>
+    <Left>lib/netstandard2.0/StreamJsonRpc.dll</Left>
+    <Right>lib/netstandard2.0/StreamJsonRpc.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StreamJsonRpc.Reflection.MessageFormatterProgressTracker.CreateProgress(StreamJsonRpc.JsonRpc,System.Object,System.Type)</Target>
+    <Left>lib/netstandard2.1/StreamJsonRpc.dll</Left>
+    <Right>lib/netstandard2.1/StreamJsonRpc.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/StreamJsonRpc/FormatterBase.cs
+++ b/src/StreamJsonRpc/FormatterBase.cs
@@ -93,6 +93,7 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
                 this.rpcMarshaledContextTracker = this.CreateMessageFormatterRpcMarshaledContextTracker(value);
                 this.enumerableTracker = new MessageFormatterEnumerableTracker(value, this, this.rpcMarshaledContextTracker);
                 this.duplexPipeTracker = new MessageFormatterDuplexPipeTracker(value, this) { MultiplexingStream = this.MultiplexingStream };
+                this.IsInitialized = true;
             }
         }
     }
@@ -177,6 +178,11 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
     /// </summary>
     private protected JsonRpcMessage? DeserializingMessage { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether this formatter has been connected to a <see cref="StreamJsonRpc.JsonRpc"/> instance.
+    /// </summary>
+    private protected bool IsInitialized { get; private set; }
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -209,6 +215,40 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
     /// <param name="message">The message being serialized.</param>
     /// <returns>A value to dispose of when serialization has completed.</returns>
     protected SerializationTracking TrackSerialization(JsonRpcMessage message) => new(this, message);
+
+    private protected static Type NormalizeType(Type type)
+    {
+        if (TrackerHelpers.FindIProgressInterfaceImplementedBy(type) is Type iface)
+        {
+            type = iface;
+        }
+        else if (TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(type) is Type iface2)
+        {
+            type = iface2;
+        }
+        else if (typeof(IDuplexPipe).IsAssignableFrom(type))
+        {
+            type = typeof(IDuplexPipe);
+        }
+        else if (typeof(PipeWriter).IsAssignableFrom(type))
+        {
+            type = typeof(PipeWriter);
+        }
+        else if (typeof(PipeReader).IsAssignableFrom(type))
+        {
+            type = typeof(PipeReader);
+        }
+        else if (typeof(Stream).IsAssignableFrom(type))
+        {
+            type = typeof(Stream);
+        }
+        else if (typeof(Exception).IsAssignableFrom(type))
+        {
+            type = typeof(Exception);
+        }
+
+        return type;
+    }
 
     private protected abstract MessageFormatterRpcMarshaledContextTracker CreateMessageFormatterRpcMarshaledContextTracker(JsonRpc rpc);
 
@@ -243,6 +283,8 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
                 break;
         }
     }
+
+    private protected void ThrowIfInitialized() => Verify.Operation(!this.IsInitialized, "Formatter already initialized.");
 
     /// <summary>
     /// Tracks deserialization of a message.

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -694,6 +694,9 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <summary>
     /// Gets a trim unsafe type loader.
     /// </summary>
+    /// <remarks>
+    /// A trim-safe loader is implemented by <see cref="JsonRpc"/> itself.
+    /// </remarks>
     internal ExceptionSerializationHelpers.IExceptionTypeLoader TrimUnsafeTypeLoader
     {
         [RequiresUnreferencedCode(RuntimeReasons.LoadType)]

--- a/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
+++ b/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IO.Pipelines;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -258,40 +257,6 @@ public partial class NerdbankMessagePackFormatter : FormatterBase, IJsonRpcMessa
         topLevelProperties ??= new Dictionary<string, RawMessagePack>(StringComparer.Ordinal);
         string name = context.GetConverter<string>(Witness.GeneratedTypeShapeProvider).Read(ref reader, context) ?? throw new MessagePackSerializationException("Unexpected nil at property name position.");
         topLevelProperties.Add(name, reader.ReadRaw(context));
-    }
-
-    private static Type NormalizeType(Type type)
-    {
-        if (TrackerHelpers.FindIProgressInterfaceImplementedBy(type) is Type iface)
-        {
-            type = iface;
-        }
-        else if (TrackerHelpers.FindIAsyncEnumerableInterfaceImplementedBy(type) is Type iface2)
-        {
-            type = iface2;
-        }
-        else if (typeof(IDuplexPipe).IsAssignableFrom(type))
-        {
-            type = typeof(IDuplexPipe);
-        }
-        else if (typeof(PipeWriter).IsAssignableFrom(type))
-        {
-            type = typeof(PipeWriter);
-        }
-        else if (typeof(PipeReader).IsAssignableFrom(type))
-        {
-            type = typeof(PipeReader);
-        }
-        else if (typeof(Stream).IsAssignableFrom(type))
-        {
-            type = typeof(Stream);
-        }
-        else if (typeof(Exception).IsAssignableFrom(type))
-        {
-            type = typeof(Exception);
-        }
-
-        return type;
     }
 
     private static T ActivateAssociatedType<T>(ITypeShape shape, Type associatedType)

--- a/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterProgressTracker.cs
@@ -173,13 +173,6 @@ public class MessageFormatterProgressTracker
     /// <typeparam name="T">The type of the value to be reported by <see cref="IProgress{T}"/>.</typeparam>
     public IProgress<T> CreateProgress<T>(JsonRpc rpc, object token, bool clientRequiresNamedArguments) => new ProgressProxy<T>(rpc, token, clientRequiresNamedArguments);
 
-    /// <inheritdoc cref="CreateProgress(JsonRpc, object, Type, bool)"/>
-    /// <remarks>
-    /// This overload creates an <see cref="IProgress{T}"/> that does <em>not</em> use named arguments in its notifications.
-    /// </remarks>
-    [RequiresDynamicCode(RuntimeReasons.CloseGenerics)]
-    public object CreateProgress(JsonRpc rpc, object token, Type valueType) => this.CreateProgress(rpc, token, valueType, clientRequiresNamedArguments: false);
-
     /// <summary>
     /// Creates a new instance of <see cref="IProgress{T}"/> to use on the receiving end of an RPC call.
     /// </summary>


### PR DESCRIPTION
In preparation for potentially additional PolyType-based formatters, I found this code which ought to be shared.

This includes a breaking change in removing an unused API. The impacted class is a helper class for formatters, and we don't expect or really support formatters to be written externally.