### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.5.3",
+      "version": "7.5.4",
       "commands": [
         "pwsh"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.8.118",
+      "version": "3.9.50",
       "commands": [
         "nbgv"
       ],
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.3",
+      "version": "2.78.4",
       "commands": [
         "docfx"
       ],

--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -14,46 +14,46 @@ runs:
 
   - name: 📢 Upload project.assets.json files
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: projectAssetsJson-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/projectAssetsJson
     continue-on-error: true
   - name: 📢 Upload variables
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: variables-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/Variables
     continue-on-error: true
   - name: 📢 Upload build_logs
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: build_logs-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/build_logs
     continue-on-error: true
   - name: 📢 Upload testResults
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: testResults-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/testResults
     continue-on-error: true
   - name: 📢 Upload coverageResults
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: coverageResults-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/coverageResults
     continue-on-error: true
   - name: 📢 Upload symbols
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: symbols-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/symbols
     continue-on-error: true
   - name: 📢 Upload deployables
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+    uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     with:
       name: deployables-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/deployables

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MessagePackVersion>2.5.198</MessagePackVersion>
-    <MicroBuildVersion>2.0.201</MicroBuildVersion>
+    <MicroBuildVersion>2.0.208</MicroBuildVersion>
     <RoslynVersion>4.14.0</RoslynVersion>
     <CodeAnalysisAnalyzerVersion>4.14.0</CodeAnalysisAnalyzerVersion>
     <VisualStudioThreadingVersion>17.14.15</VisualStudioThreadingVersion>
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(CodeAnalysisAnalyzerVersion)" />
@@ -68,7 +68,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.8.118" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" Condition="'$(DisablePolyfills)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -29,14 +29,17 @@ parameters:
 - name: artifact_names
   type: object
   default:
-    - build_logs
-    - coverageResults
-    - deployables
-    - projectAssetsJson
-    - symbols
-    - testResults
-    - test_symbols
-    - Variables
+    - name: build_logs
+    - name: coverageResults
+    - name: deployables
+      sbomEnabled: true
+    - name: projectAssetsJson
+    - name: symbols
+    - name: testResults
+      testOnly: true
+    - name: test_symbols
+      testOnly: true
+    - name: Variables
 # The Enable*Build parameters turn non-Windows agents on or off.
 # Their default value should be based on whether the build and tests are expected/required to pass on that platform.
 # Callers (e.g. Official.yml) *may* expose these parameters at queue-time in order to turn OFF optional agents.
@@ -56,6 +59,11 @@ parameters:
 # Indicates whether the entrypoint file is 1ESPT compliant. Use this parameter to switch between publish tasks to fit 1ES or non-1ES needs.
 - name: Is1ESPT
   type: boolean
+
+# Indicates whether the 'official' 1ES PT templates are being used (as opposed to the unofficial ones).
+- name: Is1ESPTOfficial
+  type: boolean
+  default: false
 
 - name: RealSign
   type: boolean
@@ -151,13 +159,21 @@ jobs:
 
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:
-      - ${{ each artifact_name in parameters.artifact_names }}:
-        - ${{ if or(ne(artifact_name, 'testResults'), parameters.RunTests) }}:
+      - ${{ each artifact in parameters.artifact_names }}:
+        - ${{ if or(ne(artifact.testOnly, 'true'), parameters.RunTests) }}:
           - output: pipelineArtifact
-            displayName: 📢 Publish ${{ artifact_name }}-Windows
-            targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact_name }}-Windows
-            artifactName: ${{ artifact_name }}-Windows
-            condition: succeededOrFailed()
+            displayName: 📢 Publish ${{ artifact.name }}-Windows
+            targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-Windows
+            artifactName: ${{ artifact.name }}-Windows
+            ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+              sbomEnabled: true
+          - output: pipelineArtifact
+            displayName: 📢 Publish ${{ artifact.name }}-Windows (for failed attempts)
+            targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-Windows
+            artifactName: ${{ artifact.name }}-Windows-$(System.PhaseAttempt)
+            ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+              sbomEnabled: true
+            condition: failed()
       - output: pipelineArtifact
         displayName: 📢 Publish VSInsertion-Windows
         targetPath: $(Build.ArtifactStagingDirectory)/VSInsertion-Windows
@@ -194,7 +210,6 @@ jobs:
     - template: microbuild.before.yml
       parameters:
         EnableLocalization: ${{ parameters.EnableLocalization }}
