### PR TITLE
Test empty named argument serialization

### DIFF
--- a/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcClient20InteropTests.cs
@@ -137,10 +137,41 @@ public class JsonRpcClient20InteropTests : InteropTestBase
         Assert.Equal("value", request["params"]?["Bar"]?.ToString());
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task InvokeWithParameterPassedAsObjectAsync_NullOrEmptyDictionaryNeverSentAsArray(bool useNull)
+    {
+        IReadOnlyDictionary<string, object?>? arguments = useNull ? null : new Dictionary<string, object?>();
+        Task invokeTask = this.clientRpc.InvokeWithParameterObjectAsync<object>(
+            "test",
+            arguments,
+            argumentDeclaredTypes: null,
+            TestContext.Current.CancellationToken);
+        JToken request = await this.ReceiveAsync();
+        if (useNull)
+        {
+            Assert.Null(request["params"]);
+        }
+        else
+        {
+            Assert.Equal(JTokenType.Object, request["params"]?.Type);
+            Assert.Empty((JObject)request["params"]!);
+        }
+    }
+
     [Fact]
     public async Task InvokeWithParameterPassedAsObjectAsync_NoParameter()
     {
         Task notifyTask = this.clientRpc.InvokeWithParameterObjectAsync<object>("test", cancellationToken: TestContext.Current.CancellationToken);
+        JToken request = await this.ReceiveAsync();
+        Assert.Null(request["params"]);
+    }
+
+    [Fact]
+    public async Task InvokeWithParameterPassedAsObjectAsync_ExplicitNullObjectOmitsParams()
+    {
+        Task invokeTask = this.clientRpc.InvokeWithParameterObjectAsync<object>("test", (object?)null, TestContext.Current.CancellationToken);
         JToken request = await this.ReceiveAsync();
         Assert.Null(request["params"]);
     }

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.Loader;
 #endif
 using Microsoft.VisualStudio.Threading;
 using Nerdbank;
+using Newtonsoft.Json.Linq;
 using StreamJsonRpc.Reflection;
 using StreamJsonRpc.Tests;
 using ExAssembly = StreamJsonRpc.Tests.ExternalAssembly;
@@ -413,6 +414,20 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     {
         await this.clientRpc.IncrementAsync();
         Assert.Equal(1, this.server.Counter);
+    }
+
+    [Fact]
+    public async Task CallMethod_void_void_ServerRequiresNamedArguments_NeverUsesArray()
+    {
+        var messageHandler = new CapturingMessageHandler();
+        using JsonRpc clientRpc = new(messageHandler);
+        IServer proxy = clientRpc.Attach<IServer>(new JsonRpcProxyOptions(this.DefaultProxyOptions) { ServerRequiresNamedArguments = true });
+        clientRpc.StartListening();
+
+        _ = proxy.IncrementAsync();
+        JToken request = await messageHandler.WrittenMessages.DequeueAsync(this.TimeoutToken);
+
+        Assert.NotEqual(JTokenType.Array, request["params"]?.Type);
     }
 
     [Theory]
@@ -1379,6 +1394,41 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     {
         public Task<ExAssembly.SomeOtherInternalType?> GetOptionsAsync(ExAssembly.InternalStruct id, CancellationToken cancellationToken)
             => Task.FromResult<ExAssembly.SomeOtherInternalType?>(null);
+    }
+
+    private sealed class CapturingMessageHandler : MessageHandlerBase
+    {
+        private readonly JsonMessageFormatter formatter;
+
+        internal CapturingMessageHandler()
+            : this(new JsonMessageFormatter())
+        {
+        }
+
+        private CapturingMessageHandler(JsonMessageFormatter formatter)
+            : base(formatter)
+        {
+            this.formatter = formatter;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        internal AsyncQueue<JToken> MessagesToRead { get; } = new();
+
+        internal AsyncQueue<JToken> WrittenMessages { get; } = new();
+
+        protected override async ValueTask<JsonRpcMessage?> ReadCoreAsync(CancellationToken cancellationToken)
+            => this.formatter.Deserialize(await this.MessagesToRead.DequeueAsync(cancellationToken));
+
+        protected override ValueTask WriteCoreAsync(JsonRpcMessage content, CancellationToken cancellationToken)
+        {
+            this.WrittenMessages.Enqueue(this.formatter.Serialize(content));
+            return default;
+        }
+
+        protected override ValueTask FlushAsync(CancellationToken cancellationToken) => default;
     }
 
     private class TimeTestedServer : ITimeTestedProxy

--- a/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcProxyGenerationTests.cs
@@ -165,6 +165,8 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     [JsonRpcContract, GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
     public partial interface IServerWithVoidReturnType
     {
+        void Notify();
+
         void Notify(int a, int b);
 
         void NotifyWithCancellation(int a, int b, CancellationToken cancellationToken);
@@ -417,17 +419,17 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
     }
 
     [Fact]
-    public async Task CallMethod_void_void_ServerRequiresNamedArguments_NeverUsesArray()
+    public async Task CallVoidMethod_NoArguments_ServerRequiresNamedArguments_NeverUsesArray()
     {
         var messageHandler = new CapturingMessageHandler();
         using JsonRpc clientRpc = new(messageHandler);
-        IServer proxy = clientRpc.Attach<IServer>(new JsonRpcProxyOptions(this.DefaultProxyOptions) { ServerRequiresNamedArguments = true });
+        IServerWithVoidReturnType proxy = clientRpc.Attach<IServerWithVoidReturnType>(new JsonRpcProxyOptions(this.DefaultProxyOptions) { ServerRequiresNamedArguments = true });
         clientRpc.StartListening();
 
-        _ = proxy.IncrementAsync();
+        proxy.Notify();
         JToken request = await messageHandler.WrittenMessages.DequeueAsync(this.TimeoutToken);
 
-        Assert.NotEqual(JTokenType.Array, request["params"]?.Type);
+        Assert.True(request["params"] is null or JObject);
     }
 
     [Theory]
@@ -1352,6 +1354,10 @@ public abstract partial class JsonRpcProxyGenerationTests : TestBase
         public ValueTask DoSomethingValueAsync() => default;
 
         public ValueTask<int> AddValueAsync(int a, int b) => new ValueTask<int>(a + b);
+
+        public void Notify()
+        {
+        }
 
         public void Notify(int a, int b) => this.NotifyResult.SetResult(a + b);
 


### PR DESCRIPTION
Issue #1030 requested coverage to ensure parameter-object calls do not serialize empty arguments as `params: []`.

This adds wire-level tests for:
- omitted and explicitly null parameter objects, which continue to omit `params`
- null and empty named-argument dictionaries, ensuring they are omitted or serialized as `{}` rather than `[]`
- source-generated and dynamic proxies with `ServerRequiresNamedArguments`

No product change is required because the reported behavior does not reproduce on the current implementation.

Fixes #1030