### PR TITLE
Merge v2.21 into v2.22

### DIFF
--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -5,7 +5,6 @@ schedules:
   displayName: Weekly OptProf run
   branches:
     include:
-    - 'v*.*'
     - main
   always: true # we must keep data fresh since optimizationdata drops are purged after 30 days
 


### PR DESCRIPTION
This is *mostly* a no-op PR except to merge history from a prior servicing branch into a newer one to record that all servicing from older versions has reached newer ones if applicable.
The only real file change is to disable optprof in servicing branches, which is something we want to do for this repo due to it for all those branches, and we don't plan to fix it.