### PR TITLE
Implement async disposal on client proxies

### DIFF
--- a/docfx/docs/proxies.md
+++ b/docfx/docs/proxies.md
@@ -47,6 +47,7 @@ Generated proxies have the following traits:
 1. They implement <xref:StreamJsonRpc.IJsonRpcClientProxy>, allowing access back to the <xref:StreamJsonRpc.JsonRpc> instance that created them.
 1. They implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable>.
    *If* the proxy is created using a *static* <xref:StreamJsonRpc.JsonRpc.Attach``1(System.IO.Stream)> overload, disposal of the proxy is forwarded to <xref:StreamJsonRpc.JsonRpc.Dispose>.
+   An exception is when the RPC contract itself derives from <xref:System.IAsyncDisposable>: its `DisposeAsync` method is treated as an RPC method and does not dispose the local proxy.
 
 ## RPC interfaces
 
@@ -58,7 +59,8 @@ A proxy can only be generated for an interface that meets these requirements:
 1. All events are typed with <xref:System.EventHandler> or <xref:System.EventHandler`1>. The JSON-RPC contract for raising such events is that the request contain exactly one argument, which supplies the value for the `T` in <xref:System.EventHandler`1>.
 1. Methods *may* accept a @System.Threading.CancellationToken as the last parameter.
 
-The RPC interface may derive from <xref:System.IDisposable> or <xref:System.IAsyncDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
+The RPC interface may derive from <xref:System.IDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
+An RPC interface may also derive from <xref:System.IAsyncDisposable>, but its `DisposeAsync` method is invoked on the remote target and does not close the local JSON-RPC connection.
 
 Applying the <xref:StreamJsonRpc.JsonRpcContractAttribute> to all RPC interfaces is strongly encouraged, as it has two significant benefits:
 

--- a/docfx/docs/proxies.md
+++ b/docfx/docs/proxies.md
@@ -47,7 +47,6 @@ Generated proxies have the following traits:
 1. They implement <xref:StreamJsonRpc.IJsonRpcClientProxy>, allowing access back to the <xref:StreamJsonRpc.JsonRpc> instance that created them.
 1. They implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable>.
    *If* the proxy is created using a *static* <xref:StreamJsonRpc.JsonRpc.Attach``1(System.IO.Stream)> overload, disposal of the proxy is forwarded to <xref:StreamJsonRpc.JsonRpc.Dispose>.
-   An exception is when the RPC contract itself derives from <xref:System.IAsyncDisposable>: its `DisposeAsync` method is treated as an RPC method and does not dispose the local proxy.
 
 ## RPC interfaces
 
@@ -59,8 +58,7 @@ A proxy can only be generated for an interface that meets these requirements:
 1. All events are typed with <xref:System.EventHandler> or <xref:System.EventHandler`1>. The JSON-RPC contract for raising such events is that the request contain exactly one argument, which supplies the value for the `T` in <xref:System.EventHandler`1>.
 1. Methods *may* accept a @System.Threading.CancellationToken as the last parameter.
 
-The RPC interface may derive from <xref:System.IDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
-An RPC interface may also derive from <xref:System.IAsyncDisposable>, but its `DisposeAsync` method is invoked on the remote target and does not close the local JSON-RPC connection.
+The RPC interface may derive from <xref:System.IDisposable> or <xref:System.IAsyncDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
 
 Applying the <xref:StreamJsonRpc.JsonRpcContractAttribute> to all RPC interfaces is strongly encouraged, as it has two significant benefits:
 

--- a/docfx/docs/proxies.md
+++ b/docfx/docs/proxies.md
@@ -45,7 +45,7 @@ Generated proxies have the following traits:
    They are sent as notifications if they return `void`.
 1. Events on the interface are raised locally when a notification with the same name is received from the other party.
 1. They implement <xref:StreamJsonRpc.IJsonRpcClientProxy>, allowing access back to the <xref:StreamJsonRpc.JsonRpc> instance that created them.
-1. They implement <xref:System.IDisposable>.
+1. They implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable>.
    *If* the proxy is created using a *static* <xref:StreamJsonRpc.JsonRpc.Attach``1(System.IO.Stream)> overload, disposal of the proxy is forwarded to <xref:StreamJsonRpc.JsonRpc.Dispose>.
 
 ## RPC interfaces
@@ -58,7 +58,7 @@ A proxy can only be generated for an interface that meets these requirements:
 1. All events are typed with <xref:System.EventHandler> or <xref:System.EventHandler`1>. The JSON-RPC contract for raising such events is that the request contain exactly one argument, which supplies the value for the `T` in <xref:System.EventHandler`1>.
 1. Methods *may* accept a @System.Threading.CancellationToken as the last parameter.
 
-The RPC interface may derive from <xref:System.IDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
+The RPC interface may derive from <xref:System.IDisposable> or <xref:System.IAsyncDisposable> and is encouraged to do so as it encourages folks who hold proxies to dispose of them and thereby close the JSON-RPC connection.
 
 Applying the <xref:StreamJsonRpc.JsonRpcContractAttribute> to all RPC interfaces is strongly encouraged, as it has two significant benefits:
 

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
@@ -46,6 +46,9 @@ internal record InterfaceModel(string FullName, string Name, ImmutableEquatableA
                 case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IDisposable):
                     // We don't map this special Dispose method.
                     break;