-        EnableOptProf: ${{ parameters.EnableOptProf }}
         IsOptProf: ${{ parameters.IsOptProf }}
         ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
         RealSign: ${{ parameters.RealSign }}
@@ -215,7 +230,6 @@ jobs:
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     - template: microbuild.after.yml
       parameters:
-        EnableOptProf: ${{ parameters.EnableOptProf }}
         IsOptProf: ${{ parameters.IsOptProf }}
         SkipCodesignVerify: ${{ parameters.SkipCodesignVerify }}
 
@@ -233,13 +247,21 @@ jobs:
                 signWithProd: true
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
-          - ${{ each artifact_name in parameters.artifact_names }}:
-            - ${{ if or(ne(artifact_name, 'testResults'), parameters.RunTests) }}:
+          - ${{ each artifact in parameters.artifact_names }}:
+            - ${{ if or(ne(artifact.testOnly, 'true'), parameters.RunTests) }}:
               - output: pipelineArtifact
-                displayName: 📢 Publish ${{ artifact_name }}-Linux
-                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact_name }}-Linux
-                artifactName: ${{ artifact_name }}-Linux
-                condition: succeededOrFailed()
+                displayName: 📢 Publish ${{ artifact.name }}-Linux
+                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-Linux
+                artifactName: ${{ artifact.name }}-Linux
+                ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+                  sbomEnabled: true
+              - output: pipelineArtifact
+                displayName: 📢 Publish ${{ artifact.name }}-Linux (for failed attempts)
+                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-Linux
+                artifactName: ${{ artifact.name }}-Linux-$(System.PhaseAttempt)
+                ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+                  sbomEnabled: true
+                condition: failed()
       steps:
       - checkout: self
         fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
@@ -270,13 +292,21 @@ jobs:
                 signWithProd: true
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
-          - ${{ each artifact_name in parameters.artifact_names }}:
-            - ${{ if or(ne(artifact_name, 'testResults'), parameters.RunTests) }}:
+          - ${{ each artifact in parameters.artifact_names }}:
+            - ${{ if or(ne(artifact.testOnly, 'true'), parameters.RunTests) }}:
               - output: pipelineArtifact
-                displayName: 📢 Publish ${{ artifact_name }}-macOS
-                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact_name }}-macOS
-                artifactName: ${{ artifact_name }}-macOS
-                condition: succeededOrFailed()
+                displayName: 📢 Publish ${{ artifact.name }}-macOS
+                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-macOS
+                artifactName: ${{ artifact.name }}-macOS
+                ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+                  sbomEnabled: true
+              - output: pipelineArtifact
+                displayName: 📢 Publish ${{ artifact.name }}-macOS (for failed attempts)
+                targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact.name }}-macOS
+                artifactName: ${{ artifact.name }}-macOS-$(System.PhaseAttempt)
+                ${{ if and(parameters.Is1ESPTOfficial, eq(artifact.sbomEnabled, 'true')) }}:
+                  sbomEnabled: true
+                condition: failed()
       steps:
       - checkout: self
         fetchDepth: 0 # avoid shallow clone so nbgv can do its work.

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -1,7 +1,4 @@
 parameters:
-- name: EnableOptProf
-  type: boolean
-  default: false
 - name: IsOptProf
   type: boolean
   default: false

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -2,9 +2,6 @@ parameters:
 - name: EnableLocalization
   type: boolean
   default: false
-- name: EnableOptProf
-  type: boolean
-  default: false
 - name: IsOptProf
   type: boolean
   default: false
@@ -26,7 +23,7 @@ steps:
     inputs:
       outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
       outputformat: text
-    retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
+    retryCountOnTaskFailure: 10 # fails when the cloud service is overloaded
     continueOnError: ${{ not(parameters.RealSign) }} # Tolerate failures when we're not building something that may ship.
 
 - ${{ if parameters.IsOptProf }}:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -68,6 +68,7 @@ extends:
       - template: /azure-pipelines/build.yml@self
         parameters:
           Is1ESPT: true
+          Is1ESPTOfficial: true
           RealSign: true
           ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
           EnableAPIScan: ${{ parameters.EnableAPIScan }}

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -28,7 +28,8 @@ extends:
     stages:
     - stage: release
       jobs:
-      - job: release
+      - job: nuget
+        displayName: 📦 Push nuget.org packages
         pool:
           name: AzurePipelines-EO
           demands:
