### PR TITLE
Target analyzers at .NET 8 SDK

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,11 +7,11 @@
 	],
 	"packageRules": [
 		{
-			"matchPackageNames": [ "Microsoft.AspNetCore.TestHost" ],
+			"matchPackageNames": ["Microsoft.AspNetCore.TestHost"],
 			"allowedVersions": "<2.4"
 		},
 		{
-			"matchJsonata": [ "sharedVariableName='RoslynVersionForAnalyzers'" ],
+			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
 		}
 	]

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,5 +5,7 @@
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
 
+  <Import Project="Directory.Packages.Analyzers.props" Condition="'$(IsAnalyzerProject)'=='true'" />
+
   <Import Project="Directory.Traversal.targets" Condition="'$(IsTraversal)'=='true'" />
 </Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <!-- Roslyn 4.11 is what .NET 8 SDK uses.-->
+    <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Update="System.IO.Pipelines" Version="8.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersionForAnalyzers)" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,14 +1,21 @@
 <Project>
+  <!-- These versions are chosen to support the .NET 8 SDK. -->
   <PropertyGroup>
-    <!-- Roslyn 4.11 is what .NET 8 SDK uses.-->
-    <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
+    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Update="System.IO.Pipelines" Version="8.0.0" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.1" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersionForAnalyzers)" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(RoslynVersion)" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,7 @@
     <MicrosoftTestingPlatformVersion>2.3.0</MicrosoftTestingPlatformVersion>
     <MessagePackVersion>2.5.302</MessagePackVersion>
     <MicroBuildVersion>2.0.226</MicroBuildVersion>
-    <RoslynVersion>5.3.0</RoslynVersion>
-    <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
-    <CodeAnalysisAnalyzerVersion>4.14.0</CodeAnalysisAnalyzerVersion>
+    <RoslynVersion>5.6.0</RoslynVersion>
     <VisualStudioThreadingVersion>17.14.15</VisualStudioThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -45,14 +43,6 @@
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
     <PackageVersion Include="xunit.stafact" Version="3.0.13" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
-    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Update="System.IO.Pipelines" Version="8.0.0" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.1" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersionForAnalyzers)" />
-  </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
@@ -63,8 +53,8 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(CodeAnalysisAnalyzerVersion)" />
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25218.8" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,9 +3,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <ItemGroup>
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="10.0.1" />
     <PackageVersion Update="System.IO.Pipelines" Version="10.0.8" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="9.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="10.0.1" />
     <PackageVersion Update="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This carefully controls dependencies so the analyzers will run on the .NET 8 SDK.It also ensures that all such dependency versions are specified in a dedicated file so that renovate won't try to update those versions.