### PR TITLE
Preserve exception details across RPC hops

### DIFF
--- a/src/StreamJsonRpc/Protocol/CommonErrorData.cs
+++ b/src/StreamJsonRpc/Protocol/CommonErrorData.cs
@@ -34,7 +34,14 @@ public partial class CommonErrorData
         this.StackTrace = copyFrom.StackTrace;
         this.HResult = copyFrom.HResult;
         this.TypeName = copyFrom.GetType().FullName;
-        this.Inner = copyFrom.InnerException is not null ? new CommonErrorData(copyFrom.InnerException) : null;
+        if (copyFrom.InnerException is not null)
+        {
+            this.Inner = new CommonErrorData(copyFrom.InnerException);
+        }
+        else if (copyFrom is RemoteInvocationException { DeserializedErrorData: CommonErrorData remoteErrorData })
+        {
+            this.Inner = remoteErrorData;
+        }
     }
 
     /// <summary>

--- a/test/StreamJsonRpc.Tests/SpecialCaseTests.cs
+++ b/test/StreamJsonRpc.Tests/SpecialCaseTests.cs
@@ -11,6 +11,21 @@ public class SpecialCaseTests : TestBase
     {
     }
 
+    [Fact]
+    public async Task ExceptionDetailsSurviveMultipleRpcHops_CommonErrorData()
+    {
+        await this.ExceptionDetailsSurviveMultipleRpcHopsAsync(ExceptionProcessing.CommonErrorData);
+    }
+
+    [Fact]
+    public async Task ExceptionDetailsSurviveMultipleRpcHops_ISerializable()
+    {
+        RemoteInvocationException exception = await this.ExceptionDetailsSurviveMultipleRpcHopsAsync(ExceptionProcessing.ISerializable);
+        RemoteInvocationException forwardingException = Assert.IsType<RemoteInvocationException>(exception.InnerException);
+        InvalidOperationException originalException = Assert.IsType<InvalidOperationException>(forwardingException.InnerException);
+        Assert.Equal(ThrowingServer.ExceptionMessage, originalException.Message);
+    }
+
     /// <summary>
     /// Verifies that if the server fails to transmit a response, it drops the connection to avoid a client hang
     /// while waiting for the response.
@@ -42,11 +57,68 @@ public class SpecialCaseTests : TestBase
         Assert.Equal(0, bytesRead);
     }
 
+    private async Task<RemoteInvocationException> ExceptionDetailsSurviveMultipleRpcHopsAsync(ExceptionProcessing exceptionStrategy)
+    {
+        (Stream firstClientStream, Stream firstServerStream) = FullDuplexStream.CreatePair();
+        (Stream secondClientStream, Stream secondServerStream) = FullDuplexStream.CreatePair();
+        using JsonRpc secondClient = CreateJsonRpc(secondClientStream, exceptionStrategy);
+        using JsonRpc secondServer = CreateJsonRpc(secondServerStream, exceptionStrategy, new ThrowingServer());
+        using JsonRpc firstServer = CreateJsonRpc(firstServerStream, exceptionStrategy, new ForwardingServer(secondClient));
+        using JsonRpc firstClient = CreateJsonRpc(firstClientStream, exceptionStrategy);
+
+        RemoteInvocationException exception = await Assert.ThrowsAsync<RemoteInvocationException>(
+            () => firstClient.InvokeAsync(nameof(ForwardingServer.ForwardAsync)));
+
+        CommonErrorData forwardingError = Assert.IsType<CommonErrorData>(exception.DeserializedErrorData);
+        Assert.Equal(typeof(RemoteInvocationException).FullName, forwardingError.TypeName);
+        Assert.Contains(nameof(ForwardingServer.ForwardAsync), forwardingError.StackTrace);
+
+        CommonErrorData originalError = Assert.IsType<CommonErrorData>(forwardingError.Inner);
+        Assert.Equal(typeof(InvalidOperationException).FullName, originalError.TypeName);
+        Assert.Equal(ThrowingServer.ExceptionMessage, originalError.Message);
+        Assert.Contains(nameof(ThrowingServer.Throw), originalError.StackTrace);
+        return exception;
+
+        static JsonRpc CreateJsonRpc(Stream stream, ExceptionProcessing exceptionStrategy, object? target = null)
+        {
+            var rpc = new JsonRpc(stream)
+            {
+                ExceptionStrategy = exceptionStrategy,
+            };
+            if (target is not null)
+            {
+                rpc.AddLocalRpcTarget(target);
+            }
+
+            rpc.StartListening();
+            return rpc;
+        }
+    }
+
     private class Server
     {
         public void Hi()
         {
         }
+    }
+
+    private class ForwardingServer
+    {
+        private readonly JsonRpc nextClient;
+
+        internal ForwardingServer(JsonRpc nextClient)
+        {
+            this.nextClient = nextClient;
+        }
+
+        public async Task ForwardAsync() => await this.nextClient.InvokeAsync(nameof(ThrowingServer.Throw));
+    }
+
+    private class ThrowingServer
+    {
+        internal const string ExceptionMessage = "Exception from the second server.";
+
+        public void Throw() => throw new InvalidOperationException(ExceptionMessage);
     }
 
     private class ThrowingMessageHandler : HeaderDelimitedMessageHandler


### PR DESCRIPTION
Multi-hop RPC failures currently lose the original server exception details when an intermediate server forwards a `RemoteInvocationException`, leaving callers with only the intermediate server stack.

Preserve the deserialized remote `CommonErrorData` as the inner error when no CLR inner exception is available. This retains both server stack traces while continuing to prefer a real `InnerException` for the `ISerializable` strategy. Regression tests cover both exception processing modes across two RPC hops.

Fixes #720