+                case IMethodSymbol method when symbols.IAsyncDisposable is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IAsyncDisposable):
+                    // We don't map this special DisposeAsync method.
+                    break;
                 case IMethodSymbol { AssociatedSymbol: not null }:
                     // We'll handle these as part of the associated symbol.
                     break;

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
@@ -46,9 +46,6 @@ internal record InterfaceModel(string FullName, string Name, ImmutableEquatableA
                 case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IDisposable):
                     // We don't map this special Dispose method.
                     break;
-                case IMethodSymbol method when symbols.IAsyncDisposable is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IAsyncDisposable):
-                    // We don't map this special DisposeAsync method.
-                    break;
                 case IMethodSymbol { AssociatedSymbol: not null }:
                     // We'll handle these as part of the associated symbol.
                     break;

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
@@ -46,6 +46,9 @@ internal record InterfaceModel(string FullName, string Name, ImmutableEquatableA
                 case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IDisposable):
                     // We don't map this special Dispose method.
                     break;
+                case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IAsyncDisposable):
+                    // We don't map this special DisposeAsync method.
+                    break;
                 case IMethodSymbol { AssociatedSymbol: not null }:
                     // We'll handle these as part of the associated symbol.
                     break;

--- a/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
+++ b/src/StreamJsonRpc.Analyzers/GeneratorModels/InterfaceModel.cs
@@ -46,7 +46,7 @@ internal record InterfaceModel(string FullName, string Name, ImmutableEquatableA
                 case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IDisposable):
                     // We don't map this special Dispose method.
                     break;
