### PR TITLE
Avoid repeating async enumerator creation failures

### DIFF
--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -1191,6 +1191,7 @@ internal static class ProxyGeneration
         private class AsyncEnumeratorProxy : IAsyncEnumerator<T>
         {
             private readonly AsyncLazy<IAsyncEnumerator<T>> enumeratorLazy;
+            private bool enumeratorCreationFailureObserved;
 
             internal AsyncEnumeratorProxy(Task<IAsyncEnumerable<T>> enumerableTask, CancellationToken cancellationToken)
             {
@@ -1216,12 +1217,27 @@ internal static class ProxyGeneration
 
             public async ValueTask<bool> MoveNextAsync()
             {
-                IAsyncEnumerator<T> enumerator = await this.enumeratorLazy.GetValueAsync().ConfigureAwait(false);
+                IAsyncEnumerator<T> enumerator;
+                try
+                {
+                    enumerator = await this.enumeratorLazy.GetValueAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    this.enumeratorCreationFailureObserved = true;
+                    throw;
+                }
+
                 return await enumerator.MoveNextAsync().ConfigureAwait(false);
             }
 
             public async ValueTask DisposeAsync()
             {
+                if (this.enumeratorCreationFailureObserved)
+                {
+                    return;
+                }
+
                 // Even if we haven't been asked for the iterator yet, the server has (or soon may), so we must acquire it
                 // and dispose of it so that we don't incur a memory leak on the server.
                 IAsyncEnumerator<T> enumerator = await this.enumeratorLazy.GetValueAsync().ConfigureAwait(false);

--- a/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -42,6 +42,8 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
     [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     public partial interface IServer2
     {
+        IAsyncEnumerable<int> FailBeforeReturningAsync(CancellationToken cancellationToken);
+
         IAsyncEnumerable<int> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken);
 
         IAsyncEnumerable<int> GetNumbersParameterizedAsync(int batchSize, int readAhead, int prefetch, int totalCount, bool endWithException, CancellationToken cancellationToken);
@@ -551,6 +553,17 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
     }
 
     [Fact]
+    public async Task DisposeAsyncDoesNotRepeatMoveNextAsyncException()
+    {
+        var proxy = this.clientRpc.Attach<IServer2>();
+        IAsyncEnumerator<int> enumerator = proxy.FailBeforeReturningAsync(this.TimeoutToken).GetAsyncEnumerator(this.TimeoutToken);
+
+        RemoteInvocationException ex = await Assert.ThrowsAsync<RemoteInvocationException>(async () => await enumerator.MoveNextAsync());
+        Assert.Equal(Server.FailByDesignExceptionMessage, ex.Message);
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
     public async Task EnumerableIdDisposal()
     {
         // This test is specially arranged to create two RPC calls going opposite directions, with the same request ID.
@@ -702,6 +715,11 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
         {
             return this.GetNumbersAsync(totalCount, endWithException, cancellationToken)
                 .WithJsonRpcSettings(new JsonRpcEnumerableSettings { MinBatchSize = batchSize, MaxReadAhead = readAhead, Prefetch = prefetch });
+        }
+
+        public Task<IAsyncEnumerable<int>> FailBeforeReturningAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromException<IAsyncEnumerable<int>>(new InvalidOperationException(FailByDesignExceptionMessage));
         }
 
         public async IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemAsync([EnumeratorCancellation] CancellationToken cancellationToken)


### PR DESCRIPTION
An async enumerable RPC that fails before producing its enumerator currently throws from `MoveNextAsync`, then repeats the same cached exception from `DisposeAsync`. This can replace or obscure the exception handling performed by callers using `await foreach` or `await using`.

Track whether enumerator creation already failed during `MoveNextAsync` and make subsequent disposal a no-op in that case. Disposal still acquires and disposes the remote enumerator when creation has not already faulted, preserving the existing leak-prevention behavior.

Adds regression coverage across all configured serializers for a remote method that fails before returning its enumerable.

Fixes #1214