### PR TITLE
Add parameter name customization for JSON-RPC (attribute + transform)

### DIFF
--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
@@ -24,7 +24,13 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
 
     private string PositionalTypesFieldName => $"{this.Name}PositionalArgumentDeclaredTypes{this.UniqueSuffix}";
 
+    private string ParameterNamesFieldName => $"{this.Name}ParameterNames{this.UniqueSuffix}";
+
     private string TransformedMethodNameFieldName => $"transformed{this.Name}{this.UniqueSuffix}";
+
+    private string ParameterNameTransformStateFieldName => $"{this.Name}ParameterNameTransformState{this.UniqueSuffix}";
+
+    private string TransformedNamedTypesFieldName => $"{this.Name}TransformedNamedArgumentDeclaredTypes{this.UniqueSuffix}";
 
     private string? CancellationTokenExpression => this.CancellationToken?.Name;
 
@@ -50,7 +56,7 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
         writer.Indentation++;
         foreach (ParameterModel parameter in this.DataParameters.Span)
         {
-            writer.WriteLine($"""["{parameter.Name}"] = typeof({parameter.TypeNoNullRefAnnotations}),""");
+            writer.WriteLine($"""["{parameter.RpcName}"] = typeof({parameter.TypeNoNullRefAnnotations}),""");
         }
 
         writer.Indentation--;
@@ -75,6 +81,30 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
                 """);
 
         if (this.IsSupported)
+        {
+            writer.WriteLine($$"""
+
+                    private static readonly global::System.Collections.Generic.IReadOnlyList<string> {{this.ParameterNamesFieldName}} = new global::System.Collections.Generic.List<string>
+                    {
+                    """);
+            writer.Indentation++;
+            foreach (ParameterModel parameter in this.DataParameters.Span)
+            {
+                writer.WriteLine($$"""
+                        "{{parameter.RpcName}}",
+                        """);
+            }
+
+            writer.Indentation--;
+            writer.WriteLine($$"""
+                    };
+
+                    private string? {{this.TransformedMethodNameFieldName}};
+                    private int {{this.ParameterNameTransformStateFieldName}};
+                    private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? {{this.TransformedNamedTypesFieldName}};
+                    """);
+        }
+        else
         {
             writer.WriteLine($"""
 
@@ -133,8 +163,19 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
 
                     this.OnCallingMethod("{{this.Name}}");
                     string __rpcMethodName = this.{{this.TransformedMethodNameFieldName}} ??= this.TransformMethodName("{{this.RpcMethodName}}", typeof({{this.DeclaringInterfaceName}}));
+                    int __parameterNameTransformState = this.{{this.ParameterNameTransformStateFieldName}};
+                    if (__parameterNameTransformState == 0)
+                    {
+                        __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, {{this.ParameterNamesFieldName}});
+                        this.{{this.ParameterNameTransformStateFieldName}} = __parameterNameTransformState;
+                    }
+
+                    bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+                    global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+                        this.{{this.TransformedNamedTypesFieldName}} ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, {{this.ParameterNamesFieldName}}, {{this.PositionalTypesFieldName}}) :
+                        {{this.NamedTypesFieldName}};
                     global::System.Threading.Tasks.Task{{returnTypeArg}} __result = this.Options.ServerRequiresNamedArguments ?
-                        this.JsonRpc.{{namedArgsInvocationMethodName}}(__rpcMethodName, {{namedArgs}}(), {{this.NamedTypesFieldName}}{{cancellationArg}}) :
+                        this.JsonRpc.{{namedArgsInvocationMethodName}}(__rpcMethodName, {{namedArgs}}(__useTransformedParameterNames), __namedArgumentTypes{{cancellationArg}}) :
                         this.JsonRpc.{{positionalArgsInvocationMethodName}}(__rpcMethodName, {{positionalArgs}}, {{this.PositionalTypesFieldName}}{{cancellationArg}});
                     this.OnCalledMethod("{{this.Name}}");
 
@@ -143,19 +184,38 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
 
             writer.WriteLine($$"""
 
-                global::System.Collections.Generic.Dictionary<string, object?> {{namedArgs}}()
-                    => new()
+                global::System.Collections.Generic.Dictionary<string, object?> {{namedArgs}}(bool __useTransformedParameterNames)
+                {
+                    if (__useTransformedParameterNames)
                     {
+                        return new()
+                        {
                 """);
-            writer.Indentation += 2;
+            writer.Indentation++;
             foreach (ParameterModel parameter in this.DataParameters.Span)
             {
-                writer.WriteLine($@"[""{parameter.Name}""] = {parameter.Name},");
+                writer.WriteLine($@"[this.Options.ParameterNameTransform(""{parameter.RpcName}"")] = {parameter.Name},");
             }
 
             writer.Indentation--;
-            writer.WriteLine("};");
+            writer.WriteLine("""
+                        };
+                    }
+
+                    return new()
+                    {
+                """);
+            writer.Indentation++;
+            foreach (ParameterModel parameter in this.DataParameters.Span)
+            {
+                writer.WriteLine($@"[""{parameter.RpcName}""] = {parameter.Name},");
+            }
+
             writer.Indentation--;
+            writer.WriteLine("""
+                    };
+                }
+                """);
         }
 
         writer.Indentation--;

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/ParameterModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/ParameterModel.cs
@@ -1,12 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace StreamJsonRpc.Analyzers.GeneratorModels;
 
-internal record ParameterModel(string Name, string Type, string TypeNoNullRefAnnotations, RpcSpecialType SpecialType)
+internal record ParameterModel(string Name, string RpcName, string Type, string TypeNoNullRefAnnotations, RpcSpecialType SpecialType)
 {
     internal static ParameterModel Create(IParameterSymbol parameter, KnownSymbols symbols)
-        => new(parameter.Name, parameter.Type.ToDisplayString(ProxyGenerator.FullyQualifiedWithNullableFormat), parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), ProxyGenerator.ClassifySpecialType(parameter.Type, symbols));
+    {
+        AttributeData? jsonRpcParameterAttribute = parameter.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbols.JsonRpcParameterAttribute));
+        string rpcName = jsonRpcParameterAttribute is { ConstructorArguments: [{ Value: string name }, ..] } ? name : parameter.Name;
+
+        return new(
+            parameter.Name,
+            rpcName,
+            parameter.Type.ToDisplayString(ProxyGenerator.FullyQualifiedWithNullableFormat),
+            parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            ProxyGenerator.ClassifySpecialType(parameter.Type, symbols));
+    }
 }

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -24,6 +24,7 @@ internal record KnownSymbols(
     INamedTypeSymbol ExportRpcContractProxiesAttribute,
     INamedTypeSymbol JsonRpcProxyMappingAttribute,
     INamedTypeSymbol JsonRpcMethodAttribute,
+    INamedTypeSymbol JsonRpcParameterAttribute,
     INamedTypeSymbol? MethodShapeAttribute,
     INamedTypeSymbol SystemType,
     INamedTypeSymbol Stream)
@@ -47,6 +48,7 @@ internal record KnownSymbols(
         INamedTypeSymbol? exportRpcContractProxiesAttribute = compilation.GetTypeByMetadataName(Types.ExportRpcContractProxiesAttribute.FullName);
         INamedTypeSymbol? rpcProxyMappingAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcProxyMappingAttribute.FullName);
         INamedTypeSymbol? jsonRpcMethodAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcMethodAttribute.FullName);
+        INamedTypeSymbol? jsonRpcParameterAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcParameterAttribute.FullName);
         INamedTypeSymbol? methodShapeAttribute = compilation.GetTypeByMetadataName(Types.MethodShapeAttribute.FullName);
         INamedTypeSymbol? systemType = compilation.GetTypeByMetadataName("System.Type");
         INamedTypeSymbol? systemIOStream = compilation.GetTypeByMetadataName("System.IO.Stream");
@@ -60,6 +62,7 @@ internal record KnownSymbols(
             exportRpcContractProxiesAttribute is null ||
             rpcProxyMappingAttribute is null ||
             jsonRpcMethodAttribute is null ||
+            jsonRpcParameterAttribute is null ||
             systemType is null ||
             systemIOStream is null ||
             cancellationToken is null)
@@ -68,7 +71,7 @@ internal record KnownSymbols(
             return false;
         }
 
-        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcMethodAttribute, methodShapeAttribute, systemType, systemIOStream);
+        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
         return true;
     }
 }

--- a/src/StreamJsonRpc.Analyzers/Types.cs
+++ b/src/StreamJsonRpc.Analyzers/Types.cs
@@ -55,6 +55,11 @@ internal static class Types
         internal const string FullName = "StreamJsonRpc.JsonRpcMethodAttribute";
     }
 
+    internal static class JsonRpcParameterAttribute
+    {
+        internal const string FullName = "StreamJsonRpc.JsonRpcParameterAttribute";
+    }
+
     internal static class MethodShapeAttribute
     {
         internal const string FullName = "PolyType.MethodShapeAttribute";

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -771,6 +771,9 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
         }
 
         public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
+            => this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+
+        public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
         {
             using (this.formatter.TrackDeserialization(this, parameters))
             {
@@ -804,7 +807,7 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
                     }
                 }
 
-                return base.TryGetTypedArguments(parameters, typedArguments);
+                return base.TryGetTypedArguments(parameters, parameterNames, typedArguments);
             }
         }
 

--- a/src/StreamJsonRpc/JsonRpcProxyOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcProxyOptions.cs
@@ -115,8 +115,8 @@ public class JsonRpcProxyOptions
         get => this.methodNameTransform;
         set
         {
-            Requires.NotNull(value);
             Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
+            Requires.NotNull(value);
             this.methodNameTransform = value;
         }
     }
@@ -132,14 +132,15 @@ public class JsonRpcProxyOptions
         get => this.eventNameTransform;
         set
         {
-            Requires.NotNull(value);
             Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
+            Requires.NotNull(value);
             this.eventNameTransform = value;
         }
     }
 
     /// <summary>
-    /// Gets or sets a function that takes the CLR parameter name and returns the RPC parameter name.
+    /// Gets or sets a function that takes the effective pre-transform parameter name and returns the RPC parameter name.
+    /// The effective pre-transform name is the CLR parameter name unless <see cref="JsonRpcParameterAttribute"/> overrides it.
     /// This function applies to named arguments only.
     /// </summary>
     /// <value>A function, defaulting to a straight pass-through. Never null.</value>
@@ -149,8 +150,8 @@ public class JsonRpcProxyOptions
         get => this.parameterNameTransform;
         set
         {
-            Requires.NotNull(value);
             Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
+            Requires.NotNull(value);
             this.parameterNameTransform = value;
         }
     }

--- a/src/StreamJsonRpc/JsonRpcProxyOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcProxyOptions.cs
@@ -19,6 +19,11 @@ public class JsonRpcProxyOptions
     private Func<string, string> eventNameTransform = n => n;
 
     /// <summary>
+    /// Backing field for the <see cref="ParameterNameTransform"/> property.
+    /// </summary>
+    private Func<string, string> parameterNameTransform = n => n;
+
+    /// <summary>
     /// Backing field for the <see cref="OnDispose"/> property.
     /// </summary>
     private Action? onDispose;
@@ -60,6 +65,7 @@ public class JsonRpcProxyOptions
         Requires.NotNull(copyFrom, nameof(copyFrom));
 
         this.MethodNameTransform = copyFrom.MethodNameTransform;
+        this.ParameterNameTransform = copyFrom.ParameterNameTransform;
         this.EventNameTransform = copyFrom.EventNameTransform;
         this.ServerRequiresNamedArguments = copyFrom.ServerRequiresNamedArguments;
         this.AcceptProxyWithExtraInterfaces = copyFrom.AcceptProxyWithExtraInterfaces;
@@ -109,8 +115,9 @@ public class JsonRpcProxyOptions
         get => this.methodNameTransform;
         set
         {
+            Requires.NotNull(value);
             Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
-            this.methodNameTransform = Requires.NotNull(value, nameof(value));
+            this.methodNameTransform = value;
         }
     }
 