-                case IMethodSymbol method when SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IAsyncDisposable):
+                case IMethodSymbol method when symbols.IAsyncDisposable is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, symbols.IAsyncDisposable):
                     // We don't map this special DisposeAsync method.
                     break;
                 case IMethodSymbol { AssociatedSymbol: not null }:

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -16,6 +16,7 @@ internal record KnownSymbols(
     INamedTypeSymbol? TypeShapeAttribute,
     INamedTypeSymbol CancellationToken,
     INamedTypeSymbol IDisposable,
+    INamedTypeSymbol? IAsyncDisposable,
     INamedTypeSymbol RpcMarshalableAttribute,
     INamedTypeSymbol RpcMarshalableOptionalInterface,
     INamedTypeSymbol JsonRpcContractAttribute,
@@ -41,6 +42,7 @@ internal record KnownSymbols(
         INamedTypeSymbol? typeShapeAttribute = compilation.GetTypeByMetadataName("PolyType.TypeShapeAttribute");
         INamedTypeSymbol? cancellationToken = compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
         INamedTypeSymbol? idisposable = compilation.GetTypeByMetadataName("System.IDisposable");
+        INamedTypeSymbol? iasyncDisposable = compilation.GetTypeByMetadataName("System.IAsyncDisposable");
         INamedTypeSymbol? rpcMarshalableAttribute = compilation.GetTypeByMetadataName(Types.RpcMarshalableAttribute.FullName);
         INamedTypeSymbol? rpcMarshalableOptionalInterface = compilation.GetTypeByMetadataName(Types.RpcMarshalableOptionalInterfaceAttribute.FullName);
         INamedTypeSymbol? rpcContractAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcContractAttribute.FullName);
@@ -73,7 +75,7 @@ internal record KnownSymbols(
             return false;
         }
 
-        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
+        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, iasyncDisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
         return true;
     }
 }

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -16,7 +16,7 @@ internal record KnownSymbols(
     INamedTypeSymbol? TypeShapeAttribute,
     INamedTypeSymbol CancellationToken,
     INamedTypeSymbol IDisposable,
-    INamedTypeSymbol IAsyncDisposable,
+    INamedTypeSymbol? IAsyncDisposable,
     INamedTypeSymbol RpcMarshalableAttribute,
     INamedTypeSymbol RpcMarshalableOptionalInterface,
     INamedTypeSymbol JsonRpcContractAttribute,
@@ -58,7 +58,6 @@ internal record KnownSymbols(
         INamedTypeSymbol? systemIOStream = compilation.GetTypeByMetadataName("System.IO.Stream");
 
         if (idisposable is null ||
-            iasyncDisposable is null ||
             rpcMarshalableAttribute is null ||
             rpcMarshalableOptionalInterface is null ||
             rpcContractAttribute is null ||

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -16,7 +16,6 @@ internal record KnownSymbols(
     INamedTypeSymbol? TypeShapeAttribute,
     INamedTypeSymbol CancellationToken,
     INamedTypeSymbol IDisposable,
-    INamedTypeSymbol? IAsyncDisposable,
     INamedTypeSymbol RpcMarshalableAttribute,
     INamedTypeSymbol RpcMarshalableOptionalInterface,
     INamedTypeSymbol JsonRpcContractAttribute,
@@ -42,7 +41,6 @@ internal record KnownSymbols(
         INamedTypeSymbol? typeShapeAttribute = compilation.GetTypeByMetadataName("PolyType.TypeShapeAttribute");
         INamedTypeSymbol? cancellationToken = compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
         INamedTypeSymbol? idisposable = compilation.GetTypeByMetadataName("System.IDisposable");
-        INamedTypeSymbol? iasyncDisposable = compilation.GetTypeByMetadataName("System.IAsyncDisposable");
         INamedTypeSymbol? rpcMarshalableAttribute = compilation.GetTypeByMetadataName(Types.RpcMarshalableAttribute.FullName);
         INamedTypeSymbol? rpcMarshalableOptionalInterface = compilation.GetTypeByMetadataName(Types.RpcMarshalableOptionalInterfaceAttribute.FullName);
         INamedTypeSymbol? rpcContractAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcContractAttribute.FullName);
@@ -75,7 +73,7 @@ internal record KnownSymbols(
             return false;
         }
 
-        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, iasyncDisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
+        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
         return true;
     }
 }

--- a/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
+++ b/src/StreamJsonRpc.Analyzers/KnownSymbols.cs
@@ -16,6 +16,7 @@ internal record KnownSymbols(
     INamedTypeSymbol? TypeShapeAttribute,
     INamedTypeSymbol CancellationToken,
     INamedTypeSymbol IDisposable,
+    INamedTypeSymbol IAsyncDisposable,
     INamedTypeSymbol RpcMarshalableAttribute,
     INamedTypeSymbol RpcMarshalableOptionalInterface,
     INamedTypeSymbol JsonRpcContractAttribute,
@@ -41,6 +42,7 @@ internal record KnownSymbols(
         INamedTypeSymbol? typeShapeAttribute = compilation.GetTypeByMetadataName("PolyType.TypeShapeAttribute");
         INamedTypeSymbol? cancellationToken = compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
         INamedTypeSymbol? idisposable = compilation.GetTypeByMetadataName("System.IDisposable");
+        INamedTypeSymbol? iasyncDisposable = compilation.GetTypeByMetadataName("System.IAsyncDisposable");
         INamedTypeSymbol? rpcMarshalableAttribute = compilation.GetTypeByMetadataName(Types.RpcMarshalableAttribute.FullName);
         INamedTypeSymbol? rpcMarshalableOptionalInterface = compilation.GetTypeByMetadataName(Types.RpcMarshalableOptionalInterfaceAttribute.FullName);
         INamedTypeSymbol? rpcContractAttribute = compilation.GetTypeByMetadataName(Types.JsonRpcContractAttribute.FullName);
@@ -56,6 +58,7 @@ internal record KnownSymbols(
         INamedTypeSymbol? systemIOStream = compilation.GetTypeByMetadataName("System.IO.Stream");
 
         if (idisposable is null ||
+            iasyncDisposable is null ||
             rpcMarshalableAttribute is null ||
             rpcMarshalableOptionalInterface is null ||
             rpcContractAttribute is null ||
@@ -73,7 +76,7 @@ internal record KnownSymbols(
             return false;
         }
 
-        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
+        symbols = new KnownSymbols(task, taskOfT, valueTask, valueTaskOfT, asyncEnumerableOfT, generateShapeAttribute, typeShapeAttribute, cancellationToken, idisposable, iasyncDisposable, rpcMarshalableAttribute, rpcMarshalableOptionalInterface, rpcContractAttribute, jsonRpcProxyAttribute, jsonRpcProxyInterfaceGroupAttribute, exportRpcContractProxiesAttribute, rpcProxyMappingAttribute, jsonRpcIgnoreAttribute, jsonRpcMethodAttribute, jsonRpcParameterAttribute, methodShapeAttribute, systemType, systemIOStream);
         return true;
     }
 }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -831,7 +831,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <param name="stream">The bidirectional stream used to send and receive JSON-RPC messages.</param>
     /// <returns>
     /// An instance of the generated proxy.
-    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/> and <see cref="System.IAsyncDisposable"/>
     /// and should be disposed of to close the connection.
     /// </returns>
     /// <remarks>
@@ -853,7 +853,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <param name="receivingStream">The stream used to receive messages. May be null.</param>
     /// <returns>
     /// An instance of the generated proxy.
-    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/> and <see cref="System.IAsyncDisposable"/>
     /// and should be disposed of to close the connection.
     /// </returns>
     /// <inheritdoc cref="Attach{T}(Stream)" path="/remarks"/>
@@ -874,7 +874,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <param name="handler">The message handler to use.</param>
     /// <returns>
     /// An instance of the generated proxy.
-    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/> and <see cref="System.IAsyncDisposable"/>
     /// and should be disposed of to close the connection.
     /// </returns>
     /// <inheritdoc cref="Attach{T}(Stream)" path="/remarks"/>
@@ -893,7 +893,7 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <param name="options">A set of customizations for how the client proxy is wired up. If <see langword="null"/>, default options will be used.</param>
     /// <returns>
     /// An instance of the generated proxy.
-    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/>
+    /// In addition to implementing <typeparamref name="T"/>, it also implements <see cref="IDisposable"/> and <see cref="System.IAsyncDisposable"/>
     /// and should be disposed of to close the connection.
     /// </returns>
     /// <inheritdoc cref="Attach{T}(Stream)" path="/remarks"/>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -746,7 +746,7 @@ internal static class ProxyGeneration
     private static void ImplementDisposeAsyncMethod(TypeBuilder proxyTypeBuilder, MethodBuilder disposeMethod)
     {
         MethodBuilder methodBuilder = proxyTypeBuilder.DefineMethod(
-            DisposeAsyncMethod.Name,
+            $"{DisposeAsyncMethod.DeclaringType!.FullName}.{DisposeAsyncMethod.Name}",
             MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,
             DisposeAsyncMethod.ReturnType,
             Type.EmptyTypes);

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -103,6 +103,7 @@ internal static class ProxyGeneration
 
             Type[] contractInterfaces = [contractInterface, .. additionalContractInterfaces];
             IList<(Type Type, int? Code)> rpcInterfaces = GetSortedInterfaceAndCodes(inputs);
+            bool hasAsyncDisposableContract = rpcInterfaces.Any(i => typeof(System.IAsyncDisposable).IsAssignableFrom(i.Type));
 
             // For ALC selection reasons, it's vital that the *user's* selected interfaces come *before* our own supporting interfaces.
             // If the order is incorrect, type resolution may fail or the wrong AssemblyLoadContext (ALC) may be selected,
@@ -238,7 +239,11 @@ internal static class ProxyGeneration
             }
 
             MethodBuilder disposeMethod = ImplementDisposeMethod(proxyTypeBuilder, jsonRpcField, onDisposeField, disposedField);
-            ImplementDisposeAsyncMethod(proxyTypeBuilder, disposeMethod);
+            if (!hasAsyncDisposableContract)
+            {
+                ImplementDisposeAsyncMethod(proxyTypeBuilder, disposeMethod);
+            }
+
             ImplementIsDisposedProperty(proxyTypeBuilder, jsonRpcField, disposedField);
             ImplementIJsonRpcClientProxyInternal(proxyTypeBuilder, callingMethodField, calledMethodField, marshaledObjectHandleField);
 
@@ -297,7 +302,7 @@ internal static class ProxyGeneration
             IEnumerable<MethodInfo> notifyWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.NotifyWithParameterObjectAsync));
             MethodInfo notifyWithParameterObjectAsyncOfTaskMethodInfo = notifyWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
 
-            HashSet<MethodInfo> implementedMethods = new() { DisposeMethod, DisposeAsyncMethod };
+            HashSet<MethodInfo> implementedMethods = hasAsyncDisposableContract ? new() { DisposeMethod } : new() { DisposeMethod, DisposeAsyncMethod };
             foreach ((Type rpcInterface, int? rpcInterfaceCode) in rpcInterfaces)
             {
                 RpcTargetMetadata methodNameMap = RpcTargetMetadata.FromInterface(rpcInterface.GetTypeInfo());

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -67,6 +67,7 @@ internal static class ProxyGeneration
         m => m is { Name: nameof(Task.FromException), IsGenericMethod: false }
             && m.GetParameters() is [{ ParameterType: Type parameterType }]
             && parameterType == typeof(Exception));
+
     private static readonly ConstructorInfo ValueTaskFromTaskCtor = typeof(ValueTask).GetConstructor([typeof(Task)]) ?? throw Assumes.NotReachable();
 
     /// <summary>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -63,7 +63,10 @@ internal static class ProxyGeneration
     private static readonly MethodInfo DisposeMethod = typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose)) ?? throw Assumes.NotReachable();
     private static readonly MethodInfo DisposeAsyncMethod = typeof(System.IAsyncDisposable).GetMethod(nameof(System.IAsyncDisposable.DisposeAsync)) ?? throw Assumes.NotReachable();
     private static readonly MethodInfo IsDisposedPropertyGetter = typeof(IDisposableObservable).GetProperty(nameof(IDisposableObservable.IsDisposed))!.GetMethod ?? throw Assumes.NotReachable();
