### PR TITLE
Build stable 2.24 version with PolyType

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.24-polytype",
+  "version": "2.24",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
This is in preparation to merge `feature/polytype` into `main`.
We've decided that main should always build stable versioned packages.