@@ -125,8 +132,26 @@ public class JsonRpcProxyOptions
         get => this.eventNameTransform;
         set
         {
+            Requires.NotNull(value);
             Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
-            this.eventNameTransform = Requires.NotNull(value, nameof(value));
+            this.eventNameTransform = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a function that takes the CLR parameter name and returns the RPC parameter name.
+    /// This function applies to named arguments only.
+    /// </summary>
+    /// <value>A function, defaulting to a straight pass-through. Never null.</value>
+    /// <exception cref="ArgumentNullException">Thrown if set to a null value.</exception>
+    public Func<string, string> ParameterNameTransform
+    {
+        get => this.parameterNameTransform;
+        set
+        {
+            Requires.NotNull(value);
+            Verify.Operation(!this.IsFrozen, Resources.CannotMutateFrozenInstance);
+            this.parameterNameTransform = value;
         }
     }
 

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -24,6 +24,7 @@ public class JsonRpcTargetOptions
         Requires.NotNull(copyFrom, nameof(copyFrom));
 
         this.MethodNameTransform = copyFrom.MethodNameTransform;
+        this.ParameterNameTransform = copyFrom.ParameterNameTransform;
         this.EventNameTransform = copyFrom.EventNameTransform;
         this.NotifyClientOfEvents = copyFrom.NotifyClientOfEvents;
         this.AllowNonPublicInvocation = copyFrom.AllowNonPublicInvocation;
@@ -37,6 +38,12 @@ public class JsonRpcTargetOptions
     /// This method is useful for adding prefixes to all methods, or making them camelCased.
     /// </summary>
     public Func<string, string>? MethodNameTransform { get; set; }
+
+    /// <summary>
+    /// Gets or sets a function that takes the CLR parameter name and returns the RPC parameter name.
+    /// This function applies to named arguments only.
+    /// </summary>
+    public Func<string, string>? ParameterNameTransform { get; set; }
 
     /// <summary>
     /// Gets or sets a function that takes the CLR event name and returns the RPC event name used in notification messages.

--- a/src/StreamJsonRpc/JsonRpcTargetOptions.cs
+++ b/src/StreamJsonRpc/JsonRpcTargetOptions.cs
@@ -40,7 +40,8 @@ public class JsonRpcTargetOptions
     public Func<string, string>? MethodNameTransform { get; set; }
 
     /// <summary>
-    /// Gets or sets a function that takes the CLR parameter name and returns the RPC parameter name.
+    /// Gets or sets a function that takes the effective pre-transform parameter name and returns the RPC parameter name.
+    /// The effective pre-transform name is the CLR parameter name unless <see cref="JsonRpcParameterAttribute"/> overrides it.
     /// This function applies to named arguments only.
     /// </summary>
     public Func<string, string>? ParameterNameTransform { get; set; }

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -2209,6 +2209,9 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
         internal IReadOnlyList<ReadOnlySequence<byte>>? MsgPackPositionalArguments { get; set; }
 
         public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
+            => this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+
+        public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
         {
             using (this.formatter.TrackDeserialization(this, parameters))
             {
@@ -2229,7 +2232,7 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
                     }
                 }
 
-                return base.TryGetTypedArguments(parameters, typedArguments);
+                return base.TryGetTypedArguments(parameters, parameterNames, typedArguments);
             }
         }
 

--- a/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
+++ b/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
@@ -1065,6 +1065,9 @@ public partial class NerdbankMessagePackFormatter : FormatterBase, IJsonRpcMessa
         internal IReadOnlyList<RawMessagePack>? MsgPackPositionalArguments { get; set; }
 
         public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
+            => this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+
+        public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
         {
             using (this.formatter.TrackDeserialization(this, parameters))
             {
@@ -1088,7 +1091,7 @@ public partial class NerdbankMessagePackFormatter : FormatterBase, IJsonRpcMessa
                     }
                 }
 
-                return base.TryGetTypedArguments(parameters, typedArguments);
+                return base.TryGetTypedArguments(parameters, parameterNames, typedArguments);
             }
         }
 

--- a/src/StreamJsonRpc/PolyTypeJsonFormatter.cs
+++ b/src/StreamJsonRpc/PolyTypeJsonFormatter.cs
@@ -543,6 +543,9 @@ public partial class PolyTypeJsonFormatter : FormatterBase, IJsonRpcMessageForma
         }
 
         public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
+            => this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+
+        public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
         {
             using (this.formatter.TrackDeserialization(this, parameters))
             {
@@ -553,7 +556,7 @@ public partial class PolyTypeJsonFormatter : FormatterBase, IJsonRpcMessageForma
                     return ArgumentMatchResult.Success;
                 }
 
-                return base.TryGetTypedArguments(parameters, typedArguments);
+                return base.TryGetTypedArguments(parameters, parameterNames, typedArguments);
             }
         }
 

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -221,7 +221,9 @@ public partial class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// An array to initialize with arguments that can satisfy CLR type requirements for each of the <paramref name="parameters"/>.
     /// The length of this span must equal the length of <paramref name="parameters"/>.
     /// </param>
-    /// <returns><see langword="true"/> if all the arguments can conform to the types of the <paramref name="parameters"/> and <paramref name="typedArguments"/> is initialized; <see langword="false"/> otherwise.</returns>
+    /// <returns>
+    /// An <see cref="ArgumentMatchResult"/> describing whether argument matching succeeded or why it failed.
+    /// </returns>
     /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
     public virtual ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
     {
@@ -240,7 +242,9 @@ public partial class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// An array to initialize with arguments that can satisfy CLR type requirements for each of the <paramref name="parameters"/>.
     /// The length of this span must equal the length of <paramref name="parameters"/>.
     /// </param>
-    /// <returns><see langword="true"/> if all the arguments can conform to the types of the <paramref name="parameters"/> and <paramref name="typedArguments"/> is initialized; <see langword="false"/> otherwise.</returns>
+    /// <returns>
+    /// An <see cref="ArgumentMatchResult"/> describing whether argument matching succeeded or why it failed.
+    /// </returns>
     /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
     public virtual ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
     {

--- a/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
+++ b/src/StreamJsonRpc/Protocol/JsonRpcRequest.cs
@@ -225,7 +225,27 @@ public partial class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
     /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
     public virtual ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
     {
+        return this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+    }
+
+    /// <summary>
+    /// Gets the arguments to supply to the method invocation, coerced to types that will satisfy the given list of parameters.
+    /// </summary>
+    /// <param name="parameters">The list of parameters that the arguments must satisfy.</param>
+    /// <param name="parameterNames">
+    /// The names to use when matching named arguments to parameters.
+    /// When omitted, each <see cref="ParameterInfo.Name"/> from <paramref name="parameters"/> is used.
+    /// </param>
+    /// <param name="typedArguments">
+    /// An array to initialize with arguments that can satisfy CLR type requirements for each of the <paramref name="parameters"/>.
+    /// The length of this span must equal the length of <paramref name="parameters"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if all the arguments can conform to the types of the <paramref name="parameters"/> and <paramref name="typedArguments"/> is initialized; <see langword="false"/> otherwise.</returns>
+    /// <exception cref="RpcArgumentDeserializationException">Thrown if the argument exists, but cannot be deserialized.</exception>
+    public virtual ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
+    {
         Requires.Argument(parameters.Length == typedArguments.Length, nameof(typedArguments), "Length of spans do not match.");
+        Requires.Argument(parameterNames.IsEmpty || parameterNames.Length == parameters.Length, nameof(parameterNames), "Length must match parameters or be empty.");
 
         // If we're given more arguments than parameters to hold them, that's a pretty good sign there's a method mismatch.
         if (parameters.Length < this.ArgumentCount)
@@ -241,7 +261,8 @@ public partial class JsonRpcRequest : JsonRpcMessage, IJsonRpcMessageWithId
         for (int i = 0; i < parameters.Length; i++)
         {
             ParameterInfo parameter = parameters[i];
-            if (this.TryGetArgumentByNameOrIndex(parameter.Name, i, parameter.ParameterType, out object? argument))
+            string? parameterName = parameterNames.IsEmpty ? parameter.Name : parameterNames[i];
+            if (this.TryGetArgumentByNameOrIndex(parameterName, i, parameter.ParameterType, out object? argument))
             {
                 if (argument is null)
                 {

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -52,9 +52,13 @@ internal static class ProxyGeneration
 
     private static readonly MethodInfo MethodNameTransformPropertyGetter = typeof(JsonRpcProxyOptions).GetRuntimeProperty(nameof(JsonRpcProxyOptions.MethodNameTransform))!.GetMethod!;
     private static readonly MethodInfo MethodNameTransformInvoke = typeof(Func<string, string>).GetRuntimeMethod(nameof(JsonRpcProxyOptions.MethodNameTransform.Invoke), new Type[] { typeof(string) })!;
+    private static readonly MethodInfo ParameterNameTransformPropertyGetter = typeof(JsonRpcProxyOptions).GetRuntimeProperty(nameof(JsonRpcProxyOptions.ParameterNameTransform))!.GetMethod!;
     private static readonly MethodInfo EventNameTransformPropertyGetter = typeof(JsonRpcProxyOptions).GetRuntimeProperty(nameof(JsonRpcProxyOptions.EventNameTransform))!.GetMethod!;
     private static readonly MethodInfo EventNameTransformInvoke = typeof(Func<string, string>).GetRuntimeMethod(nameof(JsonRpcProxyOptions.EventNameTransform.Invoke), new Type[] { typeof(string) })!;
     private static readonly MethodInfo ServerRequiresNamedArgumentsPropertyGetter = typeof(JsonRpcProxyOptions).GetRuntimeProperty(nameof(JsonRpcProxyOptions.ServerRequiresNamedArguments))!.GetMethod!;
+    private static readonly MethodInfo CreateNamedArgumentsMethod = typeof(CodeGenHelpers).GetRuntimeMethod(nameof(CodeGenHelpers.CreateNamedArguments), [typeof(Func<string, string>), typeof(IReadOnlyList<string>), typeof(IReadOnlyList<object>)])!;
+    private static readonly MethodInfo CreateNamedArgumentDeclaredTypesMethod = typeof(CodeGenHelpers).GetRuntimeMethod(nameof(CodeGenHelpers.CreateNamedArgumentDeclaredTypes), [typeof(Func<string, string>), typeof(IReadOnlyList<string>), typeof(IReadOnlyList<Type>)])!;
+    private static readonly MethodInfo GetParameterNameTransformStateMethod = typeof(CodeGenHelpers).GetRuntimeMethod(nameof(CodeGenHelpers.GetParameterNameTransformState), [typeof(Func<string, string>), typeof(IReadOnlyList<string>)])!;
 
     private static readonly MethodInfo DisposeMethod = typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose)) ?? throw Assumes.NotReachable();
     private static readonly MethodInfo IsDisposedPropertyGetter = typeof(IDisposableObservable).GetProperty(nameof(IDisposableObservable.IsDisposed))!.GetMethod ?? throw Assumes.NotReachable();
@@ -272,11 +276,11 @@ internal static class ProxyGeneration
             MethodInfo invokeWithCancellationAsyncOfTaskOfTMethodInfo = invokeWithCancellationAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters().Length == 4);
 
             IEnumerable<MethodInfo> invokeWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.InvokeWithParameterObjectAsync));
-            MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
-            MethodInfo invokeWithParameterObjectAsyncOfTaskOfTMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
+            MethodInfo invokeWithParameterObjectAsyncOfTaskMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _, _]);
+            MethodInfo invokeWithParameterObjectAsyncOfTaskOfTMethodInfo = invokeWithParameterObjectAsyncMethodInfos.Single(m => m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _, _]);
 
             IEnumerable<MethodInfo> notifyWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.NotifyWithParameterObjectAsync));
-            MethodInfo notifyWithParameterObjectAsyncOfTaskMethodInfo = notifyWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }]);
+            MethodInfo notifyWithParameterObjectAsyncOfTaskMethodInfo = notifyWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
 
             HashSet<MethodInfo> implementedMethods = new() { DisposeMethod };
             foreach ((Type rpcInterface, int? rpcInterfaceCode) in rpcInterfaces)
@@ -349,25 +353,77 @@ internal static class ProxyGeneration
                         il.EmitCall(OpCodes.Callvirt, ServerRequiresNamedArgumentsPropertyGetter, null);
                         il.Emit(OpCodes.Brfalse, positionalArgsLabel);
 
-                        // The second argument is a single parameter object.
+                        // The second argument is a named arguments dictionary.
                         {
                             if (argumentCountExcludingCancellationToken > 0)
                             {
-                                ConstructorInfo paramObjectCtor = CreateParameterObjectType(proxyModuleBuilder, methodParameters.Take(argumentCountExcludingCancellationToken).ToArray());
-                                for (int i = 0; i < argumentCountExcludingCancellationToken; i++)
+                                ParameterInfo[] dataParameters = methodParameters.Take(argumentCountExcludingCancellationToken).ToArray();
+                                bool hasAttributedParameters = dataParameters.Any(static parameter => parameter.GetCustomAttribute<JsonRpcParameterAttribute>() is not null);
+                                Label useTransformedNamesLabel = il.DefineLabel();
+
+                                if (!hasAttributedParameters)
                                 {
-                                    il.Emit(OpCodes.Ldarg, i + 1);
+                                    il.Emit(OpCodes.Ldarg_0);
+                                    il.Emit(OpCodes.Ldfld, optionsField);
+                                    il.EmitCall(OpCodes.Callvirt, ParameterNameTransformPropertyGetter, null);
+                                    LoadParameterNameArrayField(proxyTypeBuilder, dataParameters, il);
+                                    il.EmitCall(OpCodes.Call, GetParameterNameTransformStateMethod, null);
+                                    il.Emit(OpCodes.Ldc_I4_2);
+                                    il.Emit(OpCodes.Beq, useTransformedNamesLabel);
+
+                                    ConstructorInfo paramObjectCtor = CreateParameterObjectType(proxyModuleBuilder, dataParameters);
+                                    for (int i = 0; i < argumentCountExcludingCancellationToken; i++)
+                                    {
+                                        il.Emit(OpCodes.Ldarg, i + 1);
+                                    }
+
+                                    il.Emit(OpCodes.Newobj, paramObjectCtor);
+                                    il.Emit(OpCodes.Ldnull); // argument declared types
+
+                                    MethodInfo invokingMethodUnchangedNames =
+                                        invokeResultTypeArgument is not null ? invokeWithParameterObjectAsyncOfTaskOfTMethodInfo.MakeGenericMethod(invokeResultTypeArgument) :
+                                        returnTypeIsVoid ? notifyWithParameterObjectAsyncOfTaskMethodInfo :
+                                        invokeWithParameterObjectAsyncOfTaskMethodInfo;
+
+                                    CompleteCall(invokingMethodUnchangedNames);
                                 }
 
-                                il.Emit(OpCodes.Newobj, paramObjectCtor);
+                                il.MarkLabel(useTransformedNamesLabel);
+                                il.Emit(OpCodes.Ldarg_0);
+                                il.Emit(OpCodes.Ldfld, optionsField);
+                                il.EmitCall(OpCodes.Callvirt, ParameterNameTransformPropertyGetter, null);
+                                LoadParameterNameArrayField(proxyTypeBuilder, dataParameters, il);
+
+                                il.Emit(OpCodes.Ldc_I4, argumentCountExcludingCancellationToken);
+                                il.Emit(OpCodes.Newarr, typeof(object));
+                                for (int i = 0; i < argumentCountExcludingCancellationToken; i++)
+                                {
+                                    il.Emit(OpCodes.Dup); // duplicate the array on the stack
+                                    il.Emit(OpCodes.Ldc_I4, i); // push the index of the array to be initialized.
+                                    il.Emit(OpCodes.Ldarg, i + 1);
+                                    if (methodParameters[i].ParameterType.GetTypeInfo().IsValueType)
+                                    {
+                                        il.Emit(OpCodes.Box, methodParameters[i].ParameterType); // box if the argument is a value type
+                                    }
+
+                                    il.Emit(OpCodes.Stelem_Ref); // set the array element.
+                                }
+
+                                il.EmitCall(OpCodes.Call, CreateNamedArgumentsMethod, null);
+
+                                // The third argument is a Type[] describing each named parameter type.
+                                il.Emit(OpCodes.Ldarg_0);
+                                il.Emit(OpCodes.Ldfld, optionsField);
+                                il.EmitCall(OpCodes.Callvirt, ParameterNameTransformPropertyGetter, null);
+                                LoadParameterNameArrayField(proxyTypeBuilder, dataParameters, il);
+                                LoadParameterTypeArrayField(proxyTypeBuilder, dataParameters, il);
+                                il.EmitCall(OpCodes.Call, CreateNamedArgumentDeclaredTypesMethod, null);
                             }
                             else
                             {
                                 il.Emit(OpCodes.Ldnull);
+                                il.Emit(OpCodes.Ldnull);
                             }
-
-                            // Note that we do NOT need to load in a dictionary of named parameter types
-                            // because of our specialized parameter object that strongly types all arguments for us.
 
                             // Construct the InvokeAsync<T> method with the T argument supplied if we have a return type.
                             MethodInfo invokingMethod =
@@ -576,6 +632,43 @@ internal static class ProxyGeneration
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Stsfld, field);
 
