### PR TITLE
Reject by-reference parameters in RPC proxies

### DIFF
--- a/src/StreamJsonRpc.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/StreamJsonRpc.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,6 +20,7 @@ StreamJsonRpc0013 | Usage | Error | RPC contracts may not include generic method
 StreamJsonRpc0014 | Usage | Error | CancellationToken may only appear as the last parameter
 StreamJsonRpc0015 | Usage | Error | RPC contracts may not be generic interfaces
 StreamJsonRpc0016 | Usage | Error | Unsupported event delegate type
+StreamJsonRpc0017 | Usage | Error | Unsupported by-reference parameter
 StreamJsonRpc0030 | Usage | Error | `JsonRpcProxyAttribute<T>` should be applied only to generic interfaces.
 StreamJsonRpc0031 | Usage | Error | `JsonRpcProxyAttribute<T>` type argument should be a closed instance of the applied type.
 StreamJsonRpc0032 | Usage | Error | `JsonRpcProxyAttribute<T>` should be accompanied by another contract attribute.

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/MethodModel.cs
@@ -44,7 +44,7 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
     };
 
     [MemberNotNullWhen(true, nameof(ReturnExpression))]
-    private bool IsSupported => this.ReturnExpression is not null;
+    private bool IsSupported => this.ReturnExpression is not null && this.Parameters.All(p => p.IsSupported);
 
     internal override void WriteFields(SourceWriter writer)
     {
@@ -144,17 +144,27 @@ internal record MethodModel(string DeclaringInterfaceName, string Name, string R
 
         writer.WriteLine($$"""
 
-                {{this.ReturnType}} {{this.DeclaringInterfaceName}}.{{this.Name}}({{string.Join(", ", this.Parameters.Select(p => $"{p.Type} {p.Name}"))}})
+                {{this.ReturnType}} {{this.DeclaringInterfaceName}}.{{this.Name}}({{string.Join(", ", this.Parameters.Select(p => p.Declaration))}})
                 {
                 """);
 
         writer.Indentation++;
         if (!this.IsSupported)
         {
-            // StreamJsonRpc0011
-            writer.WriteLine($"""
-                    throw new global::System.NotSupportedException($"The return type '{this.ReturnType}' is not supported by the generated proxy method.");
-                    """);
+            if (this.Parameters.FirstOrDefault(p => !p.IsSupported) is { } unsupportedParameter)
+            {
+                // StreamJsonRpc0017
+                writer.WriteLine($"""
+                        throw new global::System.NotSupportedException("By-reference parameter '{unsupportedParameter.Name}' is not supported by generated proxy methods.");
+                        """);
+            }
+            else
+            {
+                // StreamJsonRpc0011
+                writer.WriteLine($"""
+                        throw new global::System.NotSupportedException($"The return type '{this.ReturnType}' is not supported by the generated proxy method.");
+                        """);
+            }
         }
         else
         {

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/ParameterModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/ParameterModel.cs
@@ -6,8 +6,12 @@ using Microsoft.CodeAnalysis;
 
 namespace StreamJsonRpc.Analyzers.GeneratorModels;
 
-internal record ParameterModel(string Name, string RpcName, string Type, string TypeNoNullRefAnnotations, RpcSpecialType SpecialType)
+internal record ParameterModel(string Name, string RpcName, string Type, string TypeNoNullRefAnnotations, RpcSpecialType SpecialType, RefKind RefKind)
 {
+    internal string Declaration => $"{this.RefKind switch { RefKind.In => "in ", RefKind.Out => "out ", RefKind.Ref => "ref ", RefKind.RefReadOnlyParameter => "ref readonly ", _ => string.Empty }}{this.Type} {this.Name}";
+
+    internal bool IsSupported => this.RefKind is RefKind.None;
+
     internal static ParameterModel Create(IParameterSymbol parameter, KnownSymbols symbols)
     {
         AttributeData? jsonRpcParameterAttribute = parameter.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbols.JsonRpcParameterAttribute));
@@ -18,6 +22,7 @@ internal record ParameterModel(string Name, string RpcName, string Type, string 
             rpcName,
             parameter.Type.ToDisplayString(ProxyGenerator.FullyQualifiedWithNullableFormat),
             parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-            ProxyGenerator.ClassifySpecialType(parameter.Type, symbols));
+            ProxyGenerator.ClassifySpecialType(parameter.Type, symbols),
+            parameter.RefKind);
     }
 }

--- a/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
+++ b/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
@@ -78,6 +78,11 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
     public const string UnsupportedEventDelegateId = "StreamJsonRpc0016";
 
     /// <summary>
