### PR TITLE
Add JsonRpc outbound request timeout

### DIFF
--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -127,6 +127,13 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     private bool cancelLocallyInvokedMethodsWhenConnectionIsClosed;
 
     /// <summary>
+    /// Backing field for the <see cref="OutboundRequestTimeout"/> property.
+    /// Stores timeout ticks, with 0 representing <see langword="null"/>.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private long outboundRequestTimeoutTicks;
+
+    /// <summary>
     /// Backing field for the <see cref="SynchronizationContext"/> property.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -611,15 +618,23 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <exception cref="ArgumentOutOfRangeException">Thrown if a non-positive timeout value is assigned.</exception>
     public TimeSpan? OutboundRequestTimeout
     {
-        get;
+        get
+        {
+            long timeoutTicks = Interlocked.Read(ref this.outboundRequestTimeoutTicks);
+            return timeoutTicks == 0 ? null : TimeSpan.FromTicks(timeoutTicks);
+        }
+
         set
         {
             if (value is TimeSpan timeout)
             {
                 Requires.Range(timeout > TimeSpan.Zero, nameof(value), Resources.PositiveTimeSpanRequired);
+                Interlocked.Exchange(ref this.outboundRequestTimeoutTicks, timeout.Ticks);
             }
-
-            field = value;
+            else
+            {
+                Interlocked.Exchange(ref this.outboundRequestTimeoutTicks, 0);
+            }
         }
     }
 
@@ -2322,7 +2337,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
         {
             throw new OperationCanceledException(ex.Message, ex, cancellationToken);
         }