+        il.MarkLabel(skipInitLabel);
+    }
+
+    private static void LoadParameterNameArrayField(TypeBuilder proxyTypeBuilder, ParameterInfo[] parameterInfos, ILGenerator il)
+    {
+        if (parameterInfos.Length == 0)
+        {
+            // No need for a field when the array would be empty.
+            il.Emit(OpCodes.Ldnull);
+            return;
+        }
+
+        string fieldName = Guid.NewGuid().ToString("n");
+        FieldBuilder field = proxyTypeBuilder.DefineField(
+            fieldName,
+            typeof(string[]),
+            FieldAttributes.Static | FieldAttributes.Private);
+
+        Label skipInitLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Dup); // keep a copy on the stack after the test in case it's non-null.
+        il.Emit(OpCodes.Brtrue, skipInitLabel);
+
+        il.Emit(OpCodes.Pop); // ditch the null from stack.
+        il.Emit(OpCodes.Ldc_I4, parameterInfos.Length);
+        il.Emit(OpCodes.Newarr, typeof(string));
+        for (int i = 0; i < parameterInfos.Length; i++)
+        {
+            il.Emit(OpCodes.Dup); // duplicate the array on the stack
+            il.Emit(OpCodes.Ldc_I4, i); // push the index of the array to be initialized.
+            il.Emit(OpCodes.Ldstr, parameterInfos[i].GetCustomAttribute<JsonRpcParameterAttribute>()?.Name ?? parameterInfos[i].Name ?? string.Empty);
+            il.Emit(OpCodes.Stelem_Ref); // set the array element.
+        }
+
+        il.Emit(OpCodes.Dup); // keep a copy for the stack after assignment.
+        il.Emit(OpCodes.Stsfld, field);
         il.MarkLabel(skipInitLabel);
     }
 

--- a/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace StreamJsonRpc.Reflection;
 
@@ -12,8 +15,93 @@ namespace StreamJsonRpc.Reflection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class CodeGenHelpers
 {
+    private static readonly ConditionalWeakTable<Func<string, string>, ConcurrentDictionary<IReadOnlyList<string>, int>> ParameterNameTransformStateCache = new();
+
 #pragma warning disable VSTHRD200 // Use "Async" suffix in names of methods that return an awaitable type.
     /// <inheritdoc cref="ProxyGeneration.AsyncEnumerableProxy{T}"/>
     public static IAsyncEnumerable<T> CreateAsyncEnumerableProxy<T>(Task<IAsyncEnumerable<T>> enumerableTask, CancellationToken defaultCancellationToken) => new ProxyGeneration.AsyncEnumerableProxy<T>(enumerableTask, defaultCancellationToken);
 #pragma warning restore VSTHRD200 // Use "Async" suffix in names of methods that return an awaitable type.
+
+    /// <summary>
+    /// Creates a named arguments dictionary from raw parameter names and values.
+    /// </summary>
+    public static Dictionary<string, object?> CreateNamedArguments(Func<string, string> parameterNameTransform, IReadOnlyList<string> parameterNames, IReadOnlyList<object?> argumentValues)
+    {
+        Requires.NotNull(parameterNameTransform, nameof(parameterNameTransform));
+        Requires.NotNull(parameterNames, nameof(parameterNames));
+        Requires.NotNull(argumentValues, nameof(argumentValues));
+        Requires.Argument(parameterNames.Count == argumentValues.Count, nameof(argumentValues), "Argument and parameter name counts must match.");
+
+        var result = new Dictionary<string, object?>(parameterNames.Count, StringComparer.Ordinal);
+        for (int i = 0; i < parameterNames.Count; i++)
+        {
+            string transformedName = parameterNameTransform(parameterNames[i]);
+            Requires.Argument(transformedName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
+            result[transformedName] = argumentValues[i];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Creates a named-argument type dictionary from raw parameter names and declared parameter types.
+    /// </summary>
+    public static Dictionary<string, Type> CreateNamedArgumentDeclaredTypes(Func<string, string> parameterNameTransform, IReadOnlyList<string> parameterNames, IReadOnlyList<Type> parameterTypes)
+    {
+        Requires.NotNull(parameterNameTransform, nameof(parameterNameTransform));
+        Requires.NotNull(parameterNames, nameof(parameterNames));
+        Requires.NotNull(parameterTypes, nameof(parameterTypes));
+        Requires.Argument(parameterNames.Count == parameterTypes.Count, nameof(parameterTypes), "Parameter name and type counts must match.");
+
+        var result = new Dictionary<string, Type>(parameterNames.Count, StringComparer.Ordinal);
+        for (int i = 0; i < parameterNames.Count; i++)
+        {
+            string transformedName = parameterNameTransform(parameterNames[i]);
+            Requires.Argument(transformedName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
+            result[transformedName] = parameterTypes[i];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Checks whether applying the transform preserves all parameter names.
+    /// </summary>
+    public static bool AreParameterNamesUnchanged(Func<string, string> parameterNameTransform, IReadOnlyList<string> parameterNames)
+    {
+        Requires.NotNull(parameterNameTransform, nameof(parameterNameTransform));
+        Requires.NotNull(parameterNames, nameof(parameterNames));
+
+        foreach (string name in parameterNames)
+        {
+            if (!StringComparer.Ordinal.Equals(name, parameterNameTransform(name)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the parameter-name transform state for a method.
+    /// </summary>
+    /// <param name="parameterNameTransform">The transform to evaluate.</param>
+    /// <param name="parameterNames">The CLR/attribute parameter names for the method.</param>
+    /// <returns>
+    /// <c>1</c> when no transformed names are required; <c>2</c> when transformed names are required.
+    /// </returns>
+    public static int GetParameterNameTransformState(Func<string, string> parameterNameTransform, IReadOnlyList<string> parameterNames)
+    {
+        Requires.NotNull(parameterNameTransform, nameof(parameterNameTransform));
+        Requires.NotNull(parameterNames, nameof(parameterNames));
+
+        if (ReferenceEquals(parameterNameTransform, JsonRpcProxyOptions.Default.ParameterNameTransform))
+        {
+            return 1;
+        }
+
+        ConcurrentDictionary<IReadOnlyList<string>, int> byParameterNames = ParameterNameTransformStateCache.GetValue(parameterNameTransform, static _ => new());
+        return byParameterNames.GetOrAdd(parameterNames, names => AreParameterNamesUnchanged(parameterNameTransform, names) ? 1 : 2);
+    }
 }

--- a/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
+++ b/src/StreamJsonRpc/Reflection/CodeGenHelpers.cs
@@ -37,7 +37,7 @@ public static class CodeGenHelpers
         {
             string transformedName = parameterNameTransform(parameterNames[i]);
             Requires.Argument(transformedName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
-            result[transformedName] = argumentValues[i];
+            result.Add(transformedName, argumentValues[i]);
         }
 
         return result;
@@ -58,7 +58,7 @@ public static class CodeGenHelpers
         {
             string transformedName = parameterNameTransform(parameterNames[i]);
             Requires.Argument(transformedName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
-            result[transformedName] = parameterTypes[i];
+            result.Add(transformedName, parameterTypes[i]);
         }
 
         return result;

--- a/src/StreamJsonRpc/Reflection/JsonRpcParameterAttribute.cs
+++ b/src/StreamJsonRpc/Reflection/JsonRpcParameterAttribute.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace StreamJsonRpc;
+
+/// <summary>
+/// Attribute which changes the name by which this parameter is identified in JSON-RPC named arguments.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+public sealed class JsonRpcParameterAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonRpcParameterAttribute"/> class.
+    /// </summary>
+    /// <param name="name">Replacement name of a parameter.</param>
+    public JsonRpcParameterAttribute(string name)
+    {
+        Requires.NotNullOrEmpty(name, nameof(name));
+        this.Name = name;
+    }
+
+    /// <summary>
+    /// Gets the RPC name by which this parameter will be identified in named arguments.
+    /// </summary>
+    public string Name { get; }
+}

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace StreamJsonRpc;
@@ -10,12 +11,15 @@ namespace StreamJsonRpc;
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
 internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 {
-    internal MethodSignatureAndTarget(RpcTargetMetadata.TargetMethodMetadata signature, object? target, JsonRpcMethodAttribute? attribute, SynchronizationContext? perMethodSynchronizationContext)
+    private readonly ReadOnlyMemory<string?> parameterNamesExcludingCancellationToken;
+
+    internal MethodSignatureAndTarget(RpcTargetMetadata.TargetMethodMetadata signature, object? target, JsonRpcMethodAttribute? attribute, SynchronizationContext? perMethodSynchronizationContext, Func<string, string>? parameterNameTransform = null)
     {
         this.Signature = signature;
         this.Target = target;
         this.SynchronizationContext = perMethodSynchronizationContext;
         this.Attribute = attribute ?? signature.Attribute;
+        this.parameterNamesExcludingCancellationToken = GetEffectiveParameterNames(signature, parameterNameTransform);
     }
 
     internal RpcTargetMetadata.TargetMethodMetadata Signature { get; }
@@ -25,6 +29,8 @@ internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     internal object? Target { get; }
 
     internal SynchronizationContext? SynchronizationContext { get; }
+
+    internal ReadOnlySpan<string?> ParameterNamesExcludingCancellationToken => this.parameterNamesExcludingCancellationToken.Span;
 
     [ExcludeFromCodeCoverage]
     private string DebuggerDisplay => this.ToString();
@@ -51,4 +57,39 @@ internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 
     /// <inheritdoc/>
     public override string ToString() => $"{this.Signature} ({this.Target})";
+
+    private static ReadOnlyMemory<string?> GetEffectiveParameterNames(RpcTargetMetadata.TargetMethodMetadata signature, Func<string, string>? parameterNameTransform)
+    {
+        int parameterCount = signature.TotalParamCountExcludingCancellationToken;
+        if (parameterCount == 0)
+        {
+            return ReadOnlyMemory<string?>.Empty;
+        }
+
+        var result = new string?[parameterCount];
+        bool customNameDetected = false;
+        for (int i = 0; i < parameterCount; i++)
+        {
+            ParameterInfo parameter = signature.Parameters[i];
+            string? parameterName = parameter.GetCustomAttribute<JsonRpcParameterAttribute>()?.Name ?? parameter.Name;
+            if (!StringComparer.Ordinal.Equals(parameterName, parameter.Name))
+            {
+                customNameDetected = true;
+            }
+
+            if (parameterName is not null && parameterNameTransform is not null)
+            {
+                parameterName = parameterNameTransform(parameterName);
+                Requires.Argument(parameterName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
+                if (!StringComparer.Ordinal.Equals(parameterName, parameter.Name))
+                {
+                    customNameDetected = true;
+                }
+            }
+
+            result[i] = parameterName;
+        }
+
+        return customNameDetected ? result : ReadOnlyMemory<string?>.Empty;
+    }
 }

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -66,30 +66,37 @@ internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
             return ReadOnlyMemory<string?>.Empty;
         }
 
-        var result = new string?[parameterCount];
-        bool customNameDetected = false;
+        string?[]? result = null;
         for (int i = 0; i < parameterCount; i++)
         {
             ParameterInfo parameter = signature.Parameters[i];
             string? parameterName = parameter.GetCustomAttribute<JsonRpcParameterAttribute>()?.Name ?? parameter.Name;
-            if (!StringComparer.Ordinal.Equals(parameterName, parameter.Name))
-            {
-                customNameDetected = true;
-            }
-
-            if (parameterName is not null && parameterNameTransform is not null)
+            if (parameterNameTransform is not null && parameterName is not null)
             {
                 parameterName = parameterNameTransform(parameterName);
                 Requires.Argument(parameterName is not null, nameof(parameterNameTransform), "Delegate returned a null parameter name.");
-                if (!StringComparer.Ordinal.Equals(parameterName, parameter.Name))
-                {
-                    customNameDetected = true;
-                }
             }
 
-            result[i] = parameterName;
+            if (!StringComparer.Ordinal.Equals(parameterName, parameter.Name))
+            {
+                if (result is null)
+                {
+                    // Lazily allocate and back-fill with the original (unchanged) names for all preceding parameters.
+                    result = new string?[parameterCount];
+                    for (int j = 0; j < i; j++)
+                    {
+                        result[j] = signature.Parameters[j].Name;
+                    }
+                }
+
+                result[i] = parameterName;
+            }
+            else if (result is not null)
+            {
+                result[i] = parameterName;
+            }
         }
 
-        return customNameDetected ? result : ReadOnlyMemory<string?>.Empty;
+        return result is not null ? result : ReadOnlyMemory<string?>.Empty;
     }
 }

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -303,7 +303,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                     // Null forgiveness operator in use due to: https://github.com/dotnet/roslyn/issues/73274
                     if (!alreadyExists || !existingList!.Any(e => e.Equals(newMethod)))
                     {
-                        var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null);
+                        var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);
                         revertAddLocalRpcTarget?.RecordMethodAdded(rpcMethodName, signatureAndTarget);
                         existingList!.Add(signatureAndTarget);

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -43,7 +43,7 @@ public sealed class TargetMethod
             try
             {
                 Span<object?> args = argumentArray.AsSpan(0, parameterCount);
-                if (this.TryGetArguments(request, candidateMethod.Signature, args))
+                if (this.TryGetArguments(request, candidateMethod, args))
                 {
                     this.synchronizationContext = candidateMethod.SynchronizationContext ?? fallbackSynchronizationContext;
                     this.target = candidateMethod.Target;
@@ -145,43 +145,47 @@ public sealed class TargetMethod
         this.errorMessages.Add(message);
     }
 
-    private bool TryGetArguments(JsonRpcRequest request, RpcTargetMetadata.TargetMethodMetadata method, Span<object?> arguments)
+    private bool TryGetArguments(JsonRpcRequest request, MethodSignatureAndTarget method, Span<object?> arguments)
     {
         Requires.NotNull(request, nameof(request));
-        Requires.NotNull(method, nameof(method));
-        Requires.Argument(arguments.Length == method.Parameters.Count, nameof(arguments), "Length must equal number of parameters in method signature.");
+        Requires.NotNull(method.Signature, nameof(method));
+        Requires.Argument(arguments.Length == method.Signature.Parameters.Count, nameof(arguments), "Length must equal number of parameters in method signature.");
 
         // ref and out parameters aren't supported.
-        if (method.HasOutOrRefParameters)
+        if (method.Signature.HasOutOrRefParameters)
         {
-            this.AddErrorMessage(string.Format(CultureInfo.CurrentCulture, Resources.MethodHasRefOrOutParameters, method));
+            this.AddErrorMessage(string.Format(CultureInfo.CurrentCulture, Resources.MethodHasRefOrOutParameters, method.Signature));
             return false;
         }
 
         // When there is a CancellationToken parameter, we require that it always be the last parameter.
-        ReadOnlySpan<ParameterInfo> methodParametersExcludingCancellationToken = method.ParametersMemory.Span[..method.TotalParamCountExcludingCancellationToken];
-        Span<object?> argumentsExcludingCancellationToken = arguments.Slice(0, method.TotalParamCountExcludingCancellationToken);
-        if (method.HasCancellationTokenParameter)
+        ReadOnlySpan<ParameterInfo> methodParametersExcludingCancellationToken = method.Signature.ParametersMemory.Span[..method.Signature.TotalParamCountExcludingCancellationToken];
+        Span<object?> argumentsExcludingCancellationToken = arguments.Slice(0, method.Signature.TotalParamCountExcludingCancellationToken);
+        if (method.Signature.HasCancellationTokenParameter)
         {
             arguments[arguments.Length - 1] = CancellationToken.None;
         }
 
-        switch (request.TryGetTypedArguments(methodParametersExcludingCancellationToken, argumentsExcludingCancellationToken))
+        JsonRpcRequest.ArgumentMatchResult argumentMatch = method.ParameterNamesExcludingCancellationToken.IsEmpty
+            ? request.TryGetTypedArguments(methodParametersExcludingCancellationToken, argumentsExcludingCancellationToken)
+            : request.TryGetTypedArguments(methodParametersExcludingCancellationToken, method.ParameterNamesExcludingCancellationToken, argumentsExcludingCancellationToken);
+
+        switch (argumentMatch)
         {
             case JsonRpcRequest.ArgumentMatchResult.Success:
                 return true;
             case JsonRpcRequest.ArgumentMatchResult.ParameterArgumentCountMismatch:
                 string methodParameterCount;
-                methodParameterCount = string.Format(CultureInfo.CurrentCulture, "{0} - {1}", method.RequiredParamCount, method.TotalParamCountExcludingCancellationToken);
+                methodParameterCount = string.Format(CultureInfo.CurrentCulture, "{0} - {1}", method.Signature.RequiredParamCount, method.Signature.TotalParamCountExcludingCancellationToken);
                 this.AddErrorMessage(string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.MethodParameterCountDoesNotMatch,
-                    method,
+                    method.Signature,
                     methodParameterCount,
                     request.ArgumentCount));
                 return false;
             case JsonRpcRequest.ArgumentMatchResult.ParameterArgumentTypeMismatch:
-                this.AddErrorMessage(string.Format(CultureInfo.CurrentCulture, Resources.MethodParametersNotCompatible, method));
+                this.AddErrorMessage(string.Format(CultureInfo.CurrentCulture, Resources.MethodParametersNotCompatible, method.Signature));
                 return false;
             case JsonRpcRequest.ArgumentMatchResult.MissingArgument:
                 this.AddErrorMessage(Resources.RequiredArgumentMissing);

--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -500,6 +500,9 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
         }
 
         public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, Span<object?> typedArguments)
+            => this.TryGetTypedArguments(parameters, parameterNames: default, typedArguments);
+
+        public override ArgumentMatchResult TryGetTypedArguments(ReadOnlySpan<ParameterInfo> parameters, ReadOnlySpan<string?> parameterNames, Span<object?> typedArguments)
         {
             using (this.formatter.TrackDeserialization(this, parameters))
             {
@@ -510,7 +513,7 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
                     return ArgumentMatchResult.Success;
                 }
 
-                return base.TryGetTypedArguments(parameters, typedArguments);
+                return base.TryGetTypedArguments(parameters, parameterNames, typedArguments);
             }
         }
 

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterface.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterface.g.cs
@@ -29,7 +29,15 @@ namespace StreamJsonRpc.Generated
 			typeof(global::CustomType),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"t",
+		};
+		
 		private string? transformedAddAsync1;
+		private int AddAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public SomeExperimentalInterface_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -42,19 +50,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync1 ??= this.TransformMethodName("AddAsync", typeof(global::SomeExperimentalInterface));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames1);
+			    this.AddAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames1, AddAsyncPositionalArgumentDeclaredTypes1) :
+			    AddAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes1, token) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, token) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, t], AddAsyncPositionalArgumentDeclaredTypes1, token);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["t"] = t,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("t")] = t,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["t"] = t,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterface2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterface2.g.cs
@@ -29,7 +29,15 @@ namespace StreamJsonRpc.Generated
 			typeof(global::CustomType),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"t",
