### PR TITLE
Document multiple client proxy patterns

### DIFF
--- a/docfx/docs/proxies.md
+++ b/docfx/docs/proxies.md
@@ -14,6 +14,28 @@ This changes the above example to something like this:
 
 [!code-csharp[](../../samples/Proxies.cs#WithProxies)]
 
+## Multiple proxies on one connection
+
+Do not call static `JsonRpc.Attach<T>` multiple times on the same stream. Each static call creates a distinct <xref:StreamJsonRpc.JsonRpc> instance, and multiple instances cannot safely share one transport.
+
+The following examples use this second RPC interface in addition to `ICalculator`.
+
+[!code-csharp[](../../samples/Proxies.cs#MultipleProxiesInterfaces)]
+
+When you need multiple client proxies over one connection, use one of these patterns:
+
+1. Create one proxy that implements multiple interfaces at once.
+
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption3)]
+
+1. Create the <xref:StreamJsonRpc.JsonRpc> connection first, then call instance `Attach<T>` for each proxy.
+
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption2)]
+
+1. Create the first proxy with the static `Attach<T>` method, then get its <xref:StreamJsonRpc.JsonRpc> instance through <xref:StreamJsonRpc.IJsonRpcClientProxy> and create additional proxies with instance `Attach<T>` calls.
+
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption1)]
+
 ## Proxy traits
 
 Generated proxies have the following traits:

--- a/docfx/docs/proxies.md
+++ b/docfx/docs/proxies.md
@@ -26,15 +26,15 @@ When you need multiple client proxies over one connection, use one of these patt
 
 1. Create one proxy that implements multiple interfaces at once.
 
-   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption3)]
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesPattern1)]
 
 1. Create the <xref:StreamJsonRpc.JsonRpc> connection first, then call instance `Attach<T>` for each proxy.
 
-   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption2)]
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesPattern2)]
 
 1. Create the first proxy with the static `Attach<T>` method, then get its <xref:StreamJsonRpc.JsonRpc> instance through <xref:StreamJsonRpc.IJsonRpcClientProxy> and create additional proxies with instance `Attach<T>` calls.
 
-   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesOption1)]
+   [!code-csharp[](../../samples/Proxies.cs#MultipleProxiesPattern3)]
 
 ## Proxy traits
 

--- a/samples/Proxies.cs
+++ b/samples/Proxies.cs
@@ -37,7 +37,7 @@ namespace Proxies
 
         static async Task MultipleProxiesOption1(Stream rpcStream)
         {
-            #region MultipleProxiesOption1
+            #region MultipleProxiesPattern3
             ICalculator calculator = JsonRpc.Attach<ICalculator>(rpcStream);
             JsonRpc rpc = ((IJsonRpcClientProxy)calculator).JsonRpc;
             IAdvancedCalculator advancedCalculator = rpc.Attach<IAdvancedCalculator>();
@@ -52,7 +52,7 @@ namespace Proxies
 
         static async Task MultipleProxiesOption2(Stream rpcStream)
         {
-            #region MultipleProxiesOption2
+            #region MultipleProxiesPattern2
             using JsonRpc rpc = JsonRpc.Attach(rpcStream);
             ICalculator calculator = rpc.Attach<ICalculator>();
             IAdvancedCalculator advancedCalculator = rpc.Attach<IAdvancedCalculator>();
@@ -67,7 +67,7 @@ namespace Proxies
 
         static async Task MultipleProxiesOption3(Stream rpcStream)
         {
-            #region MultipleProxiesOption3
+            #region MultipleProxiesPattern1
             using JsonRpc rpc = JsonRpc.Attach(rpcStream);
             object combinedProxy = rpc.Attach([typeof(ICalculator), typeof(IAdvancedCalculator)], options: null);
             ICalculator calculator = (ICalculator)combinedProxy;

--- a/samples/Proxies.cs
+++ b/samples/Proxies.cs
@@ -27,6 +27,59 @@ namespace Proxies
         }
         #endregion
 
+        #region MultipleProxiesInterfaces
+        [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+        internal partial interface IAdvancedCalculator
+        {
+            Task<int> MultiplyAsync(int a, int b);
+        }
+        #endregion
+
+        static async Task MultipleProxiesOption1(Stream rpcStream)
+        {
+            #region MultipleProxiesOption1
+            ICalculator calculator = JsonRpc.Attach<ICalculator>(rpcStream);
+            JsonRpc rpc = ((IJsonRpcClientProxy)calculator).JsonRpc;
+            IAdvancedCalculator advancedCalculator = rpc.Attach<IAdvancedCalculator>();
+            using (calculator as IDisposable)
+            using (advancedCalculator as IDisposable)
+            {
+                int sum = await calculator.AddAsync(2, 5);
+                int product = await advancedCalculator.MultiplyAsync(2, 5);
+            }
+            #endregion
+        }
+
+        static async Task MultipleProxiesOption2(Stream rpcStream)
+        {
+            #region MultipleProxiesOption2
+            using JsonRpc rpc = JsonRpc.Attach(rpcStream);
+            ICalculator calculator = rpc.Attach<ICalculator>();
+            IAdvancedCalculator advancedCalculator = rpc.Attach<IAdvancedCalculator>();
+            using (calculator as IDisposable)
+            using (advancedCalculator as IDisposable)
+            {
+                int sum = await calculator.AddAsync(2, 5);
+                int product = await advancedCalculator.MultiplyAsync(2, 5);
+            }
+            #endregion
+        }
+
+        static async Task MultipleProxiesOption3(Stream rpcStream)
+        {
+            #region MultipleProxiesOption3
+            using JsonRpc rpc = JsonRpc.Attach(rpcStream);
+            object combinedProxy = rpc.Attach([typeof(ICalculator), typeof(IAdvancedCalculator)], options: null);
+            ICalculator calculator = (ICalculator)combinedProxy;
+            IAdvancedCalculator advancedCalculator = (IAdvancedCalculator)combinedProxy;
+            using (combinedProxy as IDisposable)
+            {
+                int sum = await calculator.AddAsync(2, 5);
+                int product = await advancedCalculator.MultiplyAsync(2, 5);
+            }
+            #endregion
+        }
+
         partial class ServerWithoutInterface
         {
             #region ServerWithoutInterface


### PR DESCRIPTION
## Summary

Users often attempt to call static `JsonRpc.Attach<T>` multiple times on the same stream to create multiple client proxies. This is a common mistake that leads to failures because each static call creates a distinct `JsonRpc` instance, and multiple instances cannot safely share one transport.

## Changes

This PR documents the **three supported patterns** for constructing multiple client proxies over a single JSON-RPC connection, with working code examples:

1. **Create one proxy implementing multiple interfaces at once**
   - Single proxy object implementing multiple RPC interface contracts
   - Simplest option when the set of interfaces is known upfront

2. **Create `JsonRpc` first, then call instance `Attach<T>` multiple times**
   - Most flexible pattern for creating proxies incrementally
   - Clear separation between transport setup and proxy creation

3. **Extract `JsonRpc` from the first proxy using `IJsonRpcClientProxy`**
   - Useful when starting with a static proxy attachment
   - Shows the relationship between proxies and the underlying connection

## Files Changed

- **docfx/docs/proxies.md**: Added new "Multiple proxies on one connection" section with clear guidance and code references for each pattern
- **samples/Proxies.cs**: Added working code examples for all three patterns with dedicated `#region` markers for documentation

All samples compile and pass tests.