### PR TITLE
security: upgrades nerdbank message pack version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Only" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VisualStudioThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.13.22" />
-    <PackageVersion Include="Nerdbank.MessagePack" Version="1.0.11" />
+    <PackageVersion Include="Nerdbank.MessagePack" Version="1.1.62" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />


### PR DESCRIPTION
closes #1415
fixes #1426 
due to this advisory, restores are failing on a bunch of projects. https://github.com/AArnott/Nerdbank.MessagePack/security/advisories/GHSA-2cwq-pwfr-wcw3
This pull request upgrade the dependency in an attempt to release and fix the issue.
However I was not able to test things out locally since https://dev.azure.com/azure-public/vside/_artifacts/feed/msft_consumption_public does not have that specific version, and I couldn't figure out how to get the permissions to do so.
Nuking the nuget config locally results in quite a few unit tests failing. Not sure how to proceed from there?