+    /// Diagnostic ID for StreamJsonRpc0017: RPC methods may not declare by-reference parameters.
+    /// </summary>
+    public const string UnsupportedByRefParameterId = "StreamJsonRpc0017";
+
+    /// <summary>
     /// Diagnostic for StreamJsonRpc0001: Inaccessible interface.
     /// </summary>
     public static readonly DiagnosticDescriptor InaccessibleInterface = new(
@@ -221,6 +226,18 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: AnalyzerUtilities.GetHelpLink(UnsupportedEventDelegateId));
 
+    /// <summary>
+    /// Diagnostic for StreamJsonRpc0017: Unsupported by-reference parameter.
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnsupportedByRefParameter = new(
+        id: UnsupportedByRefParameterId,
+        title: Strings.StreamJsonRpc0017_Title,
+        messageFormat: Strings.StreamJsonRpc0017_MessageFormat,
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: AnalyzerUtilities.GetHelpLink(UnsupportedByRefParameterId));
+
     private static readonly SymbolDisplayFormat NameOnly = new();
 
     /// <inheritdoc/>
@@ -237,6 +254,7 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
         CancellationTokenPosition,
         NoGenericInterface,
         UnsupportedEventDelegate,
+        UnsupportedByRefParameter,
     ];
 
     /// <inheritdoc/>
@@ -471,6 +489,17 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
                 location,
                 addl,
                 method.ReturnType.Name,
+                method.ToDisplayString(memberFormat)));
+        }
+
+        foreach (IParameterSymbol parameter in method.Parameters.Where(p => p.RefKind is not RefKind.None))
+        {
+            Location diagnosticLocation = parameter.Locations.FirstOrDefault() ?? Location.None;
+            ReportMemberDiagnostic(context, namedType, method, diagnosticLocation, (location, addl, memberFormat) => Diagnostic.Create(
+                UnsupportedByRefParameter,
+                location,
+                addl,
+                parameter.Name,
                 method.ToDisplayString(memberFormat)));
         }
 

--- a/src/StreamJsonRpc.Analyzers/Strings.resx
+++ b/src/StreamJsonRpc.Analyzers/Strings.resx
@@ -163,7 +163,7 @@
     <value>Unsupported by-reference parameter</value>
   </data>
   <data name="StreamJsonRpc0017_MessageFormat" xml:space="preserve">
-    <value>Parameter {0} on RPC method {1} may not use the in, ref, or out modifier.</value>
+    <value>Parameter {0} on RPC method {1} may not use a by-reference modifier.</value>
   </data>
   <data name="StreamJsonRpc0002_Title" xml:space="preserve">
     <value>Declare partial interface</value>

--- a/src/StreamJsonRpc.Analyzers/Strings.resx
+++ b/src/StreamJsonRpc.Analyzers/Strings.resx
@@ -159,6 +159,12 @@
   <data name="StreamJsonRpc0016_MessageFormat" xml:space="preserve">
     <value>RPC contract events must be declared with either `EventHandler` or `EventHandler&lt;T&gt;` delegate types.</value>
   </data>
+  <data name="StreamJsonRpc0017_Title" xml:space="preserve">
+    <value>Unsupported by-reference parameter</value>
+  </data>
+  <data name="StreamJsonRpc0017_MessageFormat" xml:space="preserve">
+    <value>Parameter {0} on RPC method {1} may not use the in, ref, or out modifier.</value>
+  </data>
   <data name="StreamJsonRpc0002_Title" xml:space="preserve">
     <value>Declare partial interface</value>
   </data>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -303,6 +303,10 @@ internal static class ProxyGeneration
                         VerifySupported(returnTypeIsVoid || returnTypeIsTask || returnTypeIsValueTask || returnTypeIsIAsyncEnumerable, Resources.UnsupportedMethodReturnTypeOnClientProxyInterface, method, method.ReturnType.FullName!);
                         VerifySupported(!method.IsGenericMethod, Resources.UnsupportedGenericMethodsOnClientProxyInterface, method);
 
+                        ParameterInfo[] methodParameters = method.GetParameters();
+                        ParameterInfo? unsupportedByRefParameter = methodParameters.FirstOrDefault(p => p.ParameterType.IsByRef);
+                        VerifySupported(unsupportedByRefParameter is null, Resources.UnsupportedByRefParameterOnClientProxyInterface, method, unsupportedByRefParameter?.Name!);
+
                         bool hasReturnValue = method.ReturnType.GetTypeInfo().IsGenericType;
                         Type? invokeResultTypeArgument = hasReturnValue
                             ? (returnTypeIsIAsyncEnumerable ? method.ReturnType : method.ReturnType.GetTypeInfo().GenericTypeArguments[0])
@@ -316,7 +320,6 @@ internal static class ProxyGeneration
                             rpcMethodName = $"{rpcInterfaceCode}.{rpcMethodName}";
                         }
 