-    private static readonly MethodInfo TaskFromExceptionMethod = typeof(Task).GetMethods(BindingFlags.Public | BindingFlags.Static).Single(m => m.Name == nameof(Task.FromException) && !m.IsGenericMethod);
+    private static readonly MethodInfo TaskFromExceptionMethod = typeof(Task).GetRuntimeMethods().Single(
+        m => m is { Name: nameof(Task.FromException), IsGenericMethod: false }
+            && m.GetParameters() is [{ ParameterType: Type parameterType }]
+            && parameterType == typeof(Exception));
     private static readonly ConstructorInfo ValueTaskFromTaskCtor = typeof(ValueTask).GetConstructor([typeof(Task)]) ?? throw Assumes.NotReachable();
 
     /// <summary>

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -61,7 +61,10 @@ internal static class ProxyGeneration
     private static readonly MethodInfo GetParameterNameTransformStateMethod = typeof(CodeGenHelpers).GetRuntimeMethod(nameof(CodeGenHelpers.GetParameterNameTransformState), [typeof(Func<string, string>), typeof(IReadOnlyList<string>)])!;
 
     private static readonly MethodInfo DisposeMethod = typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose)) ?? throw Assumes.NotReachable();
+    private static readonly MethodInfo DisposeAsyncMethod = typeof(System.IAsyncDisposable).GetMethod(nameof(System.IAsyncDisposable.DisposeAsync)) ?? throw Assumes.NotReachable();
     private static readonly MethodInfo IsDisposedPropertyGetter = typeof(IDisposableObservable).GetProperty(nameof(IDisposableObservable.IsDisposed))!.GetMethod ?? throw Assumes.NotReachable();
