### PR TITLE
Update documentation link for RpcMarshalableAttribute

### DIFF
--- a/src/StreamJsonRpc/Reflection/RpcMarshalableAttribute.cs
+++ b/src/StreamJsonRpc/Reflection/RpcMarshalableAttribute.cs
@@ -7,7 +7,7 @@ namespace StreamJsonRpc;
 /// Designates an interface that is used in an RPC contract to marshal the object so the receiver can invoke remote methods on it instead of serializing the object to send its data to the remote end.
 /// </summary>
 /// <remarks>
-/// <see href="https://github.com/microsoft/vs-streamjsonrpc/blob/main/doc/rpc_marshalable_objects.md">Learn more about marshalable interfaces</see>.
+/// <see href="https://microsoft.github.io/vs-streamjsonrpc/exotic_types/rpc_marshalable_objects.html">Learn more about marshalable interfaces</see>.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
 public class RpcMarshalableAttribute : Attribute


### PR DESCRIPTION
The old link 404'd, which was a bummer since this link shows up in Quick Info tooltips.