### PR TITLE
Optimize parameter rename support

### DIFF
--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -9,17 +9,18 @@ using System.Runtime.CompilerServices;
 namespace StreamJsonRpc;
 
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
-internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
+internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 {
-    private readonly ReadOnlyMemory<string?> parameterNamesExcludingCancellationToken;
+    private readonly Func<string, string>? parameterNameTransform;
+    private ReadOnlyMemory<string?>? parameterNamesExcludingCancellationToken;
 
     internal MethodSignatureAndTarget(RpcTargetMetadata.TargetMethodMetadata signature, object? target, JsonRpcMethodAttribute? attribute, SynchronizationContext? perMethodSynchronizationContext, Func<string, string>? parameterNameTransform = null)
     {
         this.Signature = signature;
         this.Target = target;
         this.SynchronizationContext = perMethodSynchronizationContext;
+        this.parameterNameTransform = parameterNameTransform;
         this.Attribute = attribute ?? signature.Attribute;
-        this.parameterNamesExcludingCancellationToken = GetEffectiveParameterNames(signature, parameterNameTransform);
     }
 
     internal RpcTargetMetadata.TargetMethodMetadata Signature { get; }
@@ -30,7 +31,7 @@ internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 
     internal SynchronizationContext? SynchronizationContext { get; }
 
-    internal ReadOnlySpan<string?> ParameterNamesExcludingCancellationToken => this.parameterNamesExcludingCancellationToken.Span;
+    internal ReadOnlySpan<string?> ParameterNamesExcludingCancellationToken => (this.parameterNamesExcludingCancellationToken ??= GetEffectiveParameterNames(this.Signature, this.parameterNameTransform)).Span;
 
     [ExcludeFromCodeCoverage]
     private string DebuggerDisplay => this.ToString();
@@ -43,10 +44,9 @@ internal struct MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     }
 
     /// <inheritdoc/>
-    public bool Equals(MethodSignatureAndTarget other)
+    public bool Equals(MethodSignatureAndTarget? other)
     {
-        return this.Signature.Equals(other.Signature)
-            && object.ReferenceEquals(this.Target, other.Target);
+        return other is not null && this.Signature.Equals(other.Signature) && object.ReferenceEquals(this.Target, other.Target);
     }
 
     /// <inheritdoc/>

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -12,6 +12,10 @@ namespace StreamJsonRpc;
 internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 {
     private readonly Func<string, string>? parameterNameTransform;
+
+    /// <summary>
+    /// The list of RPC parameter names, or an empty list if we're using the ordinary CLR parameter names.
+    /// </summary>
     private ReadOnlyMemory<string?>? parameterNamesExcludingCancellationToken;
 
     internal MethodSignatureAndTarget(RpcTargetMetadata.TargetMethodMetadata signature, object? target, JsonRpcMethodAttribute? attribute, SynchronizationContext? perMethodSynchronizationContext, Func<string, string>? parameterNameTransform = null)
@@ -58,10 +62,16 @@ internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     /// <inheritdoc/>
     public override string ToString() => $"{this.Signature} ({this.Target})";
 
+    /// <summary>
+    /// Gets the RPC parameter names for a method, excluding any <see cref="CancellationToken"/> parameter.
+    /// </summary>
+    /// <param name="signature">The method signature.</param>
+    /// <param name="parameterNameTransform">A runtime-supplied transform for parameter names.</param>
+    /// <returns>The list of RPC parameter names, or an empty list if we're using the ordinary CLR parameter names.</returns>
     private static ReadOnlyMemory<string?> GetEffectiveParameterNames(RpcTargetMetadata.TargetMethodMetadata signature, Func<string, string>? parameterNameTransform)
     {
         int parameterCount = signature.TotalParamCountExcludingCancellationToken;
-        if (parameterCount == 0)
+        if (parameterCount == 0 || (parameterNameTransform is null && !signature.HasRenamedParameters))
         {
             return ReadOnlyMemory<string?>.Empty;
         }
@@ -70,7 +80,7 @@ internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
         for (int i = 0; i < parameterCount; i++)
         {
             ParameterInfo parameter = signature.Parameters[i];
-            string? parameterName = parameter.GetCustomAttribute<JsonRpcParameterAttribute>()?.Name ?? parameter.Name;
+            string? parameterName = signature.ParameterNames[i];
             if (parameterNameTransform is not null && parameterName is not null)
             {
                 parameterName = parameterNameTransform(parameterName);

--- a/src/StreamJsonRpc/RpcTargetMetadata.cs
+++ b/src/StreamJsonRpc/RpcTargetMetadata.cs
@@ -730,7 +730,13 @@ public class RpcTargetMetadata
     [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
     public class TargetMethodMetadata
     {
+        private readonly object syncObject = new();
+
         private ParameterInfo[]? parameters;
+
+        private string?[]? parameterNames;
+
+        private bool hasRenamedParameters;
 
         internal TargetMethodMetadata(MethodInfo method, JsonRpcMethodAttribute? attribute, IMethodShape? shape, MethodShapeAttribute? methodShapeAttribute)
         {
@@ -782,6 +788,33 @@ public class RpcTargetMetadata
         /// </summary>
         /// <seealso cref="Parameters"/>
         internal ReadOnlyMemory<ParameterInfo> ParametersMemory => (ParameterInfo[])this.Parameters;
+
+        /// <summary>
+        /// Gets the statically known names of the parameters on the method.
+        /// </summary>
+        /// <remarks>
+        /// This defaults to the names of the parameters as defined in the method signature, but can be overridden by <see cref="JsonRpcParameterAttribute"/> on a parameter.
+        /// </remarks>
+        internal ReadOnlySpan<string?> ParameterNames
+        {
+            get
+            {
+                this.EnsureParameterNamesInitialized();
+                return this.parameterNames;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether any parameter has a unique RPC name specified by <see cref="JsonRpcParameterAttribute"/>.
+        /// </summary>
+        internal bool HasRenamedParameters
+        {
+            get
+            {
+                this.EnsureParameterNamesInitialized();
+                return this.hasRenamedParameters;
+            }
+        }
 
         internal Type ReturnType => this.MethodInfo.ReturnType;
 
@@ -845,6 +878,34 @@ public class RpcTargetMetadata
             }
 
             return false;
+        }
+
+        [MemberNotNull(nameof(parameterNames))]
+        private void EnsureParameterNamesInitialized()
+        {
+            lock (this.syncObject)
+            {
+                if (this.parameterNames is null)
+                {
+                    ReadOnlySpan<ParameterInfo> parameters = this.ParametersMemory.Span;
+                    var parameterNames = new string?[this.Parameters.Count];
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        ParameterInfo parameter = parameters[i];
+                        string? parameterName = parameter.Name;
+
+                        if (parameter.GetCustomAttribute<JsonRpcParameterAttribute>()?.Name is string renamed && renamed != parameterName)
+                        {
+                            parameterName = renamed;
+                            this.hasRenamedParameters = true;
+                        }
+
+                        parameterNames[i] = parameterName;
+                    }
+
+                    this.parameterNames = parameterNames;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This defers and caches work around looking for customized parameter names.

In particular it should avoid an image load regression we found while inserting #1473 into VS.