-        catch (OperationCanceledException ex) when (timeoutCancellationSource?.IsCancellationRequested is true && !cancellationToken.IsCancellationRequested && !this.DisconnectedToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (timeoutCancellationSource?.IsCancellationRequested is true && !cancellationToken.IsCancellationRequested)
         {
             throw new TimeoutException(Resources.FormatOutboundInvocationTimedOut(nameof(this.OutboundRequestTimeout)), ex);
         }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -2322,6 +2322,10 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
         {
             throw new OperationCanceledException(ex.Message, ex, cancellationToken);
         }
+        catch (OperationCanceledException ex) when (timeoutCancellationSource?.IsCancellationRequested is true && !cancellationToken.IsCancellationRequested && !this.DisconnectedToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(Resources.FormatOutboundInvocationTimedOut(nameof(this.OutboundRequestTimeout)), ex);
+        }
         catch (OperationCanceledException ex) when (this.DisconnectedToken.IsCancellationRequested && !effectiveOutboundCancellationToken.IsCancellationRequested)
         {
             throw new ConnectionLostException(Resources.ConnectionDropped, ex);

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -591,6 +591,39 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     }
 
     /// <summary>
+    /// Gets or sets the timeout to apply to each outbound invocation that expects a response.
+    /// </summary>
+    /// <value>
+    /// The timeout, or <see langword="null"/> to disable this behavior.
+    /// The default value is <see langword="null"/>.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    /// This timeout is applied to outbound method invocations (such as <see cref="InvokeWithCancellationAsync(string, IReadOnlyList{object?}?, CancellationToken)"/> and proxy method calls),
+    /// but not notifications.
+    /// </para>
+    /// <para>
+    /// When a timeout triggers, a notification is sent to the server to request cancellation
+    /// and the local invocation is immediately canceled allowing the caller to handle the timeout
+    /// as a <see cref="TimeoutException"/>.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if a non-positive timeout value is assigned.</exception>
+    public TimeSpan? OutboundRequestTimeout
+    {
+        get;
+        set
+        {
+            if (value is TimeSpan timeout)
+            {
+                Requires.Range(timeout > TimeSpan.Zero, nameof(value), Resources.PositiveTimeSpanRequired);
+            }
+
+            field = value;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the <see cref="System.Diagnostics.TraceSource"/> used to trace JSON-RPC messages and events.
     /// </summary>
     /// <value>The value can never be null.</value>
@@ -2120,9 +2153,19 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
         Requires.NotNull(request, nameof(request));
         Assumes.NotNull(request.Method);
 
+        CancellationToken effectiveOutboundCancellationToken = cancellationToken;
+        CancellationTokenSource? timeoutCancellationSource = null;
+        if (request.IsResponseExpected && this.OutboundRequestTimeout is TimeSpan outboundRequestTimeout)
+        {
+            timeoutCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCancellationSource.CancelAfter(outboundRequestTimeout);
+            effectiveOutboundCancellationToken = timeoutCancellationSource.Token;
+        }
+
         try
         {
-            using (CancellationTokenExtensions.CombinedCancellationToken cts = this.DisconnectedToken.CombineWith(cancellationToken))
+            using (timeoutCancellationSource)
+            using (CancellationTokenExtensions.CombinedCancellationToken cts = this.DisconnectedToken.CombineWith(effectiveOutboundCancellationToken))
             {
                 if (!request.IsResponseExpected)
                 {
@@ -2161,10 +2204,10 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
                                 JsonRpcEventSource.Instance.ReceivedNoResponse(request.RequestId.NumberIfPossibleForEvent);
                             }
 
-                            if (cancellationToken.IsCancellationRequested)
+                            if (effectiveOutboundCancellationToken.IsCancellationRequested)
                             {
                                 // Consider lost connection to be result of task canceled and set state to canceled.
-                                tcs.TrySetCanceled(cancellationToken);
+                                tcs.TrySetCanceled(effectiveOutboundCancellationToken);
                             }
                             else
                             {
@@ -2180,7 +2223,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
 
                             if (error.Error?.Code == JsonRpcErrorCode.RequestCanceled)
                             {
-                                tcs.TrySetCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : CancellationToken.None);
+                                tcs.TrySetCanceled(effectiveOutboundCancellationToken.IsCancellationRequested ? effectiveOutboundCancellationToken : CancellationToken.None);
                             }
                             else
                             {
@@ -2241,22 +2284,45 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
                 // Arrange for sending a cancellation message if canceled while we're waiting for a response.
                 try
                 {
-                    using (cancellationToken.Register(this.cancelPendingOutboundRequestAction!, request.RequestId, useSynchronizationContext: false))
+                    using (effectiveOutboundCancellationToken.Register(this.cancelPendingOutboundRequestAction!, request.RequestId, useSynchronizationContext: false))
                     {
-                        // This task will be completed when the Response object comes back from the other end of the pipe
-                        return await tcs.Task.ConfigureAwait(false);
+                        // This task will be completed when the Response object comes back from the other end of the pipe.
+                        try
+                        {
+                            if (timeoutCancellationSource is null)
+                            {
+                                return await tcs.Task.ConfigureAwait(false);
+                            }
+
+                            Task completedTask = await Task.WhenAny(tcs.Task, Task.Delay(Timeout.Infinite, effectiveOutboundCancellationToken)).ConfigureAwait(false);
+                            if (completedTask == tcs.Task)
+                            {
+                                return await tcs.Task.ConfigureAwait(false);
+                            }
+
+                            effectiveOutboundCancellationToken.ThrowIfCancellationRequested();
+                            throw Assumes.NotReachable();
+                        }
+                        catch (OperationCanceledException ex) when (timeoutCancellationSource?.IsCancellationRequested is true && !cancellationToken.IsCancellationRequested)
+                        {
+                            throw new TimeoutException(Resources.FormatOutboundInvocationTimedOut(nameof(this.OutboundRequestTimeout)), ex);
+                        }
                     }
                 }
                 finally
                 {
-                    if (cancellationToken.IsCancellationRequested)
+                    if (effectiveOutboundCancellationToken.IsCancellationRequested)
                     {
                         this.CancellationStrategy?.OutboundRequestEnded(request.RequestId);
                     }
                 }
             }
         }
-        catch (OperationCanceledException ex) when (this.DisconnectedToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested && ex.CancellationToken != cancellationToken)
+        {
+            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (this.DisconnectedToken.IsCancellationRequested && !effectiveOutboundCancellationToken.IsCancellationRequested)
         {
             throw new ConnectionLostException(Resources.ConnectionDropped, ex);
         }

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -256,6 +256,9 @@
   <data name="PositiveIntegerRequired" xml:space="preserve">
     <value>A positive integer is required.</value>
   </data>
+  <data name="PositiveTimeSpanRequired" xml:space="preserve">
+    <value>A positive TimeSpan is required.</value>
+  </data>
   <data name="ReachedEndOfStream" xml:space="preserve">
     <value>Reached end of stream.</value>
   </data>
@@ -320,6 +323,9 @@
   </data>
   <data name="TaskWasCancelled" xml:space="preserve">
     <value>The task was cancelled.</value>
+  </data>
+  <data name="OutboundInvocationTimedOut" xml:space="preserve">
+    <value>The outbound JSON-RPC invocation was canceled automatically after reaching the timeout configured by {0}. The server may still be processing the request.</value>
   </data>
   <data name="TextEncoderNotApplicable" xml:space="preserve">
     <value>Text encoding is not supported because the formatter "{0}" does not implement "{1}".</value>

--- a/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -92,6 +92,18 @@ public class CustomCancellationStrategyTests : TestBase
     }
 
     [Fact]
+    public async Task CancelRequest_WhenOutboundRequestTimesOut()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { false }, cancellationToken: CancellationToken.None);
+
+        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
+        Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+        Assert.True(this.mockStrategy.CancelRequestMade);
+        await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
+    }
+
+    [Fact]
     public async Task UncanceledRequest_GetsNoClientSideInvocations()
     {
         using var cts = new CancellationTokenSource();

--- a/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -94,13 +94,13 @@ public class CustomCancellationStrategyTests : TestBase
     [Fact]
     public async Task CancelRequest_WhenOutboundRequestTimesOut()
     {
-        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromSeconds(1);
         Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { false }, cancellationToken: CancellationToken.None);
+        await this.server.MethodEntered.WaitAsync(this.TimeoutToken);
 
         TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
         Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
-        await this.mockStrategy.CancelOutboundRequestInvoked.WaitAsync(this.TimeoutToken);
-        await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
+        Assert.True(this.mockStrategy.OutboundRequestEndedCalled);
     }
 
     [Fact]
@@ -126,11 +126,9 @@ public class CustomCancellationStrategyTests : TestBase
         var completingTask = await Task.WhenAny(invokeTask, this.server.MethodEntered.WaitAsync(TestContext.Current.CancellationToken)).WithCancellation(this.TimeoutToken);
         await completingTask;  // rethrow an exception if there is one.
 
+        this.mockStrategy.BlockCancelOutboundRequest = true;
         this.mockStrategy.AllowCancelOutboundRequestToExit.Reset();
         cts.Cancel();
-
-        // This may be invoked, but if the product doesn't invoke it, that's ok too.
-        ////await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
     }
 
     protected virtual void InitializeFormattersAndHandlers()
@@ -182,11 +180,15 @@ public class CustomCancellationStrategyTests : TestBase
 
         internal bool CancelRequestMade { get; private set; }
 
-        internal AsyncAutoResetEvent CancelOutboundRequestInvoked { get; } = new AsyncAutoResetEvent();
+        internal bool OutboundRequestEndedCalled { get; private set; }
 
-        internal AsyncAutoResetEvent OutboundRequestEndedInvoked { get; } = new AsyncAutoResetEvent();
+        internal AsyncManualResetEvent CancelOutboundRequestInvoked { get; } = new AsyncManualResetEvent();
+
+        internal AsyncManualResetEvent OutboundRequestEndedInvoked { get; } = new AsyncManualResetEvent();
 
         internal ManualResetEventSlim AllowCancelOutboundRequestToExit { get; } = new ManualResetEventSlim(initialState: true);
+
+        internal bool BlockCancelOutboundRequest { get; set; }
 
         public void CancelOutboundRequest(RequestId requestId)
         {
@@ -208,19 +210,23 @@ public class CustomCancellationStrategyTests : TestBase
             this.CancelRequestMade = true;
             this.CancelOutboundRequestInvoked.Set();
 
-            // Wait for the out of order invocation to happen if it's possible,
-            // so the OutboundCancellationStartAndRequestFinishOverlap test can catch it.
-            // Otherwise timeout, which is necessary to avoid a test hang when the product DOES work,
-            // since it shouldn't allow OutboundRequestEnded to execute before this method exits.
-            if (!this.AllowCancelOutboundRequestToExit.Wait(ExpectedTimeout))
+            if (this.BlockCancelOutboundRequest)
             {
-                this.logger.WriteLine("Timed out waiting for " + nameof(this.AllowCancelOutboundRequestToExit) + " to be signaled (good thing).");
+                // Wait for the out of order invocation to happen if it's possible,
+                // so the OutboundCancellationStartAndRequestFinishOverlap test can catch it.
+                // Otherwise timeout, which is necessary to avoid a test hang when the product DOES work,
+                // since it shouldn't allow OutboundRequestEnded to execute before this method exits.
+                if (!this.AllowCancelOutboundRequestToExit.Wait(ExpectedTimeout))
+                {
+                    this.logger.WriteLine("Timed out waiting for " + nameof(this.AllowCancelOutboundRequestToExit) + " to be signaled (good thing).");
+                }
             }
         }
 
         public void OutboundRequestEnded(RequestId requestId)
         {
             this.logger.WriteLine($"{nameof(this.OutboundRequestEnded)}({requestId}) invoked.");
+            this.OutboundRequestEndedCalled = true;
             lock (this.endedRequestIds)
             {
                 this.endedRequestIds.Add(requestId);

--- a/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -99,7 +99,7 @@ public class CustomCancellationStrategyTests : TestBase
 
         TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
         Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
-        Assert.True(this.mockStrategy.CancelRequestMade);
+        await this.mockStrategy.CancelOutboundRequestInvoked.WaitAsync(this.TimeoutToken);
         await this.mockStrategy.OutboundRequestEndedInvoked.WaitAsync(this.TimeoutToken);
     }
 
@@ -182,6 +182,8 @@ public class CustomCancellationStrategyTests : TestBase
 
         internal bool CancelRequestMade { get; private set; }
 
+        internal AsyncAutoResetEvent CancelOutboundRequestInvoked { get; } = new AsyncAutoResetEvent();
+
         internal AsyncAutoResetEvent OutboundRequestEndedInvoked { get; } = new AsyncAutoResetEvent();
 
         internal ManualResetEventSlim AllowCancelOutboundRequestToExit { get; } = new ManualResetEventSlim(initialState: true);
@@ -204,6 +206,7 @@ public class CustomCancellationStrategyTests : TestBase
 
             cts?.Cancel();
             this.CancelRequestMade = true;
+            this.CancelOutboundRequestInvoked.Set();
 
             // Wait for the out of order invocation to happen if it's possible,
             // so the OutboundCancellationStartAndRequestFinishOverlap test can catch it.

--- a/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -274,6 +274,16 @@ public class JsonRpcClient20InteropTests : InteropTestBase
     }
 
     [Fact]
+    public async Task NotifyAsync_IgnoresOutboundRequestTimeout()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(1);
+        await this.clientRpc.NotifyAsync("test");
+        JToken request = await this.ReceiveAsync();
+        Assert.Equal("test", request["method"]?.ToString());
+        Assert.Null(request["id"]);
+    }
+
+    [Fact]
     public async Task ErrorResponseIncludesCallstack()
     {
         var requestTask = this.clientRpc.InvokeAsync("SomeMethod");

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -62,6 +62,22 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         }
     }
 