+    private static readonly MethodInfo TaskFromExceptionMethod = typeof(Task).GetMethods(BindingFlags.Public | BindingFlags.Static).Single(m => m.Name == nameof(Task.FromException) && !m.IsGenericMethod);
+    private static readonly ConstructorInfo ValueTaskFromTaskCtor = typeof(ValueTask).GetConstructor([typeof(Task)]) ?? throw Assumes.NotReachable();
 
     /// <summary>
     /// Gets a dynamically generated type that implements a given interface in terms of a <see cref="JsonRpc"/> instance.
@@ -100,7 +103,7 @@ internal static class ProxyGeneration
             // For ALC selection reasons, it's vital that the *user's* selected interfaces come *before* our own supporting interfaces.
             // If the order is incorrect, type resolution may fail or the wrong AssemblyLoadContext (ALC) may be selected,
             // leading to runtime errors or unexpected behavior when loading types or invoking methods.
-            Type[] proxyInterfaces = [.. rpcInterfaces.Select(i => i.Type), typeof(IJsonRpcClientProxy), typeof(IJsonRpcClientProxyInternal)];
+            Type[] proxyInterfaces = [.. rpcInterfaces.Select(i => i.Type), typeof(IJsonRpcClientProxy), typeof(IJsonRpcClientProxyInternal), typeof(System.IAsyncDisposable)];
             ModuleBuilder proxyModuleBuilder = GetProxyModuleBuilder(proxyInterfaces);
 
             TypeBuilder proxyTypeBuilder = proxyModuleBuilder.DefineType(
@@ -223,7 +226,8 @@ internal static class ProxyGeneration
                 il.Emit(OpCodes.Ret);
             }
 
-            ImplementDisposeMethod(proxyTypeBuilder, jsonRpcField, onDisposeField, disposedField);
+            MethodBuilder disposeMethod = ImplementDisposeMethod(proxyTypeBuilder, jsonRpcField, onDisposeField, disposedField);
+            ImplementDisposeAsyncMethod(proxyTypeBuilder, disposeMethod);
             ImplementIsDisposedProperty(proxyTypeBuilder, jsonRpcField, disposedField);
             ImplementIJsonRpcClientProxyInternal(proxyTypeBuilder, callingMethodField, calledMethodField, marshaledObjectHandleField);
 
@@ -282,7 +286,7 @@ internal static class ProxyGeneration
             IEnumerable<MethodInfo> notifyWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.NotifyWithParameterObjectAsync));
             MethodInfo notifyWithParameterObjectAsyncOfTaskMethodInfo = notifyWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
 
-            HashSet<MethodInfo> implementedMethods = new() { DisposeMethod };
+            HashSet<MethodInfo> implementedMethods = new() { DisposeMethod, DisposeAsyncMethod };
             foreach ((Type rpcInterface, int? rpcInterfaceCode) in rpcInterfaces)
             {
                 RpcTargetMetadata methodNameMap = RpcTargetMetadata.FromInterface(rpcInterface.GetTypeInfo());
@@ -689,7 +693,7 @@ internal static class ProxyGeneration
         il.MarkLabel(notDisposedLabel);
     }
 