+		};
+		
 		private string? transformedAddAsync1;
+		private int AddAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public SomeExperimentalInterface2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -42,19 +50,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync1 ??= this.TransformMethodName("AddAsync", typeof(global::SomeExperimentalInterface2));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames1);
+			    this.AddAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames1, AddAsyncPositionalArgumentDeclaredTypes1) :
+			    AddAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes1, token) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, token) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, t], AddAsyncPositionalArgumentDeclaredTypes1, token);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["t"] = t,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("t")] = t,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["t"] = t,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterfaceMDGoEVkn.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/ExperimentalApis/SomeExperimentalInterfaceMDGoEVkn.g.cs
@@ -35,7 +35,15 @@ namespace StreamJsonRpc.Generated
 			typeof(global::CustomType),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"t",
+		};
+		
 		private string? transformedAddAsync1;
+		private int AddAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AddAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -49,7 +57,15 @@ namespace StreamJsonRpc.Generated
 			typeof(global::CustomType),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"t",
+		};
+		
 		private string? transformedAddAsync2;
+		private int AddAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		public SomeExperimentalInterfaceMDGoEVkn_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -62,19 +78,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync1 ??= this.TransformMethodName("AddAsync", typeof(global::SomeExperimentalInterface));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames1);
+			    this.AddAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames1, AddAsyncPositionalArgumentDeclaredTypes1) :
+			    AddAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes1, token) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, token) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, t], AddAsyncPositionalArgumentDeclaredTypes1, token);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["t"] = t,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("t")] = t,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["t"] = t,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::SomeExperimentalInterface2.AddAsync(int a, global::CustomType t, global::System.Threading.CancellationToken token)
@@ -83,19 +121,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync2 ??= this.TransformMethodName("AddAsync", typeof(global::SomeExperimentalInterface2));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames2);
+			    this.AddAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames2, AddAsyncPositionalArgumentDeclaredTypes2) :
+			    AddAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes2, token) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, token) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, t], AddAsyncPositionalArgumentDeclaredTypes2, token);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["t"] = t,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("t")] = t,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["t"] = t,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyService.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyService2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyService2.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask21;
+		private int Task2ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask21 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames1);
+			    this.Task2ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames1, Task2PositionalArgumentDeclaredTypes1) :
+			    Task2NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task2PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyServiceZiHkAQOD.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_ArrayInitializer/IMyServiceZiHkAQOD.g.cs
@@ -31,7 +31,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> Task2NamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -41,7 +47,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask22;
+		private int Task2ParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes2;
 		
 		public IMyServiceZiHkAQOD_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -54,17 +66,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyService2.Task2()
@@ -73,17 +105,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask22 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames2);
+			    this.Task2ParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames2, Task2PositionalArgumentDeclaredTypes2) :
+			    Task2NamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task2PositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyService.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyService2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyService2.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask21;
+		private int Task2ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask21 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames1);
+			    this.Task2ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames1, Task2PositionalArgumentDeclaredTypes1) :
+			    Task2NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task2PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyServiceZiHkAQOD.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_CollectionInitializer/IMyServiceZiHkAQOD.g.cs
@@ -31,7 +31,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> Task2NamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -41,7 +47,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedTask22;
+		private int Task2ParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes2;
 		
 		public IMyServiceZiHkAQOD_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -54,17 +66,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyService2.Task2()
@@ -73,17 +105,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask22 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames2);
+			    this.Task2ParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames2, Task2PositionalArgumentDeclaredTypes2) :
+			    Task2NamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], Task2PositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyService.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyService2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyService2.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyServiceZiHkAQOD.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_DistinctYetRedundantMethods/IMyServiceZiHkAQOD.g.cs
@@ -33,7 +33,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> Task1NamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -45,7 +52,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask12;
+		private int Task1ParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes2;
 		
 		public IMyServiceZiHkAQOD_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -58,18 +72,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyService2.Task1(string name)
@@ -78,18 +113,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask12 ??= this.TransformMethodName("Task1", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames2);
+			    this.Task1ParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames2, Task1PositionalArgumentDeclaredTypes2) :
+			    Task1NamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyService.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyService2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyService2.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> Task2NamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -39,7 +46,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"color",
+		};
+		
 		private string? transformedTask22;
+		private int Task2ParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes2;
 		
 		public IMyService2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -52,18 +66,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyService2.Task2(string color)
@@ -72,18 +107,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask22 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames2);
+			    this.Task2ParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames2, Task2PositionalArgumentDeclaredTypes2) :
+			    Task2NamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [color], Task2PositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["color"] = color,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("color")] = color,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["color"] = color,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyServiceZiHkAQOD.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interceptor_AttachMultipleInterfaces_OneDerivesFromTheOther/IMyServiceZiHkAQOD.g.cs
@@ -33,7 +33,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task1ParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedTask11;
+		private int Task1ParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task1TransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> Task2NamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -45,7 +52,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> Task2ParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"color",
+		};
+		
 		private string? transformedTask22;
+		private int Task2ParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? Task2TransformedNamedArgumentDeclaredTypes2;
 		
 		public IMyServiceZiHkAQOD_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -58,18 +72,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task1");
 			string __rpcMethodName = this.transformedTask11 ??= this.TransformMethodName("Task1", typeof(global::IMyService));
