### PR TITLE
Accept null JSON-RPC params consistently

### DIFF
--- a/src/StreamJsonRpc/FormatterBase.cs
+++ b/src/StreamJsonRpc/FormatterBase.cs
@@ -52,6 +52,8 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
 
     private bool serializingRequest;
 
+    private int nullParamsWarningEmitted;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FormatterBase"/> class.
     /// </summary>
@@ -248,6 +250,21 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
         }
 
         return type;
+    }
+
+    /// <summary>
+    /// Traces the first occurrence of a JSON-RPC message with an explicit <see langword="null"/> value for its <c>params</c> property.
+    /// </summary>
+    private protected void TraceNullParamsProtocolViolation()
+    {
+        JsonRpc? jsonRpc = this.JsonRpc;
+        if (jsonRpc is not null && Interlocked.Exchange(ref this.nullParamsWarningEmitted, 1) == 0)
+        {
+            jsonRpc.TraceSource.TraceEvent(
+                TraceEventType.Warning,
+                (int)JsonRpc.TraceEvents.NonFatalProtocolViolation,
+                "The remote party sent a JSON-RPC message with a null \"params\" property. Treating it as omitted, although the JSON-RPC protocol requires \"params\" to be an object or array when present.");
+        }
     }
 
     private protected abstract MessageFormatterRpcMarshaledContextTracker CreateMessageFormatterRpcMarshaledContextTracker(JsonRpc rpc);

--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -595,6 +595,11 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
         // We leave arguments as JTokens at this point, so that we can try deserializing them
         // to more precise .NET types as required by the method we're invoking.
         JToken? args = json["params"];
+        if (args?.Type == JTokenType.Null)
+        {
+            this.TraceNullParamsProtocolViolation();
+        }
+
         object? arguments =
             args is JObject argsObject ? PartiallyParseNamedArguments(argsObject) :
             args is JArray argsArray ? (object)PartiallyParsePositionalArguments(argsArray) :

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -457,6 +457,11 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
         /// An error occurred while deserializing a value within an <see cref="IFormatterConverter"/> interface.
         /// </summary>
         IFormatterConverterDeserializationFailure,
+
+        /// <summary>
+        /// The remote party violated the JSON-RPC protocol in a way that did not require terminating the connection.
+        /// </summary>
+        NonFatalProtocolViolation,
     }
 
     /// <summary>

--- a/src/StreamJsonRpc/MessagePackFormatter.cs
+++ b/src/StreamJsonRpc/MessagePackFormatter.cs
@@ -1570,6 +1570,7 @@ public class MessagePackFormatter : FormatterBase, IJsonRpcMessageFormatter, IJs
                             result.MsgPackNamedArguments = namedArgs;
                             break;
                         case MessagePackType.Nil:
+                            this.formatter.TraceNullParamsProtocolViolation();
                             result.MsgPackPositionalArguments = Array.Empty<ReadOnlySequence<byte>>();
                             reader.ReadNil();
                             break;

--- a/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
+++ b/src/StreamJsonRpc/NerdbankMessagePackFormatter.cs
@@ -468,6 +468,7 @@ public partial class NerdbankMessagePackFormatter : FormatterBase, IJsonRpcMessa
                             result.MsgPackNamedArguments = namedArgs;
                             break;
                         case MessagePackType.Nil:
+                            formatter.TraceNullParamsProtocolViolation();
                             result.MsgPackPositionalArguments = [];
                             reader.ReadNil();
                             break;

--- a/src/StreamJsonRpc/PolyTypeJsonFormatter.cs
+++ b/src/StreamJsonRpc/PolyTypeJsonFormatter.cs
@@ -534,10 +534,16 @@ public partial class PolyTypeJsonFormatter : FormatterBase, IJsonRpcMessageForma
             get => this.jsonArguments;
             init
             {
-                this.jsonArguments = value;
-                if (value.HasValue)
+                if (value?.ValueKind == JsonValueKind.Null)
                 {
-                    this.argumentCount = CountArguments(value.Value);
+                    this.formatter.TraceNullParamsProtocolViolation();
+                    this.jsonArguments = null;
+                    this.argumentCount = 0;
+                }
+                else
+                {
+                    this.jsonArguments = value;
+                    this.argumentCount = value.HasValue ? CountArguments(value.Value) : null;
                 }
             }
         }