-    private static void ImplementDisposeMethod(TypeBuilder proxyTypeBuilder, FieldBuilder jsonRpcField, FieldBuilder onDisposeField, FieldBuilder disposedField)
+    private static MethodBuilder ImplementDisposeMethod(TypeBuilder proxyTypeBuilder, FieldBuilder jsonRpcField, FieldBuilder onDisposeField, FieldBuilder disposedField)
     {
         MethodBuilder methodBuilder = proxyTypeBuilder.DefineMethod(
             DisposeMethod.Name,
@@ -736,6 +740,41 @@ internal static class ProxyGeneration
         il.Emit(OpCodes.Ret);
 
         proxyTypeBuilder.DefineMethodOverride(methodBuilder, DisposeMethod);
+        return methodBuilder;
+    }
+
+    private static void ImplementDisposeAsyncMethod(TypeBuilder proxyTypeBuilder, MethodBuilder disposeMethod)
+    {
+        MethodBuilder methodBuilder = proxyTypeBuilder.DefineMethod(
+            DisposeAsyncMethod.Name,
+            MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,
+            DisposeAsyncMethod.ReturnType,
+            Type.EmptyTypes);
+        ILGenerator il = methodBuilder.GetILGenerator();
+        LocalBuilder resultLocal = il.DeclareLocal(typeof(ValueTask));
+
+        il.BeginExceptionBlock();
+
+        // this.Dispose();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, disposeMethod);
+
+        // result = default;
+        il.Emit(OpCodes.Ldloca_S, resultLocal);
+        il.Emit(OpCodes.Initobj, typeof(ValueTask));
+
+        il.BeginCatchBlock(typeof(Exception));
+
+        // result = new ValueTask(Task.FromException(exception));
+        il.Emit(OpCodes.Call, TaskFromExceptionMethod);
+        il.Emit(OpCodes.Newobj, ValueTaskFromTaskCtor);
+        il.Emit(OpCodes.Stloc, resultLocal);
+
+        il.EndExceptionBlock();
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+
+        proxyTypeBuilder.DefineMethodOverride(methodBuilder, DisposeAsyncMethod);
     }
 
     private static void ImplementIsDisposedProperty(TypeBuilder proxyTypeBuilder, FieldBuilder jsonRpcField, FieldBuilder disposedField)

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -107,7 +107,14 @@ internal static class ProxyGeneration
             // For ALC selection reasons, it's vital that the *user's* selected interfaces come *before* our own supporting interfaces.
             // If the order is incorrect, type resolution may fail or the wrong AssemblyLoadContext (ALC) may be selected,
             // leading to runtime errors or unexpected behavior when loading types or invoking methods.
-            Type[] proxyInterfaces = [.. rpcInterfaces.Select(i => i.Type), typeof(IJsonRpcClientProxy), typeof(IJsonRpcClientProxyInternal), typeof(System.IAsyncDisposable)];
+            Type[] proxyInterfaces =
+            [
+                .. rpcInterfaces.Select(i => i.Type)
+                    .Append(typeof(IJsonRpcClientProxy))
+                    .Append(typeof(IJsonRpcClientProxyInternal))
+                    .Append(typeof(System.IAsyncDisposable))
+                    .Distinct(),
+            ];
             ModuleBuilder proxyModuleBuilder = GetProxyModuleBuilder(proxyInterfaces);
 
             TypeBuilder proxyTypeBuilder = proxyModuleBuilder.DefineType(

--- a/src/StreamJsonRpc/ProxyGeneration.cs
+++ b/src/StreamJsonRpc/ProxyGeneration.cs
@@ -103,7 +103,6 @@ internal static class ProxyGeneration
 
             Type[] contractInterfaces = [contractInterface, .. additionalContractInterfaces];
             IList<(Type Type, int? Code)> rpcInterfaces = GetSortedInterfaceAndCodes(inputs);
-            bool hasAsyncDisposableContract = rpcInterfaces.Any(i => typeof(System.IAsyncDisposable).IsAssignableFrom(i.Type));
 
             // For ALC selection reasons, it's vital that the *user's* selected interfaces come *before* our own supporting interfaces.
             // If the order is incorrect, type resolution may fail or the wrong AssemblyLoadContext (ALC) may be selected,
@@ -239,11 +238,7 @@ internal static class ProxyGeneration
             }
 
             MethodBuilder disposeMethod = ImplementDisposeMethod(proxyTypeBuilder, jsonRpcField, onDisposeField, disposedField);
-            if (!hasAsyncDisposableContract)
-            {
-                ImplementDisposeAsyncMethod(proxyTypeBuilder, disposeMethod);
-            }
-
+            ImplementDisposeAsyncMethod(proxyTypeBuilder, disposeMethod);
             ImplementIsDisposedProperty(proxyTypeBuilder, jsonRpcField, disposedField);
             ImplementIJsonRpcClientProxyInternal(proxyTypeBuilder, callingMethodField, calledMethodField, marshaledObjectHandleField);
 
@@ -302,7 +297,7 @@ internal static class ProxyGeneration
             IEnumerable<MethodInfo> notifyWithParameterObjectAsyncMethodInfos = typeof(JsonRpc).GetTypeInfo().DeclaredMethods.Where(m => m.Name == nameof(JsonRpc.NotifyWithParameterObjectAsync));
             MethodInfo notifyWithParameterObjectAsyncOfTaskMethodInfo = notifyWithParameterObjectAsyncMethodInfos.Single(m => !m.IsGenericMethod && m.GetParameters() is [_, { ParameterType.Name: nameof(Object) }, _]);
 
-            HashSet<MethodInfo> implementedMethods = hasAsyncDisposableContract ? new() { DisposeMethod } : new() { DisposeMethod, DisposeAsyncMethod };
+            HashSet<MethodInfo> implementedMethods = new() { DisposeMethod, DisposeAsyncMethod };
             foreach ((Type rpcInterface, int? rpcInterfaceCode) in rpcInterfaces)
             {
                 RpcTargetMetadata methodNameMap = RpcTargetMetadata.FromInterface(rpcInterface.GetTypeInfo());

--- a/src/StreamJsonRpc/Reflection/ProxyBase.cs
+++ b/src/StreamJsonRpc/Reflection/ProxyBase.cs
@@ -23,7 +23,7 @@ namespace StreamJsonRpc.Reflection;
 /// Abstract base class for source generated proxies.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public abstract class ProxyBase : IJsonRpcClientProxyInternal
+public abstract class ProxyBase : IJsonRpcClientProxyInternal, IAsyncDisposable
 {
     /// <summary>
     /// A map of .NET BCL types that we have special handling for so that users can use them in their RPC interfaces
@@ -326,6 +326,20 @@ public abstract class ProxyBase : IJsonRpcClientProxyInternal
         else
         {
             this.client.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync()
+    {
+        try
+        {
+            this.Dispose();
+            return default;
+        }
+        catch (Exception ex)
+        {
+            return new ValueTask(Task.FromException(ex));
         }
     }
 

--- a/src/StreamJsonRpc/Reflection/ProxyBase.cs
+++ b/src/StreamJsonRpc/Reflection/ProxyBase.cs
@@ -330,7 +330,7 @@ public abstract class ProxyBase : IJsonRpcClientProxyInternal, IAsyncDisposable
     }
 
     /// <inheritdoc/>
-    public ValueTask DisposeAsync()
+    ValueTask IAsyncDisposable.DisposeAsync()
     {
         try
         {

--- a/test/StreamJsonRpc.Tests/DisposableProxyTests.cs
+++ b/test/StreamJsonRpc.Tests/DisposableProxyTests.cs
@@ -89,6 +89,20 @@ public abstract partial class DisposableProxyTests : TestBase
     }
 
     [Fact]
+    public async Task DisposableReturnValue_DisposeAsyncSendsRemoteDisposalAndDisposeIsIdempotent()
+    {
+        IDisposable? proxyDisposable = await this.client.GetDisposableAsync();
+        Assert.NotNull(proxyDisposable);
+        Assumes.NotNull(this.server.ReturnedDisposable);
+
+        await ((System.IAsyncDisposable)proxyDisposable).DisposeAsync();
+        proxyDisposable.Dispose();
+
+        await this.server.ReturnedDisposableDisposed.WaitAsync(this.TimeoutToken);
+        Assert.True(this.server.ReturnedDisposable.IsDisposed);
+    }
+
+    [Fact]
     public async Task DisposableReturnValue_IsMarshaledAndLaterCollected()
     {
         var weakRefs = await this.DisposableReturnValue_Helper();

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -124,6 +124,11 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+    public partial interface IAsyncDisposableServer2 : System.IAsyncDisposable, IServer2
+    {
+    }
+
+    [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     [SuppressMessage("Usage", "StreamJsonRpc0010", Justification = "Overloads are intentional to test proxy cancellation behavior.")]
     public partial interface IServerWithParamsObject
     {
@@ -397,6 +402,23 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
+    public async Task RpcInterfaceCanDispose_IAsyncDisposable()
+    {
+        var streams = FullDuplexStream.CreateStreams();
+
+        var clientRpc = this.AttachJsonRpc<IAsyncDisposableServer2>(streams.Item1);
+        var server = new Server2();
+
+        this.serverRpc = new JsonRpc(streams.Item2);
+        this.serverRpc.AddLocalRpcTarget(server);
+        this.serverRpc.StartListening();
+
+        Assert.Equal(6, await clientRpc.MultiplyAsync(2, 3));
+        await clientRpc.DisposeAsync();
+        Assert.True(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
+    }
+
+    [Fact]
     public async Task CallMethod_void_String()
     {
         Assert.Equal("Hi!", await this.clientRpc.SayHiAsync());
@@ -451,6 +473,14 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
             await Task.Delay(1, TestContext.Current.CancellationToken);
             this.TimeoutToken.ThrowIfCancellationRequested();
         }
+    }
+
+    [Fact]
+    public async Task ImplementsIAsyncDisposable()
+    {
+        var disposableClient = Assert.IsAssignableFrom<System.IAsyncDisposable>(this.clientRpc);
+        await disposableClient.DisposeAsync();
+        Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
     }
 
     [Fact]

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -411,7 +411,7 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
-    public async Task RpcInterfaceCanDispose_IAsyncDisposable()
+    public async Task RpcInterfaceIAsyncDisposableRemainsRemote()
     {
         var streams = FullDuplexStream.CreateStreams();
 
@@ -424,7 +424,9 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
 
         Assert.Equal(6, await clientRpc.MultiplyAsync(2, 3));
         await clientRpc.DisposeAsync();
-        Assert.True(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
+        Assert.Equal(1, server.AsyncDisposeCount);
+        Assert.False(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
+        ((IDisposable)clientRpc).Dispose();
     }
 
     [Fact]
@@ -1448,6 +1450,14 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
 
     internal class Server2 : IServer2
     {
+        internal int AsyncDisposeCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            this.AsyncDisposeCount++;
+            return default;
+        }
+
         public Task<int> MultiplyAsync(int a, int b) => Task.FromResult(a * b);
     }
 

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -129,6 +129,12 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+    public partial interface IServerWithDisposeAsyncMethod
+    {
+        ValueTask DisposeAsync();
+    }
+
+    [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     [SuppressMessage("Usage", "StreamJsonRpc0010", Justification = "Overloads are intentional to test proxy cancellation behavior.")]
     public partial interface IServerWithParamsObject
     {
@@ -481,6 +487,27 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         var disposableClient = Assert.IsAssignableFrom<System.IAsyncDisposable>(this.clientRpc);
         await disposableClient.DisposeAsync();
         Assert.True(((IDisposableObservable)this.clientRpc).IsDisposed);
+    }
+
+    [Fact]
+    public void RpcMethodNamedDisposeAsyncDoesNotCollideWithAsyncDisposal()
+    {
+        var rpc = new JsonRpc(Stream.Null);
+        var clientRpc = rpc.Attach<IServerWithDisposeAsyncMethod>(this.DefaultProxyOptions);
+
+        Assert.IsAssignableFrom<System.IAsyncDisposable>(clientRpc);
+    }
+
+    [Fact]
+    public async Task DisposeAsyncReturnsFaultedValueTaskWhenDisposalFails()
+    {
+        var rpc = new ThrowingDisposeJsonRpc();
+        var clientRpc = (System.IAsyncDisposable)rpc.Attach<IServer>(this.DefaultProxyOptions);
+
+        ValueTask disposal = clientRpc.DisposeAsync();
+
+        Assert.True(disposal.IsCompleted);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => disposal.AsTask());
     }
 
     [Fact]
@@ -1409,6 +1436,11 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     {
         public Task<ExAssembly.SomeOtherInternalType?> GetOptionsAsync(ExAssembly.InternalStruct id, CancellationToken cancellationToken)
             => Task.FromResult<ExAssembly.SomeOtherInternalType?>(null);
+    }
+
+    private sealed class ThrowingDisposeJsonRpc() : JsonRpc(Stream.Null)
+    {
+        protected override void Dispose(bool disposing) => throw new InvalidOperationException();
     }
 
     private class TimeTestedServer : ITimeTestedProxy

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -1216,7 +1216,17 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
 #endif
 
 #if NO_INTERCEPTORS
-    public class Dynamic(ITestOutputHelper logger) : JsonRpcProxyGenerationTests(logger, JsonRpcProxyOptions.ProxyImplementation.AlwaysDynamic);
+    public class Dynamic(ITestOutputHelper logger) : JsonRpcProxyGenerationTests(logger, JsonRpcProxyOptions.ProxyImplementation.AlwaysDynamic)
+    {
+        [Fact]
+        public void IAsyncDisposableMayBeContractInterface()
+        {
+            using JsonRpc rpc = new(Stream.Null);
+            object proxy = rpc.Attach(typeof(System.IAsyncDisposable), this.DefaultProxyOptions);
+
+            Assert.IsAssignableFrom<System.IAsyncDisposable>(proxy);
+        }
+    }
 #endif
 
     public class SourceGenerated(ITestOutputHelper logger) : JsonRpcProxyGenerationTests(logger, JsonRpcProxyOptions.ProxyImplementation.AlwaysSourceGenerated)

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -427,6 +427,7 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         Assert.Equal(1, server.AsyncDisposeCount);
         Assert.False(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
         ((IDisposable)clientRpc).Dispose();
+        Assert.True(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
     }
 
     [Fact]

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -411,7 +411,7 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
-    public async Task RpcInterfaceIAsyncDisposableRemainsRemote()
+    public async Task RpcInterfaceCanDispose_IAsyncDisposable()
     {
         var streams = FullDuplexStream.CreateStreams();
 
@@ -424,10 +424,8 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
 
         Assert.Equal(6, await clientRpc.MultiplyAsync(2, 3));
         await clientRpc.DisposeAsync();
-        Assert.Equal(1, server.AsyncDisposeCount);
-        Assert.False(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
-        ((IDisposable)clientRpc).Dispose();
         Assert.True(((IJsonRpcClientProxy)clientRpc).JsonRpc.IsDisposed);
+        ((IDisposable)clientRpc).Dispose();
     }
 
     [Fact]
@@ -1451,14 +1449,6 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
 
     internal class Server2 : IServer2
     {
-        internal int AsyncDisposeCount { get; private set; }
-
-        public ValueTask DisposeAsync()
-        {
-            this.AsyncDisposeCount++;
-            return default;
-        }
-
         public Task<int> MultiplyAsync(int a, int b) => Task.FromResult(a * b);
     }
 


### PR DESCRIPTION
Client proxies have always supported synchronous disposal, but callers using asynchronous disposal patterns could not dispose them through `System.IAsyncDisposable`.

This change makes both dynamic and source-generated proxies implement `System.IAsyncDisposable`. `DisposeAsync` uniformly performs the same local, synchronous proxy disposal as `IDisposable.Dispose`, including when the RPC contract derives from `IAsyncDisposable`. Disposal failures are represented by a faulted `ValueTask`. For marshaled object proxies, this follows the existing disposal path that sends the protocol-level release/dispose notifications to the server.

Tests cover implicit and explicit `IAsyncDisposable` support, method-name collisions, failure propagation, protocol-level remote release, and idempotent `DisposeAsync` followed by `Dispose` across both proxy implementations and supported test frameworks. The proxy documentation and API remarks are updated accordingly.

Fixes #645