-                        ParameterInfo[] methodParameters = method.GetParameters();
                         MethodBuilder methodBuilder = proxyTypeBuilder.DefineMethod(
                             methodName,
                             MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -381,6 +381,9 @@
   <data name="UnsupportedMethodReturnTypeOnClientProxyInterface" xml:space="preserve">
     <value>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</value>
   </data>
+  <data name="UnsupportedByRefParameterOnClientProxyInterface" xml:space="preserve">
+    <value>Method "{0}" has unsupported by-reference parameter "{1}". The in, ref, and out modifiers are not supported.</value>
+  </data>
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>
   </data>

--- a/src/StreamJsonRpc/Resources.resx
+++ b/src/StreamJsonRpc/Resources.resx
@@ -382,7 +382,7 @@
     <value>Method "{0}" has unsupported return type "{1}". Only Task-returning methods are supported.</value>
   </data>
   <data name="UnsupportedByRefParameterOnClientProxyInterface" xml:space="preserve">
-    <value>Method "{0}" has unsupported by-reference parameter "{1}". The in, ref, and out modifiers are not supported.</value>
+    <value>Method "{0}" has unsupported by-reference parameter "{1}". By-reference parameters are not supported.</value>
   </data>
   <data name="UnsupportedPropertiesOnClientProxyInterface" xml:space="preserve">
     <value>Properties are not supported for service interfaces.</value>

--- a/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
@@ -95,6 +95,20 @@ public class JsonRpcContractAnalyzerTests
     }
 
     [Fact]
+    public async Task ByReferenceParameters()
+    {
+        await VerifyCS.VerifyAnalyzerAsync("""
+            [JsonRpcContract, TypeShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            public partial interface IMyRpc
+            {
+                Task UnsupportedInAsync(in int {|StreamJsonRpc0017:value|});
+                Task UnsupportedOutAsync(out int {|StreamJsonRpc0017:value|});
+                Task UnsupportedRefAsync(ref int {|StreamJsonRpc0017:value|});
+            }
+            """);
+    }
+
+    [Fact]
     public async Task InaccessibleInterface_Private()
     {
         await VerifyCS.VerifyAnalyzerAsync("""

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -189,6 +189,21 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         Task AddAsync<T>(T a, T b);
     }
 
+    public interface IServerWithOutParameter
+    {
+        Task GetValueAsync(out int value);
+    }
+
+    public interface IServerWithRefParameter
+    {
+        Task SetValueAsync(ref int value);
+    }
+
+    public interface IServerWithInParameter
+    {
+        Task<int> EchoAsync(in int value);
+    }
+
     [JsonRpcContract]
     [SuppressMessage("Usage", "StreamJsonRpc0008", Justification = "Source generated shapes cause this to fail unrelated tests.")]
     public partial interface IReferenceAnUnreachableAssembly
@@ -520,6 +535,36 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         var exception = Assert.Throws<NotSupportedException>(() => JsonRpc.Attach<IServerWithGenericMethod>(this.clientStream));
 #pragma warning restore StreamJsonRpc0003 // Use JsonRpcContractAttribute
         this.Logger.WriteLine(exception.Message);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void OutParameterOnInterface()
+    {
+#pragma warning disable StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => new JsonRpc(Stream.Null).Attach(typeof(IServerWithOutParameter), new JsonRpcProxyOptions { ProxySource = JsonRpcProxyOptions.ProxyImplementation.AlwaysDynamic }));
+#pragma warning restore StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        Assert.Contains("value", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void RefParameterOnInterface()
+    {
+#pragma warning disable StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => new JsonRpc(Stream.Null).Attach(typeof(IServerWithRefParameter), new JsonRpcProxyOptions { ProxySource = JsonRpcProxyOptions.ProxyImplementation.AlwaysDynamic }));
+#pragma warning restore StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        Assert.Contains("value", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("NegativeTest", "")]
+    public void InParameterOnInterface()
+    {
+#pragma warning disable StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => new JsonRpc(Stream.Null).Attach(typeof(IServerWithInParameter), new JsonRpcProxyOptions { ProxySource = JsonRpcProxyOptions.ProxyImplementation.AlwaysDynamic }));
+#pragma warning restore StreamJsonRpc0003 // Dynamic-proxy fallback coverage.
+        Assert.Contains("value", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Dynamic proxy generation currently attempts to emit fields for managed-reference parameter types, causing a runtime crash when an RPC contract uses `in`, `ref`, or `out`.

Reject these parameter modifiers before emitting proxy IL, and report `StreamJsonRpc0017` for attributed contracts. Source-generated proxies preserve the declared modifier and produce a deterministic `NotSupportedException` if the analyzer error is suppressed. Regression coverage includes all three modifiers across dynamic proxy and analyzer paths.

Fixes #847