--- a/src/StreamJsonRpc/SystemTextJsonFormatter.cs
+++ b/src/StreamJsonRpc/SystemTextJsonFormatter.cs
@@ -491,10 +491,16 @@ public partial class SystemTextJsonFormatter : FormatterBase, IJsonRpcMessageFor
             get => this.jsonArguments;
             init
             {
-                this.jsonArguments = value;
-                if (value.HasValue)
+                if (value?.ValueKind == JsonValueKind.Null)
                 {
-                    this.argumentCount = CountArguments(value.Value);
+                    this.formatter.TraceNullParamsProtocolViolation();
+                    this.jsonArguments = null;
+                    this.argumentCount = 0;
+                }
+                else
+                {
+                    this.jsonArguments = value;
+                    this.argumentCount = value.HasValue ? CountArguments(value.Value) : null;
                 }
             }
         }

--- a/test/StreamJsonRpc.Tests/NullParamsTests.cs
+++ b/test/StreamJsonRpc.Tests/NullParamsTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Text;
+using MessagePack;
+using Nerdbank.Streams;
+using PolyType.ReflectionProvider;
+
+#pragma warning disable PolyTypeJson
+
+public class NullParamsTests
+{
+    private static readonly byte[] JsonRequest = Encoding.UTF8.GetBytes("""{"jsonrpc":"2.0","id":1,"method":"test","params":null}""");
+
+    private static readonly byte[] MessagePackRequest = CreateMessagePackRequest();
+
+    public static IEnumerable<object[]> Formatters
+    {
+        get
+        {
+            yield return [new JsonMessageFormatter()];
+            yield return [new SystemTextJsonFormatter()];
+            yield return [new PolyTypeJsonFormatter { TypeShapeProvider = ReflectionTypeShapeProvider.Default }];
+            yield return [new MessagePackFormatter()];
+            yield return [new NerdbankMessagePackFormatter { TypeShapeProvider = ReflectionTypeShapeProvider.Default }];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Formatters))]
+    public void NullParamsAreAcceptedAndWarnedAboutOnce(IJsonRpcMessageFormatter formatter)
+    {
+        byte[] request = formatter is MessagePackFormatter or NerdbankMessagePackFormatter ? MessagePackRequest : JsonRequest;
+        var listener = new CollectingTraceListener();
+        using var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(Stream.Null, formatter))
+        {
+            TraceSource = new TraceSource(formatter.GetType().Name, SourceLevels.Warning)
+            {
+                Listeners = { listener },
+            },
+        };
+
+        JsonRpcRequest firstRequest = Assert.IsAssignableFrom<JsonRpcRequest>(formatter.Deserialize(new ReadOnlySequence<byte>(request)));
+        JsonRpcRequest secondRequest = Assert.IsAssignableFrom<JsonRpcRequest>(formatter.Deserialize(new ReadOnlySequence<byte>(request)));
+
+        Assert.Equal(0, firstRequest.ArgumentCount);
+        Assert.Equal(0, secondRequest.ArgumentCount);
+        (TraceEventType EventType, string? Message) warning = Assert.Single(
+            listener.Events,
+            e => e.EventType == TraceEventType.Warning && e.Message?.Contains("\"params\"", StringComparison.Ordinal) is true);
+        Assert.Contains("remote party", warning.Message, StringComparison.Ordinal);
+    }
+
+    private static byte[] CreateMessagePackRequest()
+    {
+        using var buffer = new Sequence<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(4);
+        writer.Write("jsonrpc");
+        writer.Write("2.0");
+        writer.Write("id");
+        writer.Write(1);
+        writer.Write("method");
+        writer.Write("test");
+        writer.Write("params");
+        writer.WriteNil();
+        writer.Flush();
+        return buffer.AsReadOnlySequence.ToArray();
+    }
+}


### PR DESCRIPTION
`SystemTextJsonFormatter` and `PolyTypeJsonFormatter` rejected explicit `null` parameters even though the Newtonsoft JSON and MessagePack formatters already treated them as omitted. This inconsistency could terminate an otherwise usable connection for clients that send `"params": null`.

This change standardizes all bundled formatters on accepting explicit `null` or `nil` parameters as omitted. Because the value is still a protocol violation, the receiving connection emits a `NonFatalProtocolViolation` warning the first time it encounters one, without flooding logs on repeated messages.

The regression theory exercises every bundled formatter and verifies both argument normalization and the once-per-connection warning.

Fixes #1504