### PR TITLE
Merge v2.23 to main

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.24",
+  "version": "2.24-preview",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
This PR neutralizes certain unwanted changes from the v2.23 branch. 
It also builds an unstable package because we have unstable dependencies, in order to fix the build break in our CI.