### PR TITLE
Fix IDE fast up-to-date check

### DIFF
--- a/src/StreamJsonRpc/StreamJsonRpc.csproj
+++ b/src/StreamJsonRpc/StreamJsonRpc.csproj
@@ -40,10 +40,6 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" PrivateAssets="compile" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="$(TargetFramework)\PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="$(TargetFramework)\PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <Using Include="Microsoft" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
It was failing consistently because the project was referencing source files that no longer exist.
