### PR TITLE
Merge Library.Template release updates

### DIFF
--- a/.github/skills/bundle-dependency-prs/SKILL.md
+++ b/.github/skills/bundle-dependency-prs/SKILL.md
@@ -18,6 +18,9 @@ Always validate your changes locally before pushing them to the remote repositor
 
 When writing PR bodies or comments, avoid unmatched markdown code fences. Keep markdown well-formed.
 
+For purposes of assessing PR readiness by its PR checks, consider docfx related checks to be irrelevant.
+If a docfx check fails but all other checks succeed, then that is a 'successful' dependency update PR.
+
 ## Fix up dependency PRs with failing checks
 
 Before aggregating PRs, first try to fix any individual dependency update PRs with failing build/test checks.

--- a/docfx/docs/vs.md
+++ b/docfx/docs/vs.md
@@ -36,6 +36,7 @@ When building a Visual Studio extension, you should not include StreamJsonRpc in
 | VS 2022.14 | 1.5.x, 2.22.x
 | VS 2026.0  | 1.5.x, 2.23.x
 | VS 2026.3  | 1.5.x, 2.24.x
+| VS 2026.8  | 1.5.x, 2.25.x
 
 StreamJsonRpc versions are forwards and backwards compatible "over the wire". For example it is perfectly legitimate to use StreamJsonRpc 2.4 on the server-side even if the client only uses 1.0, or vice versa. If an RPC method utilizes a newer StreamJsonRpc feature (e.g. `IAsyncEnumerable<T>` return value) and an older client that doesn't support these specially marshaled objects is used to call that method, a memory leak on the server may result.
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.25",
+  "version": "2.26",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
## Summary
- advance the repo version from 2.25 to 2.26
- add the VS 2026.8 compatibility row to the docfx Visual Studio guidance

## Validation
- `dotnet restore` succeeded
- local `dotnet build` was blocked by missing `vswhere.exe` for the NativeAOT linker step in this environment
- local `tools/dotnet-test-cloud.ps1` hit one existing/likely unrelated failing test: `AsyncEnumerableJsonTests.ReturnEnumerable_AutomaticallyReleasedOnErrorFromIteratorMethod`