### PR TITLE
Bulk dependency updates (ready checks)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.6.2",
+      "version": "18.7.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.1",
+      "version": "7.6.2",
       "commands": [
         "pwsh"
       ],

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -13,7 +13,7 @@ jobs:
     name: 📚 Doc validation
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: 🔗 Markup Link Checker (mlc)

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 


### PR DESCRIPTION
## Summary
This PR aggregates dependency update branches that are ready to merge (all non-docfx checks passing):
- #1437 Update dependency dotnet-coverage to v18.7.0
- #1440 Update dependency powershell to v7.6.2
- #1449 Update actions/checkout action to v6.0.3

## Validation
- Ran ./.github/Prime-ForCopilot.ps1
- Ran dotnet build StreamJsonRpc.slnx -c Release (succeeded)
- Ran dotnet test --no-build -c Release -- --filter-not-trait "FailsInCloudTest=true"
  - Several existing/flaky tests failed in StreamJsonRpc.Tests (memory leak and PolyType-related assertions).
  - Individual dependency PR checks are already green for build/test; only docfx is failing on #1437/#1440 and is considered non-blocking per dependency-bundling instructions.