+			int __parameterNameTransformState = this.Task1ParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task1ParameterNames1);
+			    this.Task1ParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task1TransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task1ParameterNames1, Task1PositionalArgumentDeclaredTypes1) :
+			    Task1NamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task1NamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], Task1PositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Task1");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyService2.Task2(string color)
@@ -78,18 +113,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Task2");
 			string __rpcMethodName = this.transformedTask22 ??= this.TransformMethodName("Task2", typeof(global::IMyService2));
+			int __parameterNameTransformState = this.Task2ParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, Task2ParameterNames2);
+			    this.Task2ParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.Task2TransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, Task2ParameterNames2, Task2PositionalArgumentDeclaredTypes2) :
+			    Task2NamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), Task2NamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [color], Task2PositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("Task2");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["color"] = color,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("color")] = color,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["color"] = color,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromIDisposable/IFoo.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromIDisposable/IFoo.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IFoo_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::IFoo));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromOthers/IFoo2.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromOthers/IFoo2.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> JustAnotherCancellationAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -35,7 +41,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustAnotherCancellationAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustAnotherCancellationAsync2;
+		private int JustAnotherCancellationAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		public IFoo2_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -48,17 +60,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::IFoo));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IFoo2.JustAnotherCancellationAsync(global::System.Threading.CancellationToken cancellationToken)
@@ -67,17 +99,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustAnotherCancellationAsync");
 			string __rpcMethodName = this.transformedJustAnotherCancellationAsync2 ??= this.TransformMethodName("JustAnotherCancellationAsync", typeof(global::IFoo2));
+			int __parameterNameTransformState = this.JustAnotherCancellationAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames2);
+			    this.JustAnotherCancellationAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames2, JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes2) :
+			    JustAnotherCancellationAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustAnotherCancellationAsyncNamedArgumentDeclaredTypes2, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes2, cancellationToken);
 			this.OnCalledMethod("JustAnotherCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromOthersWithRedundantMethods/ICalc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_DerivesFromOthersWithRedundantMethods/ICalc.g.cs
@@ -29,7 +29,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedAddAsync1;
+		private int AddAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AddAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -43,7 +51,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedAddAsync2;
+		private int AddAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		public ICalc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -56,19 +72,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync1 ??= this.TransformMethodName("AddAsync", typeof(global::ICalc1));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames1);
+			    this.AddAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames1, AddAsyncPositionalArgumentDeclaredTypes1) :
+			    AddAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], AddAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::ICalc2.AddAsync(int a, int b)
@@ -77,19 +115,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync2 ??= this.TransformMethodName("AddAsync", typeof(global::ICalc2));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames2);
+			    this.AddAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames2, AddAsyncPositionalArgumentDeclaredTypes2) :
+			    AddAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], AddAsyncPositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_HasAsyncDisposeWithoutIDisposable/IFoo.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_HasAsyncDisposeWithoutIDisposable/IFoo.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DisposeParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedDispose1;
+		private int DisposeParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DisposeTransformedNamedArgumentDeclaredTypes1;
 		
 		public IFoo_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Dispose");
 			string __rpcMethodName = this.transformedDispose1 ??= this.TransformMethodName("Dispose", typeof(global::IFoo));
+			int __parameterNameTransformState = this.DisposeParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DisposeParameterNames1);
+			    this.DisposeParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DisposeTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DisposeParameterNames1, DisposePositionalArgumentDeclaredTypes1) :
+			    DisposeNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), DisposeNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], DisposePositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("Dispose");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_HasNestedTypes/IHaveNestedTypes.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Interface_HasNestedTypes/IHaveNestedTypes.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedDoSomethingAsync1;
+		private int DoSomethingAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IHaveNestedTypes_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingAsync");
 			string __rpcMethodName = this.transformedDoSomethingAsync1 ??= this.TransformMethodName("DoSomethingAsync", typeof(global::IHaveNestedTypes));
+			int __parameterNameTransformState = this.DoSomethingAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingAsyncParameterNames1);
+			    this.DoSomethingAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingAsyncParameterNames1, DoSomethingAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), DoSomethingAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], DoSomethingAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/MethodNamesCustomizedByAttribute/IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/MethodNamesCustomizedByAttribute/IMyRpc.g.cs
@@ -29,7 +29,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedAddAsync1;
+		private int AddAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> IntegrateAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -43,7 +51,15 @@ namespace StreamJsonRpc.Generated
 			typeof(double),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> IntegrateAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"from",
+			"to",
+		};
+		
 		private string? transformedIntegrateAsync2;
+		private int IntegrateAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? IntegrateAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> DivideAsyncNamedArgumentDeclaredTypes3 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -57,7 +73,15 @@ namespace StreamJsonRpc.Generated
 			typeof(double),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DivideAsyncParameterNames3 = new global::System.Collections.Generic.List<string>
+		{
+			"from",
+			"to",
+		};
+		
 		private string? transformedDivideAsync3;
+		private int DivideAsyncParameterNameTransformState3;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DivideAsyncTransformedNamedArgumentDeclaredTypes3;
 		
 		public IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -70,19 +94,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync1 ??= this.TransformMethodName("AddRenamed", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames1);
+			    this.AddAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames1, AddAsyncPositionalArgumentDeclaredTypes1) :
+			    AddAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [a, b], AddAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyRpc.IntegrateAsync(double from, double to, global::System.Threading.CancellationToken cancellationToken)
@@ -91,19 +137,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("IntegrateAsync");
 			string __rpcMethodName = this.transformedIntegrateAsync2 ??= this.TransformMethodName("IntegrateRenamed", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.IntegrateAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, IntegrateAsyncParameterNames2);
+			    this.IntegrateAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.IntegrateAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, IntegrateAsyncParameterNames2, IntegrateAsyncPositionalArgumentDeclaredTypes2) :
+			    IntegrateAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), IntegrateAsyncNamedArgumentDeclaredTypes2, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [from, to], IntegrateAsyncPositionalArgumentDeclaredTypes2, cancellationToken);
 			this.OnCalledMethod("IntegrateAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["from"] = from,
-					["to"] = to,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("from")] = from,
+				[this.Options.ParameterNameTransform("to")] = to,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["from"] = from,
+				["to"] = to,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IMyRpc.DivideAsync(double from, double to, global::System.Threading.CancellationToken cancellationToken)
@@ -112,19 +180,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DivideAsync");
 			string __rpcMethodName = this.transformedDivideAsync3 ??= this.TransformMethodName("DivideRenamed", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.DivideAsyncParameterNameTransformState3;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DivideAsyncParameterNames3);
+			    this.DivideAsyncParameterNameTransformState3 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DivideAsyncTransformedNamedArgumentDeclaredTypes3 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DivideAsyncParameterNames3, DivideAsyncPositionalArgumentDeclaredTypes3) :
+			    DivideAsyncNamedArgumentDeclaredTypes3;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), DivideAsyncNamedArgumentDeclaredTypes3, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [from, to], DivideAsyncPositionalArgumentDeclaredTypes3, cancellationToken);
 			this.OnCalledMethod("DivideAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["from"] = from,
-					["to"] = to,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("from")] = from,
+				[this.Options.ParameterNameTransform("to")] = to,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["from"] = from,
+				["to"] = to,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NameRequiredContainingTypeQualifier/A.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NameRequiredContainingTypeQualifier/A.IMyRpc.g.cs
@@ -20,7 +20,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public A_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -33,17 +39,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::A.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NameRequiredContainingTypeQualifier/B.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NameRequiredContainingTypeQualifier/B.IMyRpc.g.cs
@@ -20,7 +20,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustAnotherCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustAnotherCancellationAsync1;
+		private int JustAnotherCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public B_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -33,17 +39,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustAnotherCancellationAsync");
 			string __rpcMethodName = this.transformedJustAnotherCancellationAsync1 ??= this.TransformMethodName("JustAnotherCancellationAsync", typeof(global::B.IMyRpc));
+			int __parameterNameTransformState = this.JustAnotherCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames1);
+			    this.JustAnotherCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames1, JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustAnotherCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustAnotherCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustAnotherCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NamesRequiredNamespaceQualifier/A.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NamesRequiredNamespaceQualifier/A.IMyRpc.g.cs
@@ -28,7 +28,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public A_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -41,17 +47,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::A.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NamesRequiredNamespaceQualifier/B.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NamesRequiredNamespaceQualifier/B.IMyRpc.g.cs
@@ -28,7 +28,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustAnotherCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustAnotherCancellationAsync1;
+		private int JustAnotherCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public B_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -41,17 +47,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustAnotherCancellationAsync");
 			string __rpcMethodName = this.transformedJustAnotherCancellationAsync1 ??= this.TransformMethodName("JustAnotherCancellationAsync", typeof(global::B.IMyRpc));
+			int __parameterNameTransformState = this.JustAnotherCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames1);
+			    this.JustAnotherCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustAnotherCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustAnotherCancellationAsyncParameterNames1, JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustAnotherCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustAnotherCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustAnotherCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustAnotherCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NestedInType/Wrapper.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NestedInType/Wrapper.IMyRpc.g.cs
@@ -28,7 +28,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public Wrapper_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -41,17 +47,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::Wrapper.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NestedInTypeAndNamespace/A.Wrapper.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NestedInTypeAndNamespace/A.Wrapper.IMyRpc.g.cs
@@ -31,7 +31,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public A_Wrapper_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -44,17 +50,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::A.Wrapper.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NonPartialNestedInPartialType/Wrapper.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NonPartialNestedInPartialType/Wrapper.IMyRpc.g.cs
@@ -20,7 +20,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public Wrapper_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -33,17 +39,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::Wrapper.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/NullableTypeArgument/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/NullableTypeArgument/IMyService.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> GetNullableIntAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"value",
+		};
+		
 		private string? transformedGetNullableIntAsync1;
+		private int GetNullableIntAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? GetNullableIntAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("GetNullableIntAsync");
 			string __rpcMethodName = this.transformedGetNullableIntAsync1 ??= this.TransformMethodName("GetNullableIntAsync", typeof(global::IMyService));
+			int __parameterNameTransformState = this.GetNullableIntAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, GetNullableIntAsyncParameterNames1);
+			    this.GetNullableIntAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.GetNullableIntAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, GetNullableIntAsyncParameterNames1, GetNullableIntAsyncPositionalArgumentDeclaredTypes1) :
+			    GetNullableIntAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<object?> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<object?>(__rpcMethodName, ConstructNamedArgs(), GetNullableIntAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<object?>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<object?>(__rpcMethodName, [value], GetNullableIntAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("GetNullableIntAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["value"] = value,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("value")] = value,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["value"] = value,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Overloads/IFoo.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Overloads/IFoo.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> SayHiParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedSayHi1;
+		private int SayHiParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? SayHiTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> SayHiNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -37,7 +43,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> SayHiParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+		};
+		
 		private string? transformedSayHi2;
+		private int SayHiParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? SayHiTransformedNamedArgumentDeclaredTypes2;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> SayHiNamedArgumentDeclaredTypes3 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -51,7 +64,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> SayHiParameterNames3 = new global::System.Collections.Generic.List<string>
+		{
+			"name",
+			"age",
+		};
+		
 		private string? transformedSayHi3;
+		private int SayHiParameterNameTransformState3;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? SayHiTransformedNamedArgumentDeclaredTypes3;
 		
 		public IFoo_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -64,17 +85,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("SayHi");
 			string __rpcMethodName = this.transformedSayHi1 ??= this.TransformMethodName("SayHi", typeof(global::IFoo));
+			int __parameterNameTransformState = this.SayHiParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, SayHiParameterNames1);
+			    this.SayHiParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.SayHiTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, SayHiParameterNames1, SayHiPositionalArgumentDeclaredTypes1) :
+			    SayHiNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), SayHiNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], SayHiPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("SayHi");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IFoo.SayHi(string name)
@@ -83,18 +124,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("SayHi");
 			string __rpcMethodName = this.transformedSayHi2 ??= this.TransformMethodName("SayHi", typeof(global::IFoo));
+			int __parameterNameTransformState = this.SayHiParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, SayHiParameterNames2);
+			    this.SayHiParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.SayHiTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, SayHiParameterNames2, SayHiPositionalArgumentDeclaredTypes2) :
+			    SayHiNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), SayHiNamedArgumentDeclaredTypes2, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name], SayHiPositionalArgumentDeclaredTypes2, default);
 			this.OnCalledMethod("SayHi");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task global::IFoo.SayHi(string name, int age)
@@ -103,19 +165,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("SayHi");
 			string __rpcMethodName = this.transformedSayHi3 ??= this.TransformMethodName("SayHi", typeof(global::IFoo));
+			int __parameterNameTransformState = this.SayHiParameterNameTransformState3;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, SayHiParameterNames3);
+			    this.SayHiParameterNameTransformState3 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.SayHiTransformedNamedArgumentDeclaredTypes3 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, SayHiParameterNames3, SayHiPositionalArgumentDeclaredTypes3) :
+			    SayHiNamedArgumentDeclaredTypes3;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), SayHiNamedArgumentDeclaredTypes3, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [name, age], SayHiPositionalArgumentDeclaredTypes3, default);
 			this.OnCalledMethod("SayHi");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["name"] = name,
-					["age"] = age,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("name")] = name,
+				[this.Options.ParameterNameTransform("age")] = age,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["name"] = name,
+				["age"] = age,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/PartialNestedInNonPartialType/Wrapper.IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/PartialNestedInNonPartialType/Wrapper.IMyRpc.g.cs
@@ -20,7 +20,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public Wrapper_IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -33,17 +39,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::Wrapper.IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/Public_NotNested/IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/Public_NotNested/IMyRpc.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -37,7 +43,14 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AnArgAndCancellationAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"arg",
+		};
+		
 		private string? transformedAnArgAndCancellationAsync2;