+    [Fact]
+    public async Task InvokeAsync_UsesOutboundRequestTimeoutWhenSendAsyncTimesOut()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new BlockingSendJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2), this.server);
+
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+        clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        clientRpc.BlockRequestSend = true;
+
+        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => clientRpc.InvokeAsync<int>(nameof(Server.GetCallCountAsync)));
+        Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+    }
+
 #pragma warning disable CA1801 // use all parameters
     public class Server
     {
@@ -155,6 +171,26 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
             }
 
             return base.SendAsync(message, cancellationToken);
+        }
+    }
+
+    private sealed class BlockingSendJsonRpc : DelegatedJsonRpc
+    {
+        public BlockingSendJsonRpc(IJsonRpcMessageHandler handler)
+            : base(handler)
+        {
+        }
+
+        public bool BlockRequestSend { get; set; }
+
+        protected override async ValueTask SendAsync(JsonRpcMessage message, CancellationToken cancellationToken)
+        {
+            if (this.BlockRequestSend && message is JsonRpcRequest)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            await base.SendAsync(message, cancellationToken);
         }
     }
 

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -71,10 +71,12 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
 
         clientRpc.StartListening();
         serverRpc.StartListening();
-        clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        clientRpc.OutboundRequestTimeout = ExpectedTimeout;
         clientRpc.BlockRequestSend = true;