@@ -45,6 +46,28 @@ extends:
             publishFeedCredentials: VisualStudioExtensibility (nuget.org)
         steps:
         - checkout: none
+        - download: CI
+          artifact: deployables-Windows
+          displayName: 🔻 Download deployables-Windows artifact
+          patterns: 'NuGet/*'
+      - job: github
+        displayName: 📢 GitHub release
+        dependsOn: nuget
+        pool:
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals 1ESPT-Ubuntu22.04
+          os: Linux
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: CI
+            artifactName: deployables-Windows
+            targetPath: $(Pipeline.Workspace)/CI/deployables-Windows
+        steps:
+        - checkout: none
         - powershell: |
             Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
             if ('$(resources.pipeline.CI.runName)'.Contains('-')) {
@@ -53,10 +76,6 @@ extends:
               Write-Host "##vso[task.setvariable variable=IsPrerelease]false"
             }
           displayName: ⚙ Set up pipeline
-        - download: CI
-          artifact: deployables-Windows
-          displayName: 🔻 Download deployables-Windows artifact
-          patterns: 'NuGet/*'
         - task: GitHubRelease@1
           displayName: 📢 GitHub release (create)
           inputs:

--- a/tools/Get-ExternalSymbolFiles.ps1
+++ b/tools/Get-ExternalSymbolFiles.ps1
@@ -79,11 +79,13 @@ Function Get-PackageVersion($id) {
     $version
 }
 
-# All 3rd party packages for which symbols packages are expected should be listed here.
+# All 1st party packages for which symbols packages are expected should be listed here.
 # These must all be sourced from nuget.org, as it is the only feed that supports symbol packages.
-$3rdPartyPackageIds = @()
+# We should NOT add 3rd party packages to this list because PDBs may be unsafe for our debuggers to load,
+# so we should only archive 1st party symbols.
+$1stPartyPackageIds = @()
 
-$3rdPartyPackageIds | % {
+$1stPartyPackageIds | % {
     $version = Get-PackageVersion $_
     if ($version) {
         Get-SymbolsFromPackage -id $_ -version $version

--- a/tools/artifacts/Variables.ps1
+++ b/tools/artifacts/Variables.ps1
@@ -26,7 +26,7 @@ Get-ChildItem "$PSScriptRoot/../variables" |% {
 
         if ($value) {
             # We got something, so wrap it with quotes so it's treated like a literal value.
-            $value = "'$value'"
+            $value = "'" + $value.Replace("'", "''") + "'"
         }
     }
 

--- a/tools/artifacts/symbols.ps1
+++ b/tools/artifacts/symbols.ps1
@@ -1,10 +1,10 @@
 $BinPath = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../bin")
-$3rdPartyPath = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../obj/SymbolsPackages")
+$ExternalPath = [System.IO.Path]::GetFullPath("$PSScriptRoot/../../obj/SymbolsPackages")
 if (!(Test-Path $BinPath)) { return }
 $symbolfiles = & "$PSScriptRoot/../Get-SymbolFiles.ps1" -Path $BinPath | Get-Unique
-$3rdPartyFiles = & "$PSScriptRoot/../Get-3rdPartySymbolFiles.ps1"
+$ExternalFiles = & "$PSScriptRoot/../Get-ExternalSymbolFiles.ps1"
 
 @{
     "$BinPath" = $SymbolFiles;
-    "$3rdPartyPath" = $3rdPartyFiles;
+    "$ExternalPath" = $ExternalFiles;
 }


### PR DESCRIPTION
- Update dependency powershell to v7.5.4
- Update mcr.microsoft.com/dotnet/sdk:9.0.306-noble Docker digest to d88e637
- Move `GitHubRelease` task to a release job
- Drop EnableOptProf parameter where it is unused
- Add SBOM to `deployables` pipeline artifact
- Bump MicroBuildVersion to 2.0.208
- Fix artifact publishing failures due to prior failed attempts
- Switch from sln to slnx
- Clarify that symbols should be only 1st party
- Fix template expansion after slnx rename
- Another template expansion fix
- Update dependency docfx to v2.78.4
- Update GitHub Artifact Actions
- Increase retry count on NOTICE task failure to 10
- Update dependency xunit.v3 to 3.2.0
- Update nbgv and nerdbank.gitversioning updates to 3.9.50
- Fix variable persistence when value includes a single quote