+		private int AnArgAndCancellationAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AnArgAndCancellationAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AddAsyncNamedArgumentDeclaredTypes3 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -51,7 +64,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames3 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedAddAsync3;
+		private int AddAsyncParameterNameTransformState3;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes3;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> MultiplyAsyncNamedArgumentDeclaredTypes4 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -65,7 +86,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> MultiplyAsyncParameterNames4 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedMultiplyAsync4;
+		private int MultiplyAsyncParameterNameTransformState4;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? MultiplyAsyncTransformedNamedArgumentDeclaredTypes4;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> StartNamedArgumentDeclaredTypes5 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -77,7 +106,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> StartParameterNames5 = new global::System.Collections.Generic.List<string>
+		{
+			"bah",
+		};
+		
 		private string? transformedStart5;
+		private int StartParameterNameTransformState5;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? StartTransformedNamedArgumentDeclaredTypes5;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> StartCancelableNamedArgumentDeclaredTypes6 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -89,7 +125,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> StartCancelableParameterNames6 = new global::System.Collections.Generic.List<string>
+		{
+			"bah",
+		};
+		
 		private string? transformedStartCancelable6;
+		private int StartCancelableParameterNameTransformState6;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? StartCancelableTransformedNamedArgumentDeclaredTypes6;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> CountAsyncNamedArgumentDeclaredTypes7 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -103,7 +146,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> CountAsyncParameterNames7 = new global::System.Collections.Generic.List<string>
+		{
+			"start",
+			"count",
+		};
+		
 		private string? transformedCountAsync7;
+		private int CountAsyncParameterNameTransformState7;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? CountAsyncTransformedNamedArgumentDeclaredTypes7;
 		
 		public IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -116,17 +167,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.ValueTask global::IMyRpc.AnArgAndCancellationAsync(int arg, global::System.Threading.CancellationToken cancellationToken)
@@ -135,18 +206,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AnArgAndCancellationAsync");
 			string __rpcMethodName = this.transformedAnArgAndCancellationAsync2 ??= this.TransformMethodName("AnArgAndCancellationAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.AnArgAndCancellationAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AnArgAndCancellationAsyncParameterNames2);
+			    this.AnArgAndCancellationAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AnArgAndCancellationAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AnArgAndCancellationAsyncParameterNames2, AnArgAndCancellationAsyncPositionalArgumentDeclaredTypes2) :
+			    AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [arg], AnArgAndCancellationAsyncPositionalArgumentDeclaredTypes2, cancellationToken);
 			this.OnCalledMethod("AnArgAndCancellationAsync");
 			
 			return new global::System.Threading.Tasks.ValueTask(__result);
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["arg"] = arg,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("arg")] = arg,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["arg"] = arg,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::IMyRpc.AddAsync(int a, int b, global::System.Threading.CancellationToken cancellationToken)
@@ -155,19 +247,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync3 ??= this.TransformMethodName("AddAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState3;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames3);
+			    this.AddAsyncParameterNameTransformState3 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes3 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames3, AddAsyncPositionalArgumentDeclaredTypes3) :
+			    AddAsyncNamedArgumentDeclaredTypes3;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes3, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], AddAsyncPositionalArgumentDeclaredTypes3, cancellationToken);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::IMyRpc.MultiplyAsync(int a, int b)
@@ -176,19 +290,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("MultiplyAsync");
 			string __rpcMethodName = this.transformedMultiplyAsync4 ??= this.TransformMethodName("MultiplyAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.MultiplyAsyncParameterNameTransformState4;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, MultiplyAsyncParameterNames4);
+			    this.MultiplyAsyncParameterNameTransformState4 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.MultiplyAsyncTransformedNamedArgumentDeclaredTypes4 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, MultiplyAsyncParameterNames4, MultiplyAsyncPositionalArgumentDeclaredTypes4) :
+			    MultiplyAsyncNamedArgumentDeclaredTypes4;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), MultiplyAsyncNamedArgumentDeclaredTypes4, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], MultiplyAsyncPositionalArgumentDeclaredTypes4, default);
 			this.OnCalledMethod("MultiplyAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		void global::IMyRpc.Start(string bah)
@@ -197,18 +333,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Start");
 			string __rpcMethodName = this.transformedStart5 ??= this.TransformMethodName("Start", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.StartParameterNameTransformState5;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, StartParameterNames5);
+			    this.StartParameterNameTransformState5 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.StartTransformedNamedArgumentDeclaredTypes5 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, StartParameterNames5, StartPositionalArgumentDeclaredTypes5) :
+			    StartNamedArgumentDeclaredTypes5;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), StartNamedArgumentDeclaredTypes5) :
+			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes) :
 			    this.JsonRpc.NotifyAsync(__rpcMethodName, [bah], StartPositionalArgumentDeclaredTypes5);
 			this.OnCalledMethod("Start");
 			
 			return ;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["bah"] = bah,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("bah")] = bah,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["bah"] = bah,
+			    };
+			}
 		}
 		
 		void global::IMyRpc.StartCancelable(string bah, global::System.Threading.CancellationToken token)
@@ -217,18 +374,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("StartCancelable");
 			string __rpcMethodName = this.transformedStartCancelable6 ??= this.TransformMethodName("StartCancelable", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.StartCancelableParameterNameTransformState6;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, StartCancelableParameterNames6);
+			    this.StartCancelableParameterNameTransformState6 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.StartCancelableTransformedNamedArgumentDeclaredTypes6 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, StartCancelableParameterNames6, StartCancelablePositionalArgumentDeclaredTypes6) :
+			    StartCancelableNamedArgumentDeclaredTypes6;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), StartCancelableNamedArgumentDeclaredTypes6) :
+			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes) :
 			    this.JsonRpc.NotifyAsync(__rpcMethodName, [bah], StartCancelablePositionalArgumentDeclaredTypes6);
 			this.OnCalledMethod("StartCancelable");
 			
 			return ;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["bah"] = bah,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("bah")] = bah,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["bah"] = bah,
+			    };
+			}
 		}
 		
 		global::System.Collections.Generic.IAsyncEnumerable<int> global::IMyRpc.CountAsync(int start, int count, global::System.Threading.CancellationToken cancellationToken)
@@ -237,19 +415,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("CountAsync");
 			string __rpcMethodName = this.transformedCountAsync7 ??= this.TransformMethodName("CountAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.CountAsyncParameterNameTransformState7;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, CountAsyncParameterNames7);
+			    this.CountAsyncParameterNameTransformState7 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.CountAsyncTransformedNamedArgumentDeclaredTypes7 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, CountAsyncParameterNames7, CountAsyncPositionalArgumentDeclaredTypes7) :
+			    CountAsyncNamedArgumentDeclaredTypes7;
 			global::System.Threading.Tasks.Task<global::System.Collections.Generic.IAsyncEnumerable<int>> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, ConstructNamedArgs(), CountAsyncNamedArgumentDeclaredTypes7, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, [start, count], CountAsyncPositionalArgumentDeclaredTypes7, cancellationToken);
 			this.OnCalledMethod("CountAsync");
 			
 			return global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateAsyncEnumerableProxy(__result, cancellationToken);
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["start"] = start,
-					["count"] = count,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("start")] = start,
+				[this.Options.ParameterNameTransform("count")] = count,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["start"] = start,
+				["count"] = count,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable/IMyRpc.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable/IMyRpc.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> JustCancellationAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedJustCancellationAsync1;
+		private int JustCancellationAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -37,7 +43,14 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AnArgAndCancellationAsyncParameterNames2 = new global::System.Collections.Generic.List<string>
+		{
+			"arg",
+		};
+		
 		private string? transformedAnArgAndCancellationAsync2;
+		private int AnArgAndCancellationAsyncParameterNameTransformState2;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AnArgAndCancellationAsyncTransformedNamedArgumentDeclaredTypes2;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> AddAsyncNamedArgumentDeclaredTypes3 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -51,7 +64,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> AddAsyncParameterNames3 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedAddAsync3;
+		private int AddAsyncParameterNameTransformState3;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? AddAsyncTransformedNamedArgumentDeclaredTypes3;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> MultiplyAsyncNamedArgumentDeclaredTypes4 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -65,7 +86,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> MultiplyAsyncParameterNames4 = new global::System.Collections.Generic.List<string>
+		{
+			"a",
+			"b",
+		};
+		
 		private string? transformedMultiplyAsync4;
+		private int MultiplyAsyncParameterNameTransformState4;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? MultiplyAsyncTransformedNamedArgumentDeclaredTypes4;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> StartNamedArgumentDeclaredTypes5 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -77,7 +106,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> StartParameterNames5 = new global::System.Collections.Generic.List<string>
+		{
+			"bah",
+		};
+		
 		private string? transformedStart5;
+		private int StartParameterNameTransformState5;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? StartTransformedNamedArgumentDeclaredTypes5;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> StartCancelableNamedArgumentDeclaredTypes6 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -89,7 +125,14 @@ namespace StreamJsonRpc.Generated
 			typeof(string),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> StartCancelableParameterNames6 = new global::System.Collections.Generic.List<string>
+		{
+			"bah",
+		};
+		
 		private string? transformedStartCancelable6;
+		private int StartCancelableParameterNameTransformState6;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? StartCancelableTransformedNamedArgumentDeclaredTypes6;
 		
 		private static readonly global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> CountAsyncNamedArgumentDeclaredTypes7 = new global::System.Collections.Generic.Dictionary<string, global::System.Type>
 		{
@@ -103,7 +146,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> CountAsyncParameterNames7 = new global::System.Collections.Generic.List<string>
+		{
+			"start",
+			"count",
+		};
+		
 		private string? transformedCountAsync7;
+		private int CountAsyncParameterNameTransformState7;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? CountAsyncTransformedNamedArgumentDeclaredTypes7;
 		
 		public IMyRpc_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -116,17 +167,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("JustCancellationAsync");
 			string __rpcMethodName = this.transformedJustCancellationAsync1 ??= this.TransformMethodName("JustCancellationAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.JustCancellationAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1);
+			    this.JustCancellationAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.JustCancellationAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, JustCancellationAsyncParameterNames1, JustCancellationAsyncPositionalArgumentDeclaredTypes1) :
+			    JustCancellationAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), JustCancellationAsyncNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], JustCancellationAsyncPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("JustCancellationAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.ValueTask global::IMyRpc.AnArgAndCancellationAsync(int arg, global::System.Threading.CancellationToken cancellationToken)
@@ -135,18 +206,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AnArgAndCancellationAsync");
 			string __rpcMethodName = this.transformedAnArgAndCancellationAsync2 ??= this.TransformMethodName("AnArgAndCancellationAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.AnArgAndCancellationAsyncParameterNameTransformState2;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AnArgAndCancellationAsyncParameterNames2);
+			    this.AnArgAndCancellationAsyncParameterNameTransformState2 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AnArgAndCancellationAsyncTransformedNamedArgumentDeclaredTypes2 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AnArgAndCancellationAsyncParameterNames2, AnArgAndCancellationAsyncPositionalArgumentDeclaredTypes2) :
+			    AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), AnArgAndCancellationAsyncNamedArgumentDeclaredTypes2, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [arg], AnArgAndCancellationAsyncPositionalArgumentDeclaredTypes2, cancellationToken);
 			this.OnCalledMethod("AnArgAndCancellationAsync");
 			
 			return new global::System.Threading.Tasks.ValueTask(__result);
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["arg"] = arg,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("arg")] = arg,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["arg"] = arg,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::IMyRpc.AddAsync(int a, int b, global::System.Threading.CancellationToken cancellationToken)
@@ -155,19 +247,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("AddAsync");
 			string __rpcMethodName = this.transformedAddAsync3 ??= this.TransformMethodName("AddAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.AddAsyncParameterNameTransformState3;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, AddAsyncParameterNames3);
+			    this.AddAsyncParameterNameTransformState3 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.AddAsyncTransformedNamedArgumentDeclaredTypes3 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, AddAsyncParameterNames3, AddAsyncPositionalArgumentDeclaredTypes3) :
+			    AddAsyncNamedArgumentDeclaredTypes3;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), AddAsyncNamedArgumentDeclaredTypes3, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], AddAsyncPositionalArgumentDeclaredTypes3, cancellationToken);
 			this.OnCalledMethod("AddAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		global::System.Threading.Tasks.Task<int> global::IMyRpc.MultiplyAsync(int a, int b)
@@ -176,19 +290,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("MultiplyAsync");
 			string __rpcMethodName = this.transformedMultiplyAsync4 ??= this.TransformMethodName("MultiplyAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.MultiplyAsyncParameterNameTransformState4;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, MultiplyAsyncParameterNames4);
+			    this.MultiplyAsyncParameterNameTransformState4 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.MultiplyAsyncTransformedNamedArgumentDeclaredTypes4 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, MultiplyAsyncParameterNames4, MultiplyAsyncPositionalArgumentDeclaredTypes4) :
+			    MultiplyAsyncNamedArgumentDeclaredTypes4;
 			global::System.Threading.Tasks.Task<int> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(), MultiplyAsyncNamedArgumentDeclaredTypes4, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<int>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<int>(__rpcMethodName, [a, b], MultiplyAsyncPositionalArgumentDeclaredTypes4, default);
 			this.OnCalledMethod("MultiplyAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["a"] = a,
-					["b"] = b,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("a")] = a,
+				[this.Options.ParameterNameTransform("b")] = b,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["a"] = a,
+				["b"] = b,
+			    };
+			}
 		}
 		
 		void global::IMyRpc.Start(string bah)
