### PR TITLE
Fix JSON-RPC 1.0 compliance

### DIFF
--- a/src/StreamJsonRpc/JsonMessageFormatter.cs
+++ b/src/StreamJsonRpc/JsonMessageFormatter.cs
@@ -267,11 +267,13 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
                 case 1:
                     this.VerifyProtocolCompliance(json["jsonrpc"] is null, json, "\"jsonrpc\" property not expected. Use protocol version 2.0.");
                     this.VerifyProtocolCompliance(json["id"] is not null, json, "\"id\" property missing.");
-                    return
+                    JsonRpcMessage message =
                         json["method"] is not null ? this.ReadRequest(json) :
                         json["error"]?.Type == JTokenType.Null ? this.ReadResult(json) :
                         json["error"] is { Type: not JTokenType.Null } ? this.ReadError(json) :
                         throw this.CreateProtocolNonComplianceException(json);
+                    message.Version = "1.0";
+                    return message;
                 case 2:
                     this.VerifyProtocolCompliance(json.Value<string>("jsonrpc") == "2.0", json, $"\"jsonrpc\" property must be set to \"2.0\", or set {nameof(this.ProtocolVersion)} to 1.0 mode.");
                     return
@@ -319,10 +321,29 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
                 json["result"] = JValue.CreateNull();
             }
 
-            if (this.ProtocolVersion.Major == 1 && json["id"] is null)
+            if (this.ProtocolVersion.Major == 1)
             {
+                ((JObject)json).Remove("jsonrpc");
+
                 // JSON-RPC 1.0 requires the id property to be present even for notifications.
-                json["id"] = JValue.CreateNull();
+                if (json["id"] is null)
+                {
+                    json["id"] = JValue.CreateNull();
+                }
+
+                // JSON-RPC 1.0 requires both response properties, with one set to null.
+                if (message is Protocol.JsonRpcResult)
+                {
+                    json["error"] = JValue.CreateNull();
+                }
+                else if (message is Protocol.JsonRpcError)
+                {
+                    json["result"] = JValue.CreateNull();
+                }
+            }
+            else
+            {
+                json["jsonrpc"] = "2.0";
             }
 
             // Copy over extra top-level properties.
@@ -591,6 +612,10 @@ public class JsonMessageFormatter : FormatterBase, IJsonRpcAsyncMessageTextForma
         Requires.NotNull(json, nameof(json));
 
         RequestId id = json["id"]?.ToObject<RequestId>(DefaultSerializer) ?? default;
+        if (this.ProtocolVersion.Major == 1 && id.IsNull)
+        {
+            id = RequestId.NotSpecified;
+        }
 
         // We leave arguments as JTokens at this point, so that we can try deserializing them
         // to more precise .NET types as required by the method we're invoking.

--- a/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonMessageFormatterTests.cs
@@ -50,6 +50,57 @@ public class JsonMessageFormatterTests : FormatterTestBase<JsonMessageFormatter>
     }
 
     [Fact]
+    public void ProtocolVersion10_SerializesRequest()
+    {
+        this.Formatter.ProtocolVersion = new Version(1, 0);
+
+        JToken json = this.Formatter.Serialize(new JsonRpcRequest { Method = "test", RequestId = new RequestId(1) });
+
+        Assert.Null(json["jsonrpc"]);
+        Assert.Equal(1, json.Value<long>("id"));
+    }
+
+    [Fact]
+    public void ProtocolVersion10_SerializesResult()
+    {
+        this.Formatter.ProtocolVersion = new Version(1, 0);
+
+        JToken json = this.Formatter.Serialize(new JsonRpcResult { RequestId = new RequestId(1), Result = "value" });
+
+        Assert.Null(json["jsonrpc"]);
+        Assert.Equal("value", json.Value<string>("result"));
+        Assert.Equal(JTokenType.Null, json["error"]?.Type);
+    }
+
+    [Fact]
+    public void ProtocolVersion10_SerializesError()
+    {
+        this.Formatter.ProtocolVersion = new Version(1, 0);
+
+        JToken json = this.Formatter.Serialize(new JsonRpcError
+        {
+            RequestId = new RequestId(1),
+            Error = new JsonRpcError.ErrorDetail { Code = JsonRpcErrorCode.InternalError, Message = "failure" },
+        });
+
+        Assert.Null(json["jsonrpc"]);
+        Assert.Equal(JTokenType.Null, json["result"]?.Type);
+        Assert.Equal("failure", json["error"]?.Value<string>("message"));
+    }
+
+    [Fact]
+    public void ProtocolVersion10_DeserializesNullIdAsNotification()
+    {
+        this.Formatter.ProtocolVersion = new Version(1, 0);
+        var json = JObject.Parse("""{"method":"test","params":[],"id":null}""");
+
+        var request = Assert.IsAssignableFrom<JsonRpcRequest>(this.Formatter.Deserialize(json));
+
+        Assert.Equal("1.0", request.Version);
+        Assert.True(request.IsNotification);
+    }
+
+    [Fact]
     public void EncodingProperty_UsedToFormat()
     {
         var msg = new JsonRpcRequest { Method = "a" };

--- a/test/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcClient10InteropTests.cs
@@ -12,12 +12,14 @@ using Newtonsoft.Json.Linq;
 public class JsonRpcClient10InteropTests : InteropTestBase
 {
     private readonly JsonRpc clientRpc;
+    private readonly NotificationTarget notificationTarget = new();
 
     public JsonRpcClient10InteropTests(ITestOutputHelper logger)
         : base(logger)
     {
         this.messageHandler.Formatter.ProtocolVersion = new Version(1, 0);
         this.clientRpc = new JsonRpc(this.messageHandler);
+        this.clientRpc.AddLocalRpcTarget(this.notificationTarget);
         this.clientRpc.StartListening();
     }
 
@@ -81,6 +83,35 @@ public class JsonRpcClient10InteropTests : InteropTestBase
     {
         await this.clientRpc.NotifyAsync("method");
         JToken request = await this.ReceiveAsync();
+        Assert.Null(request["jsonrpc"]);
         Assert.Equal(JTokenType.Null, request["id"]?.Type);
+    }
+
+    [Fact]
+    public async Task NotificationsWithNullIdDoNotReceiveResponses()
+    {
+        this.Send(new
+        {
+            method = nameof(NotificationTarget.OnNotification),
+            @params = new[] { "value" },
+            id = (object?)null,
+        });
+
+        Assert.Equal("value", await this.notificationTarget.NotificationReceived.Task.WithCancellation(this.TimeoutToken));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => this.messageHandler.WrittenMessages.DequeueAsync(ExpectedTimeoutToken));
+    }
+
+    private class NotificationTarget
+    {
+        /// <summary>
+        /// Gets a task that completes when the notification arrives.
+        /// </summary>
+        internal TaskCompletionSource<string> NotificationReceived { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Receives a test notification.
+        /// </summary>
+        /// <param name="value">The notification value.</param>
+        public void OnNotification(string value) => this.NotificationReceived.SetResult(value);
     }
 }


### PR DESCRIPTION
JSON-RPC 1.0 mode produced 2.0-style envelopes and treated incoming notifications with a null ID as requests, leading to invalid responses and interoperability failures with legacy services.

This updates the JSON formatter to omit the `jsonrpc` member in 1.0 mode, include the mandatory complementary null field in responses, and normalize null request IDs to notifications. It also adds formatter and end-to-end interoperability coverage for these behaviors.

Fixes #658