+        Task<int> invokeTask = clientRpc.InvokeAsync<int>(nameof(Server.GetCallCountAsync));
+        await clientRpc.RequestSendBlocked.WaitAsync(this.TimeoutToken);
 
-        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => clientRpc.InvokeAsync<int>(nameof(Server.GetCallCountAsync)));
+        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
         Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
     }
 
@@ -183,10 +185,13 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
 
         public bool BlockRequestSend { get; set; }
 
+        public AsyncAutoResetEvent RequestSendBlocked { get; } = new AsyncAutoResetEvent();
+
         protected override async ValueTask SendAsync(JsonRpcMessage message, CancellationToken cancellationToken)
         {
             if (this.BlockRequestSend && message is JsonRpcRequest)
             {
+                this.RequestSendBlocked.Set();
                 await Task.Delay(Timeout.Infinite, cancellationToken);
             }
 

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -551,7 +551,7 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     [Fact]
     public async Task CallMethod_UsesJsonRpcOutboundRequestTimeout()
     {
-        this.clientJsonRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        this.clientJsonRpc.OutboundRequestTimeout = ExpectedTimeout;
         this.server.ResumeMethod.Reset();
         Task task = this.clientRpc.HeavyWorkAsync(CancellationToken.None);
         await this.server.MethodEntered.WaitAsync(TestContext.Current.CancellationToken).WithCancellation(this.TimeoutToken);

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -549,6 +549,18 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    public async Task CallMethod_UsesJsonRpcOutboundRequestTimeout()
+    {
+        this.clientJsonRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        this.server.ResumeMethod.Reset();
+        Task task = this.clientRpc.HeavyWorkAsync(CancellationToken.None);
+        await this.server.MethodEntered.WaitAsync(TestContext.Current.CancellationToken).WithCancellation(this.TimeoutToken);
+
+        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => task);
+        Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CallMethod_intCancellationToken_int()
     {
         Assert.Equal(123, await this.clientRpc.HeavyWorkAsync(123, CancellationToken.None));

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1059,6 +1059,42 @@ public abstract partial class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task InvokeWithCancellationAsync_TimeoutAndDisconnectDuringSend_ThrowsTimeoutException()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(50);
+
+        using var writeStarted = new ManualResetEventSlim();
+        using var releaseWrite = new ManualResetEventSlim();
+        bool firstWrite = true;
+        ((Nerdbank.FullDuplexStream)this.clientStream).BeforeWrite = (stream, buffer, offset, count) =>
+        {
+            if (firstWrite)
+            {
+                firstWrite = false;
+                writeStarted.Set();
+                Assert.True(releaseWrite.Wait(UnexpectedTimeout));
+            }
+        };
+
+        try
+        {
+            Task<string> invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, CancellationToken.None);
+            Assert.True(writeStarted.Wait(UnexpectedTimeout, TestContext.Current.CancellationToken));
+            await Task.Delay(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
+            this.clientRpc.Dispose();
+            releaseWrite.Set();
+
+            TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
+            Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            ((Nerdbank.FullDuplexStream)this.clientStream).BeforeWrite = null;
+            releaseWrite.Set();
+        }
+    }
+
+    [Fact]
     public async Task InvokeWithCancellationAsync_CallerCancellationTakesPrecedenceOverOutboundRequestTimeout()
     {
         this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMinutes(1);
@@ -2762,6 +2798,14 @@ public abstract partial class JsonRpcTests : TestBase
         Assert.Throws<ArgumentOutOfRangeException>(() => this.clientRpc.OutboundRequestTimeout = TimeSpan.Zero);
         Assert.Throws<ArgumentOutOfRangeException>(() => this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(-1));
         this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(1);
+    }
+
+    [Fact]
+    public void OutboundRequestTimeout_UsesAtomicInt64BackingField()
+    {
+        FieldInfo? backingField = typeof(JsonRpc).GetField("outboundRequestTimeoutTicks", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(backingField);
+        Assert.Equal(typeof(long), backingField.FieldType);
     }
 
     [Fact]

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1050,7 +1050,7 @@ public abstract partial class JsonRpcTests : TestBase
     [Fact]
     public async Task InvokeWithCancellationAsync_UsesOutboundRequestTimeout()
     {
-        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        this.clientRpc.OutboundRequestTimeout = ExpectedTimeout;
         Task<string> invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, CancellationToken.None);
         await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
 

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1022,6 +1022,57 @@ public abstract partial class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task InvokeWithCancellationAsync_CancelOnFirstWriteToStream_WithOutboundRequestTimeout()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMinutes(1);
+        this.server.DelayAsyncMethodWithCancellation = true;
+
+        using var cts = new CancellationTokenSource();
+        ((Nerdbank.FullDuplexStream)this.clientStream).BeforeWrite = (stream, buffer, offset, count) =>
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                cts.Cancel();
+            }
+        };
+
+        try
+        {
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, cts.Token)).WithTimeout(UnexpectedTimeout);
+            Assert.Equal(cts.Token, ex.CancellationToken);
+        }
+        finally
+        {
+            ((Nerdbank.FullDuplexStream)this.clientStream).BeforeWrite = null;
+        }
+    }
+
+    [Fact]
+    public async Task InvokeWithCancellationAsync_UsesOutboundRequestTimeout()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(100);
+        Task<string> invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, CancellationToken.None);
+        await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
+
+        TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
+        Assert.Contains(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InvokeWithCancellationAsync_CallerCancellationTakesPrecedenceOverOutboundRequestTimeout()
+    {
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMinutes(1);
+        using var cts = new CancellationTokenSource();
+        Task<string> invokeTask = this.clientRpc.InvokeWithCancellationAsync<string>(nameof(Server.AsyncMethodWithCancellation), new[] { "a" }, cts.Token);
+        await this.server.ServerMethodReached.WaitAsync(this.TimeoutToken);
+        cts.Cancel();
+
+        OperationCanceledException ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+        Assert.DoesNotContain(nameof(JsonRpc.OutboundRequestTimeout), ex.Message, StringComparison.Ordinal);
+        Assert.Equal(cts.Token, ex.CancellationToken);
+    }
+
+    [Fact]
     public async Task Invoke_ThrowsCancellationExceptionOverDisposedException()
     {
         this.clientRpc.Dispose();
@@ -2703,6 +2754,14 @@ public abstract partial class JsonRpcTests : TestBase
         Assert.NotNull(this.clientRpc.CancellationStrategy);
         this.clientRpc.AllowModificationWhileListening = true;
         this.clientRpc.CancellationStrategy = null;
+    }
+
+    [Fact]
+    public void OutboundRequestTimeout_RequiresPositiveValue()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.clientRpc.OutboundRequestTimeout = TimeSpan.Zero);
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(-1));
+        this.clientRpc.OutboundRequestTimeout = TimeSpan.FromMilliseconds(1);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
Issue #1443 asks for a connection-wide way to bound outbound RPC calls instead of requiring each call site to create and dispose a linked `CancellationTokenSource` manually.

Fixes #1443

## What changed
- Added `JsonRpc.OutboundRequestTimeout` as a nullable, disabled-by-default setting for response-expected outbound calls.
- Applied the timeout in the shared outbound invoke path so direct `Invoke*` APIs and proxy-generated calls behave the same way.
- Timeout-origin failures now throw `TimeoutException` and include `nameof(JsonRpc.OutboundRequestTimeout)` in the message so tests can assert on invariant text instead of localized English.
- When the caller's token is canceled, `OperationCanceledException` now escapes with the caller's original token rather than an internal linked token.
- Timeout-triggered cancellation still goes through the outbound cancellation strategy, so `$/cancelRequest` is sent even though the caller stops waiting immediately.
- Notifications remain unchanged.

## Notes
The timeout only stops waiting on the client side. The server may still be processing the request, and the PR keeps that behavior explicit in the thrown timeout message.

## Testing
- `dotnet build -c Release`
- Targeted timeout/cancellation tests on `net9.0`, `net8.0`, and `net472`
- Broader cancellation-focused regression sweep on `net9.0` with `TestCategory=FailsInCloudTest` excluded