### PR TITLE
Stabilize outbound timeout cancellation test

### DIFF
--- a/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
+++ b/test/StreamJsonRpc.Tests/CustomCancellationStrategyTests.cs
@@ -95,7 +95,9 @@ public class CustomCancellationStrategyTests : TestBase
     public async Task CancelRequest_WhenOutboundRequestTimesOut()
     {
         this.clientRpc.OutboundRequestTimeout = TimeSpan.FromSeconds(1);
-        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { false }, cancellationToken: CancellationToken.None);
+
+        // Throw when the timeout cancellation reaches the server so its response cannot race the timeout with a successful result.
+        Task invokeTask = this.clientRpc.InvokeWithCancellationAsync(nameof(Server.NoticeCancellationAsync), new object?[] { true }, cancellationToken: CancellationToken.None);
         await this.server.MethodEntered.WaitAsync(this.TimeoutToken);
 
         TimeoutException ex = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);


### PR DESCRIPTION
## Summary

- make `CancelRequest_WhenOutboundRequestTimesOut` require the server method to throw when timeout cancellation reaches it
- prevent a successful server response from racing the client's timeout completion
- retain coverage that timeout cancellation invokes `OutboundRequestEnded`

## Root cause

PR #1509's Linux Azure Pipelines run (build 24619) failed this inherited test on net8.0 after roughly one second because no exception was thrown. The test passed `throwOnCanceled: false` to `NoticeCancellationAsync`. When the outbound timeout fired, the custom cancellation strategy canceled the server method, which then returned successfully. Its normal response could reach the client before the local timeout path completed, legitimately completing the invocation without an exception.

Passing `throwOnCanceled: true` makes the server report cancellation instead. Whether the local timeout task wins or the remote cancellation response arrives first, the client translates the timeout-originated cancellation to `TimeoutException`, removing the race without increasing delays, retrying, weakening assertions, or changing production behavior.

## Validation

- exact inherited net8.0 test: 10 consecutive passes
- `CustomCancellationStrategyTests` and `CustomCancellationStrategyJsonTypeHandlingTests`: 30/30 passed across net472, net8.0, and net9.0
- full `StreamJsonRpc.Tests` net8.0 project excluding `TestCategory=FailsInCloudTest`: 2,774 passed, 20 skipped