@@ -197,18 +333,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("Start");
 			string __rpcMethodName = this.transformedStart5 ??= this.TransformMethodName("Start", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.StartParameterNameTransformState5;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, StartParameterNames5);
+			    this.StartParameterNameTransformState5 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.StartTransformedNamedArgumentDeclaredTypes5 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, StartParameterNames5, StartPositionalArgumentDeclaredTypes5) :
+			    StartNamedArgumentDeclaredTypes5;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), StartNamedArgumentDeclaredTypes5) :
+			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes) :
 			    this.JsonRpc.NotifyAsync(__rpcMethodName, [bah], StartPositionalArgumentDeclaredTypes5);
 			this.OnCalledMethod("Start");
 			
 			return ;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["bah"] = bah,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("bah")] = bah,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["bah"] = bah,
+			    };
+			}
 		}
 		
 		void global::IMyRpc.StartCancelable(string bah, global::System.Threading.CancellationToken token)
@@ -217,18 +374,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("StartCancelable");
 			string __rpcMethodName = this.transformedStartCancelable6 ??= this.TransformMethodName("StartCancelable", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.StartCancelableParameterNameTransformState6;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, StartCancelableParameterNames6);
+			    this.StartCancelableParameterNameTransformState6 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.StartCancelableTransformedNamedArgumentDeclaredTypes6 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, StartCancelableParameterNames6, StartCancelablePositionalArgumentDeclaredTypes6) :
+			    StartCancelableNamedArgumentDeclaredTypes6;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), StartCancelableNamedArgumentDeclaredTypes6) :
+			    this.JsonRpc.NotifyWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes) :
 			    this.JsonRpc.NotifyAsync(__rpcMethodName, [bah], StartCancelablePositionalArgumentDeclaredTypes6);
 			this.OnCalledMethod("StartCancelable");
 			
 			return ;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["bah"] = bah,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("bah")] = bah,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["bah"] = bah,
+			    };
+			}
 		}
 		
 		global::System.Collections.Generic.IAsyncEnumerable<int> global::IMyRpc.CountAsync(int start, int count, global::System.Threading.CancellationToken cancellationToken)
@@ -237,19 +415,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("CountAsync");
 			string __rpcMethodName = this.transformedCountAsync7 ??= this.TransformMethodName("CountAsync", typeof(global::IMyRpc));
+			int __parameterNameTransformState = this.CountAsyncParameterNameTransformState7;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, CountAsyncParameterNames7);
+			    this.CountAsyncParameterNameTransformState7 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.CountAsyncTransformedNamedArgumentDeclaredTypes7 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, CountAsyncParameterNames7, CountAsyncPositionalArgumentDeclaredTypes7) :
+			    CountAsyncNamedArgumentDeclaredTypes7;
 			global::System.Threading.Tasks.Task<global::System.Collections.Generic.IAsyncEnumerable<int>> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, ConstructNamedArgs(), CountAsyncNamedArgumentDeclaredTypes7, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync<global::System.Collections.Generic.IAsyncEnumerable<int>>(__rpcMethodName, [start, count], CountAsyncPositionalArgumentDeclaredTypes7, cancellationToken);
 			this.OnCalledMethod("CountAsync");
 			
 			return global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateAsyncEnumerableProxy(__result, cancellationToken);
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["start"] = start,
-					["count"] = count,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("start")] = start,
+				[this.Options.ParameterNameTransform("count")] = count,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["start"] = start,
+				["count"] = count,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic/IGenericMarshalable_T_.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic/IGenericMarshalable_T_.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(T),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingWithParameterAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"parameter",
+		};
+		
 		private string? transformedDoSomethingWithParameterAsync1;
+		private int DoSomethingWithParameterAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IGenericMarshalable_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingWithParameterAsync");
 			string __rpcMethodName = this.transformedDoSomethingWithParameterAsync1 ??= this.TransformMethodName("DoSomethingWithParameterAsync", typeof(global::IGenericMarshalable<T>));
+			int __parameterNameTransformState = this.DoSomethingWithParameterAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1);
+			    this.DoSomethingWithParameterAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1, DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<T> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<T>(__rpcMethodName, ConstructNamedArgs(), DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<T>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<T>(__rpcMethodName, [parameter], DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingWithParameterAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["parameter"] = parameter,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("parameter")] = parameter,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["parameter"] = parameter,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_GenericWithClosedPrescriptions/IGenericMarshalable_T_.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_GenericWithClosedPrescriptions/IGenericMarshalable_T_.g.cs
@@ -28,7 +28,14 @@ namespace StreamJsonRpc.Generated
 			typeof(T),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingWithParameterAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"parameter",
+		};
+		
 		private string? transformedDoSomethingWithParameterAsync1;
+		private int DoSomethingWithParameterAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IGenericMarshalable_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -41,18 +48,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingWithParameterAsync");
 			string __rpcMethodName = this.transformedDoSomethingWithParameterAsync1 ??= this.TransformMethodName("DoSomethingWithParameterAsync", typeof(global::IGenericMarshalable<T>));
+			int __parameterNameTransformState = this.DoSomethingWithParameterAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1);
+			    this.DoSomethingWithParameterAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1, DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<T> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<T>(__rpcMethodName, ConstructNamedArgs(), DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<T>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<T>(__rpcMethodName, [parameter], DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingWithParameterAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["parameter"] = parameter,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("parameter")] = parameter,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["parameter"] = parameter,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_GenericWithClosedPrescriptions_Arity2/IGenericMarshalable_T1, T2_.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_GenericWithClosedPrescriptions_Arity2/IGenericMarshalable_T1, T2_.g.cs
@@ -28,7 +28,14 @@ namespace StreamJsonRpc.Generated
 			typeof(T2),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingWithParameterAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"parameter",
+		};
+		
 		private string? transformedDoSomethingWithParameterAsync1;
+		private int DoSomethingWithParameterAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IGenericMarshalable_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -41,18 +48,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingWithParameterAsync");
 			string __rpcMethodName = this.transformedDoSomethingWithParameterAsync1 ??= this.TransformMethodName("DoSomethingWithParameterAsync", typeof(global::IGenericMarshalable<T1, T2>));
+			int __parameterNameTransformState = this.DoSomethingWithParameterAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1);
+			    this.DoSomethingWithParameterAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1, DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task<T1> __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync<T1>(__rpcMethodName, ConstructNamedArgs(), DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync<T1>(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync<T1>(__rpcMethodName, [parameter], DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingWithParameterAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["parameter"] = parameter,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("parameter")] = parameter,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["parameter"] = parameter,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic_WithInModifier/IGenericMarshalable_T_.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic_WithInModifier/IGenericMarshalable_T_.g.cs
@@ -27,7 +27,14 @@ namespace StreamJsonRpc.Generated
 			typeof(T),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingWithParameterAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"parameter",
+		};
+		
 		private string? transformedDoSomethingWithParameterAsync1;
+		private int DoSomethingWithParameterAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IGenericMarshalable_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -40,18 +47,39 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingWithParameterAsync");
 			string __rpcMethodName = this.transformedDoSomethingWithParameterAsync1 ??= this.TransformMethodName("DoSomethingWithParameterAsync", typeof(global::IGenericMarshalable<T>));
+			int __parameterNameTransformState = this.DoSomethingWithParameterAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1);
+			    this.DoSomethingWithParameterAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1, DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [parameter], DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingWithParameterAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["parameter"] = parameter,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("parameter")] = parameter,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["parameter"] = parameter,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic_WithOutModifier/IGenericMarshalable_T_.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_Generic_WithOutModifier/IGenericMarshalable_T_.g.cs
@@ -25,7 +25,13 @@ namespace StreamJsonRpc.Generated
 		{
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> DoSomethingWithParameterAsyncParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+		};
+		
 		private string? transformedDoSomethingWithParameterAsync1;
+		private int DoSomethingWithParameterAsyncParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1;
 		
 		public IGenericMarshalable_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -38,17 +44,37 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("DoSomethingWithParameterAsync");
 			string __rpcMethodName = this.transformedDoSomethingWithParameterAsync1 ??= this.TransformMethodName("DoSomethingWithParameterAsync", typeof(global::IGenericMarshalable<T>));
+			int __parameterNameTransformState = this.DoSomethingWithParameterAsyncParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1);
+			    this.DoSomethingWithParameterAsyncParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.DoSomethingWithParameterAsyncTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, DoSomethingWithParameterAsyncParameterNames1, DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1) :
+			    DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), DoSomethingWithParameterAsyncNamedArgumentDeclaredTypes1, default) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, default) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [], DoSomethingWithParameterAsyncPositionalArgumentDeclaredTypes1, default);
 			this.OnCalledMethod("DoSomethingWithParameterAsync");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-				};
+			        return new()
+			        {
+			        };
+			    }
+			
+			    return new()
+			    {
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_ParameterNameCollision/IAsyncTaskMonitor.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/RpcMarshalable_ParameterNameCollision/IAsyncTaskMonitor.g.cs
@@ -29,7 +29,15 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private static readonly global::System.Collections.Generic.IReadOnlyList<string> OnCompletedParameterNames1 = new global::System.Collections.Generic.List<string>
+		{
+			"rpcMethodName",
+			"result",
+		};
+		
 		private string? transformedOnCompleted1;
+		private int OnCompletedParameterNameTransformState1;
+		private global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type>? OnCompletedTransformedNamedArgumentDeclaredTypes1;
 		
 		public IAsyncTaskMonitor_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
@@ -42,19 +50,41 @@ namespace StreamJsonRpc.Generated
 			
 			this.OnCallingMethod("OnCompleted");
 			string __rpcMethodName = this.transformedOnCompleted1 ??= this.TransformMethodName("OnCompleted", typeof(global::IAsyncTaskMonitor));
+			int __parameterNameTransformState = this.OnCompletedParameterNameTransformState1;
+			if (__parameterNameTransformState == 0)
+			{
+			    __parameterNameTransformState = global::StreamJsonRpc.Reflection.CodeGenHelpers.GetParameterNameTransformState(this.Options.ParameterNameTransform, OnCompletedParameterNames1);
+			    this.OnCompletedParameterNameTransformState1 = __parameterNameTransformState;
+			}
+			
+			bool __useTransformedParameterNames = __parameterNameTransformState == 2;
+			global::System.Collections.Generic.IReadOnlyDictionary<string, global::System.Type> __namedArgumentTypes = __useTransformedParameterNames ?
+			    this.OnCompletedTransformedNamedArgumentDeclaredTypes1 ??= global::StreamJsonRpc.Reflection.CodeGenHelpers.CreateNamedArgumentDeclaredTypes(this.Options.ParameterNameTransform, OnCompletedParameterNames1, OnCompletedPositionalArgumentDeclaredTypes1) :
+			    OnCompletedNamedArgumentDeclaredTypes1;
 			global::System.Threading.Tasks.Task __result = this.Options.ServerRequiresNamedArguments ?
-			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(), OnCompletedNamedArgumentDeclaredTypes1, cancellationToken) :
+			    this.JsonRpc.InvokeWithParameterObjectAsync(__rpcMethodName, ConstructNamedArgs(__useTransformedParameterNames), __namedArgumentTypes, cancellationToken) :
 			    this.JsonRpc.InvokeWithCancellationAsync(__rpcMethodName, [rpcMethodName, result], OnCompletedPositionalArgumentDeclaredTypes1, cancellationToken);
 			this.OnCalledMethod("OnCompleted");
 			
 			return __result;
 			
-			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs()
-			    => new()
+			global::System.Collections.Generic.Dictionary<string, object?> ConstructNamedArgs(bool __useTransformedParameterNames)
+			{
+			    if (__useTransformedParameterNames)
 			    {
-					["rpcMethodName"] = rpcMethodName,
-					["result"] = result,
-				};
+			        return new()
+			        {
+				[this.Options.ParameterNameTransform("rpcMethodName")] = rpcMethodName,
+				[this.Options.ParameterNameTransform("result")] = result,
+			        };
+			    }
+			
+			    return new()
+			    {
+				["rpcMethodName"] = rpcMethodName,
+				["result"] = result,
+			    };
+			}
 		}
 	}
 }

--- a/test/StreamJsonRpc.Analyzer.Tests/Resources/UnsupportedReturnType/IMyService.g.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/Resources/UnsupportedReturnType/IMyService.g.cs
@@ -29,6 +29,8 @@ namespace StreamJsonRpc.Generated
 			typeof(int),
 		};
 		
+		private string? transformedAdd1;
+		
 		public IMyService_Proxy(global::StreamJsonRpc.JsonRpc client, global::StreamJsonRpc.Reflection.ProxyInputs inputs)
 		    : base(client, inputs)
 		{

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -140,6 +140,13 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+    public partial interface IServerWithRenamedParamsObject
+    {
+        [JsonRpcMethod(nameof(Server.SumOfRenamedParameterObject))]
+        Task<int> SumOfParameterObject([JsonRpcParameter("x")] int a, [JsonRpcParameter("y")] int b, CancellationToken cancellationToken);
+    }
+
+    [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     public partial interface IServerWithValueTasks
     {
         ValueTask DoSomethingValueAsync();
@@ -163,6 +170,11 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     public interface IServerWithUnsupportedEventTypes
     {
         event Action MyActionEvent;
+    }
+
+    public interface IDynamicServer
+    {
+        Task<int> AddAsync(int a, int b);
     }
 
     ////[JsonRpcContract] // This would trigger a compile error, but we're testing runtime handling of disallowed members.
@@ -831,6 +843,98 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    public async Task CallServerWithParameterObject_ParameterNameTransform()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        var server = new Server();
+        var serverRpc = new JsonRpc(streams.Item2);
+        serverRpc.AddLocalRpcTarget(server, new JsonRpcTargetOptions { ParameterNameTransform = CommonMethodNameTransforms.Prepend("rpc.") });
+        serverRpc.StartListening();
+
+        var client = new JsonRpc(streams.Item1);
+        var clientRpc = client.Attach<IServer>(new JsonRpcProxyOptions(this.DefaultProxyOptions)
+        {
+            ServerRequiresNamedArguments = true,
+            ParameterNameTransform = CommonMethodNameTransforms.Prepend("rpc."),
+        });
+        client.StartListening();
+
+        int result = await clientRpc.AddAsync(1, 2);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task CallServerWithParameterObject_JsonRpcParameterAttribute()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+        var server = new Server();
+        var serverRpc = JsonRpc.Attach(streams.Item2, server);
+
+        var client = new JsonRpc(streams.Item1);
+        var clientRpc = client.Attach<IServerWithRenamedParamsObject>(new JsonRpcProxyOptions(this.DefaultProxyOptions) { ServerRequiresNamedArguments = true });
+        client.StartListening();
+
+        int result = await clientRpc.SumOfParameterObject(1, 2, this.TimeoutToken);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task CallServerWithParameterObject_IdentityParameterNameTransformCheckedOnce()
+    {
+        int parameterNameTransformInvocationCount = 0;
+        Func<string, string> identityParameterNameTransform = name =>
+        {
+            Interlocked.Increment(ref parameterNameTransformInvocationCount);
+            return name;
+        };
+
+        var streams = FullDuplexStream.CreateStreams();
+        var server = new Server();
+        var serverRpc = JsonRpc.Attach(streams.Item2, server);
+
+        var client = new JsonRpc(streams.Item1);
+        var clientRpc = client.Attach<IServer>(new JsonRpcProxyOptions(this.DefaultProxyOptions)
+        {
+            ServerRequiresNamedArguments = true,
+            ParameterNameTransform = identityParameterNameTransform,
+        });
+        client.StartListening();
+
+        Assert.Equal(3, await clientRpc.AddAsync(1, 2));
+        Assert.Equal(7, await clientRpc.AddAsync(3, 4));
+        Assert.Equal(2, Volatile.Read(ref parameterNameTransformInvocationCount));
+    }
+
+    [Fact]
+    public async Task CallServerWithParameterObject_IdentityParameterNameTransformCheckedOnce_DynamicProxy()
+    {
+        int parameterNameTransformInvocationCount = 0;
+        Func<string, string> identityParameterNameTransform = name =>
+        {
+            Interlocked.Increment(ref parameterNameTransformInvocationCount);
+            return name;
+        };
+
+        var streams = FullDuplexStream.CreateStreams();
+        var server = new Server();
+        var serverRpc = JsonRpc.Attach(streams.Item2, server);
+
+        var client = new JsonRpc(streams.Item1);
+#pragma warning disable StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        var clientRpc = client.Attach<IDynamicServer>(new JsonRpcProxyOptions(this.DefaultProxyOptions)
+        {
+            ServerRequiresNamedArguments = true,
+            ParameterNameTransform = identityParameterNameTransform,
+        });
+#pragma warning restore StreamJsonRpc0003
+        client.StartListening();
+
+        Assert.Equal(3, await clientRpc.AddAsync(1, 2));
+        Assert.Equal(7, await clientRpc.AddAsync(3, 4));
+        Assert.Equal(2, Volatile.Read(ref parameterNameTransformInvocationCount));
+    }
+
+    [Fact]
     public async Task CallServerWithParameterObject_WithCancellationToken()
     {
         var streams = FullDuplexStream.CreateStreams();
@@ -1157,6 +1261,15 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         {
             this.MethodEntered.Set();
             int sum = paramObject.Value<int>("a") + paramObject.Value<int>("b");
+            this.MethodResult.SetResult(sum);
+            await this.ResumeMethod.WaitAsync(cancellationToken);
+            return sum;
+        }
+
+        public async Task<int> SumOfRenamedParameterObject(Newtonsoft.Json.Linq.JToken paramObject, CancellationToken cancellationToken)
+        {
+            this.MethodEntered.Set();
+            int sum = paramObject.Value<int>("x") + paramObject.Value<int>("y");
             this.MethodResult.SetResult(sum);
             await this.ResumeMethod.WaitAsync(cancellationToken);
             return sum;

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyOptionsTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyOptionsTests.cs
@@ -7,6 +7,7 @@ public class JsonRpcProxyOptionsTests
     public void DefaultIsFrozen()
     {
         Assert.Throws<InvalidOperationException>(() => JsonRpcProxyOptions.Default.MethodNameTransform = s => s);
+        Assert.Throws<InvalidOperationException>(() => JsonRpcProxyOptions.Default.ParameterNameTransform = s => s);
         Assert.Throws<InvalidOperationException>(() => JsonRpcProxyOptions.Default.EventNameTransform = s => s);
         Assert.Throws<InvalidOperationException>(() => JsonRpcProxyOptions.Default.ServerRequiresNamedArguments = true);
     }
@@ -17,6 +18,7 @@ public class JsonRpcProxyOptionsTests
         JsonRpcProxyOptions options = new()
         {
             MethodNameTransform = s => s,
+            ParameterNameTransform = s => s,
             EventNameTransform = s => s,
             ServerRequiresNamedArguments = true,
         };

--- a/test/StreamJsonRpc.Tests/JsonRpcTargetOptionsTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTargetOptionsTests.cs
@@ -15,6 +15,7 @@ public class JsonRpcTargetOptionsTests
         options.DisposeOnDisconnect = !options.DisposeOnDisconnect;
         options.EventNameTransform = s => s;
         options.MethodNameTransform = s => s;
+        options.ParameterNameTransform = s => s;
         options.NotifyClientOfEvents = !options.NotifyClientOfEvents;
         options.UseSingleObjectParameterDeserialization = !options.UseSingleObjectParameterDeserialization;
 
@@ -24,6 +25,7 @@ public class JsonRpcTargetOptionsTests
         Assert.Equal(options.DisposeOnDisconnect, copy.DisposeOnDisconnect);
         Assert.Equal(options.EventNameTransform, copy.EventNameTransform);
         Assert.Equal(options.MethodNameTransform, copy.MethodNameTransform);
+        Assert.Equal(options.ParameterNameTransform, copy.ParameterNameTransform);
         Assert.Equal(options.NotifyClientOfEvents, copy.NotifyClientOfEvents);
         Assert.Equal(options.UseSingleObjectParameterDeserialization, copy.UseSingleObjectParameterDeserialization);
     }

--- a/test/StreamJsonRpc.Tests/JsonRpcTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcTests.cs
@@ -1739,6 +1739,46 @@ public abstract partial class JsonRpcTests : TestBase
     }
 
     [Fact]
+    public async Task AddLocalRpcTarget_JsonRpcParameterAttribute()
+    {
+        var streams = FullDuplexStream.CreatePair();
+        var rpc = new JsonRpc(streams.Item1, streams.Item2);
+        rpc.AddLocalRpcTarget(new Server());
+        rpc.StartListening();
+
+        int result = await rpc.InvokeWithParameterObjectAsync<int>(
+            nameof(Server.MethodWithRenamedParameters),
+            new Dictionary<string, object?> { ["left"] = 1, ["right"] = 2 },
+            this.TimeoutToken);
+        Assert.Equal(3, result);
+
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeWithParameterObjectAsync<int>(
+            nameof(Server.MethodWithRenamedParameters),
+            new Dictionary<string, object?> { ["a"] = 1, ["b"] = 2 },
+            this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task AddLocalRpcTarget_ParameterNameTransformAndJsonRpcParameterAttribute()
+    {
+        var streams = FullDuplexStream.CreatePair();
+        var rpc = new JsonRpc(streams.Item1, streams.Item2);
+        rpc.AddLocalRpcTarget(new Server(), new JsonRpcTargetOptions { ParameterNameTransform = CommonMethodNameTransforms.Prepend("rpc.") });
+        rpc.StartListening();
+
+        int result = await rpc.InvokeWithParameterObjectAsync<int>(
+            nameof(Server.MethodWithRenamedParameters),
+            new Dictionary<string, object?> { ["rpc.left"] = 1, ["rpc.right"] = 2 },
+            this.TimeoutToken);
+        Assert.Equal(3, result);
+
+        await Assert.ThrowsAsync<RemoteMethodNotFoundException>(() => rpc.InvokeWithParameterObjectAsync<int>(
+            nameof(Server.MethodWithRenamedParameters),
+            new Dictionary<string, object?> { ["left"] = 1, ["right"] = 2 },
+            this.TimeoutToken));
+    }
+
+    [Fact]
     public async Task AddLocalRpcMethod_ActionWith0Args()
     {
         this.ReinitializeRpcWithoutListening();
@@ -3474,6 +3514,11 @@ public abstract partial class JsonRpcTests : TestBase
         public static int MethodWithOneNonObjectParameter(int x)
         {
             return x;
+        }
+
+        public static int MethodWithRenamedParameters([JsonRpcParameter("left")] int a, [JsonRpcParameter("right")] int b)
+        {
+            return a + b;
         }
 
         [JsonRpcMethod("test/MethodWithSingleObjectParameter", UseSingleObjectParameterDeserialization = true)]


### PR DESCRIPTION
## Motivation

Closes #1441. Today, when named arguments are used, JSON-RPC parameter names are always the raw CLR parameter names and cannot be customized. This PR adds two complementary mechanisms - an attribute for per-parameter renames and a transform function for bulk/convention-based renames - mirroring the existing method-name customization APIs.

## Approach

### New public API

- **`JsonRpcParameterAttribute`** - applied to individual parameters to supply an explicit RPC name (like `JsonRpcMethodAttribute` for methods).
- **`JsonRpcTargetOptions.ParameterNameTransform`** (`Func<string,string>?`) - applied server-side when binding named arguments from an incoming request.
- **`JsonRpcProxyOptions.ParameterNameTransform`** (`Func<string,string>`) - applied client-side when emitting named-argument keys in the outgoing request; identity default, freeze-aware.

Name precedence for a parameter: CLR name -> overridden by `[JsonRpcParameter(Name = ...)]` -> transformed by `ParameterNameTransform`.

### Server-side dispatch

`MethodSignatureAndTarget` computes effective parameter names from the attribute + transform. `TargetMethod.TryGetArguments` passes those names to a new three-argument `JsonRpcRequest.TryGetTypedArguments` overload for named-argument lookup. When no names are changed (empty span), the existing two-argument code path is used unchanged - no extra allocations.

### Dynamic proxy (IL emit)

`JsonRpcParameterAttribute` names are baked into a static `string[]` at proxy-type-creation time (zero runtime cost). For the transform, `CodeGenHelpers.GetParameterNameTransformState` evaluates the transform lazily on first use, caches the result via a `ConditionalWeakTable`-backed dictionary (so delegate instances are not strongly rooted), and branches: identity state takes the existing parameter-object path; transformed state builds a `Dictionary<string,object?>` and calls the four-argument `InvokeWithParameterObjectAsync`/`NotifyWithParameterObjectAsync` overloads.

### Source-generated proxy

`ParameterModel` reads `JsonRpcParameterAttribute` at generation time and records `RpcName`. `MethodModel` emits:

- A static `string[]` field with the RPC names (burned in, zero runtime cost for attribute renames).
- A per-instance `int` transform-state field (0=unknown, 1=unchanged, 2=transformed) populated lazily via `CodeGenHelpers.GetParameterNameTransformState` on first invocation.
- A lazy cached `IReadOnlyDictionary<string,Type>` for the transformed declared-types map.
- A `ConstructNamedArgs(bool)` local method that picks the right names.

When the default identity transform is in use, the `ReferenceEquals` fast-path in `GetParameterNameTransformState` returns "unchanged" immediately with no per-parameter probing.

### Formatter parity

All five `InboundJsonRpcRequest` subclasses (`JsonMessageFormatter`, `SystemTextJsonFormatter`, `PolyTypeJsonFormatter`, `MessagePackFormatter`, `NerdbankMessagePackFormatter`) now override the three-argument `TryGetTypedArguments` so their formatter-specific logic (`UseSingleObjectParameterDeserialization`, `JToken` special-casing, etc.) is preserved when custom names are in use. The two-argument override now delegates to the three-argument one to avoid duplication.

## Testing

- **`JsonRpcTests` (formatter-matrix)** - `AddLocalRpcTarget_JsonRpcParameterAttribute` and `AddLocalRpcTarget_ParameterNameTransformAndJsonRpcParameterAttribute` run across all formatter combinations.
- **`JsonRpcProxyGenerationTests`** - new tests for source-generated and dynamic proxy attribute renames, transform renames, and verification that the identity transform is only checked once (not per-call) in both proxy implementations.
- **`JsonRpcProxyOptionsTests` / `JsonRpcTargetOptionsTests`** - copy/freeze coverage for the new `ParameterNameTransform` properties.