### PR TITLE
Propagate async enumerable cancellation between reads

### DIFF
--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -185,20 +185,12 @@ public class MessageFormatterEnumerableTracker
     }
 
     private ValueTask OnDisposeAsync(long token)
-        => this.DisposeGeneratorAsync(token, throwIfNotFound: true);
-
-    private ValueTask DisposeGeneratorAsync(long token, bool throwIfNotFound)
     {
         IGeneratingEnumeratorTracker? generator;
         lock (this.syncObject)
         {
             if (!this.generatorsByToken.TryGetValue(token, out generator))
             {
-                if (throwIfNotFound)
-                {
-                    throw new LocalRpcException(Resources.UnknownTokenToMarshaledObject) { ErrorCode = (int)JsonRpcErrorCode.NoMarshaledObjectFound };
-                }
-
                 return default;
             }
 
@@ -335,7 +327,7 @@ public class MessageFormatterEnumerableTracker
                     {
                         // Clean up all resources since we don't expect the client to send a dispose notification
                         // since finishing the enumeration implicitly should dispose of it.
-                        await this.tracker.DisposeGeneratorAsync(this.token, throwIfNotFound: false).ConfigureAwait(false);
+                        await this.tracker.OnDisposeAsync(this.token).ConfigureAwait(false);
                     }
 
                     return new EnumeratorResults<T>
@@ -348,7 +340,7 @@ public class MessageFormatterEnumerableTracker
             catch
             {
                 // An error is considered fatal to the enumerable, so clean up everything.
-                await this.tracker.DisposeGeneratorAsync(this.token, throwIfNotFound: false).ConfigureAwait(false);
+                await this.tracker.OnDisposeAsync(this.token).ConfigureAwait(false);
                 throw;
             }
         }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -185,13 +185,21 @@ public class MessageFormatterEnumerableTracker
     }
 
     private ValueTask OnDisposeAsync(long token)
+        => this.DisposeGeneratorAsync(token, throwIfNotFound: true);
+
+    private ValueTask DisposeGeneratorAsync(long token, bool throwIfNotFound)
     {
         IGeneratingEnumeratorTracker? generator;
         lock (this.syncObject)
         {
             if (!this.generatorsByToken.TryGetValue(token, out generator))
             {
-                throw new LocalRpcException(Resources.UnknownTokenToMarshaledObject) { ErrorCode = (int)JsonRpcErrorCode.NoMarshaledObjectFound };
+                if (throwIfNotFound)
+                {
+                    throw new LocalRpcException(Resources.UnknownTokenToMarshaledObject) { ErrorCode = (int)JsonRpcErrorCode.NoMarshaledObjectFound };
+                }
+
+                return default;
             }
 
             this.generatorsByToken.Remove(token);
@@ -327,7 +335,7 @@ public class MessageFormatterEnumerableTracker
                     {
                         // Clean up all resources since we don't expect the client to send a dispose notification
                         // since finishing the enumeration implicitly should dispose of it.
-                        await this.tracker.OnDisposeAsync(this.token).ConfigureAwait(false);
+                        await this.tracker.DisposeGeneratorAsync(this.token, throwIfNotFound: false).ConfigureAwait(false);
                     }
 
                     return new EnumeratorResults<T>
@@ -340,7 +348,7 @@ public class MessageFormatterEnumerableTracker
             catch
             {
                 // An error is considered fatal to the enumerable, so clean up everything.
-                await this.tracker.OnDisposeAsync(this.token).ConfigureAwait(false);
+                await this.tracker.DisposeGeneratorAsync(this.token, throwIfNotFound: false).ConfigureAwait(false);
                 throw;
             }
         }
@@ -414,8 +422,11 @@ public class MessageFormatterEnumerableTracker
         {
             private readonly AsyncEnumerableProxy<T> owner;
             private readonly CancellationToken cancellationToken;
+            private readonly CancellationTokenRegistration cancellationRegistration;
             private readonly object[]? nextOrDisposeArguments;
             private readonly IDisposable? requestResourcesDeferral;
+            private readonly object abortSyncObject = new object();
+            private Task? abortNotificationTask;
 
             /// <summary>
             /// A sequence of values that have already been received from the generator but not yet consumed.
@@ -444,6 +455,9 @@ public class MessageFormatterEnumerableTracker
 
                 this.generatorReportsFinished = finished;
                 this.requestResourcesDeferral = requestResourcesDeferral;
+                this.cancellationRegistration = cancellationToken.Register(
+                    static state => ((AsyncEnumeratorProxy)state!).NotifyServerOfAbortAsync().Forget(),
+                    this);
             }
 
             public T Current
@@ -465,6 +479,11 @@ public class MessageFormatterEnumerableTracker
                 if (!this.disposed)
                 {
                     this.disposed = true;
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                    await this.cancellationRegistration.DisposeAsync().ConfigureAwait(false);
+#else
+                    this.cancellationRegistration.Dispose();
+#endif
 
                     // Recycle buffers
                     this.localCachedValues.Reset();
@@ -472,7 +491,7 @@ public class MessageFormatterEnumerableTracker
                     // Notify server if it wasn't already finished.
                     if (!this.generatorReportsFinished)
                     {
-                        await this.owner.jsonRpc.NotifyAsync(DisposeMethodName, this.nextOrDisposeArguments).ConfigureAwait(false);
+                        await this.NotifyServerOfAbortAsync().ConfigureAwait(false);
                     }
 
                     // Clean up any local resources that were held open for the remote source of the enumeration.
@@ -518,6 +537,14 @@ public class MessageFormatterEnumerableTracker
                         }
 
                         this.generatorReportsFinished = results.Finished;
+                        if (this.generatorReportsFinished)
+                        {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                            await this.cancellationRegistration.DisposeAsync().ConfigureAwait(false);
+#else
+                            this.cancellationRegistration.Dispose();
+#endif
+                        }
                     }
                     catch (RemoteInvocationException ex)
                     {
@@ -545,6 +572,16 @@ public class MessageFormatterEnumerableTracker
                 }
 
                 writer.Advance(values.Count);
+            }
+
+            private Task NotifyServerOfAbortAsync()
+            {
+                lock (this.abortSyncObject)
+                {
+                    return this.generatorReportsFinished || this.nextOrDisposeArguments is null
+                        ? Task.CompletedTask
+                        : this.abortNotificationTask ??= this.owner.jsonRpc.NotifyAsync(DisposeMethodName, this.nextOrDisposeArguments);
+                }
             }
         }
     }

--- a/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterEnumerableTracker.cs
@@ -471,11 +471,7 @@ public class MessageFormatterEnumerableTracker
                 if (!this.disposed)
                 {
                     this.disposed = true;
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-                    await this.cancellationRegistration.DisposeAsync().ConfigureAwait(false);
-#else
-                    this.cancellationRegistration.Dispose();
-#endif
+                    await this.DisposeCancellationRegistrationAsync().ConfigureAwait(false);
 
                     // Recycle buffers
                     this.localCachedValues.Reset();
@@ -531,17 +527,14 @@ public class MessageFormatterEnumerableTracker
                         this.generatorReportsFinished = results.Finished;
                         if (this.generatorReportsFinished)
                         {
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-                            await this.cancellationRegistration.DisposeAsync().ConfigureAwait(false);
-#else
-                            this.cancellationRegistration.Dispose();
-#endif
+                            await this.DisposeCancellationRegistrationAsync().ConfigureAwait(false);
                         }
                     }
                     catch (RemoteInvocationException ex)
                     {
                         // Avoid spending a message asking the server to dispose of the marshalled enumerator since they threw an exception at us.
                         this.generatorReportsFinished = true;
+                        await this.DisposeCancellationRegistrationAsync().ConfigureAwait(false);
 
                         if (ex.ErrorCode == (int)JsonRpcErrorCode.NoMarshaledObjectFound)
                         {
@@ -564,6 +557,16 @@ public class MessageFormatterEnumerableTracker
                 }
 
                 writer.Advance(values.Count);
+            }
+
+            private ValueTask DisposeCancellationRegistrationAsync()
+            {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                return this.cancellationRegistration.DisposeAsync();
+#else
+                this.cancellationRegistration.Dispose();
+                return default;
+#endif
             }
 
             private Task NotifyServerOfAbortAsync()

--- a/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
+++ b/test/StreamJsonRpc.Tests/AsyncEnumerableTests.cs
@@ -60,6 +60,8 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
         IAsyncEnumerable<int> GetNumbersNoCancellationAsync();
 
+        IAsyncEnumerable<int> WaitForCancellationAfterYieldAsync(CancellationToken cancellationToken);
+
         IAsyncEnumerable<int> WaitTillCanceledBeforeFirstItemAsync(CancellationToken cancellationToken);
 
         Task<IAsyncEnumerable<int>> WaitTillCanceledBeforeReturningAsync(CancellationToken cancellationToken);
@@ -320,6 +322,23 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
         Assert.True(await enumerator.MoveNextAsync());
         cts.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Theory]
+    [PairwiseData]
+    public async Task Cancellation_BetweenMoveNextCallsCancelsServerMethod(bool useProxy)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(this.TimeoutToken);
+        IAsyncEnumerable<int> enumerable = useProxy
+            ? this.clientProxy.Value.WaitForCancellationAfterYieldAsync(cts.Token)
+            : await this.clientRpc.InvokeWithCancellationAsync<IAsyncEnumerable<int>>(nameof(Server.WaitForCancellationAfterYieldAsync), cancellationToken: cts.Token);
+
+        await using IAsyncEnumerator<int> enumerator = enumerable.GetAsyncEnumerator(useProxy ? CancellationToken.None : cts.Token);
+        Assert.True(await enumerator.MoveNextAsync());
+
+        cts.Cancel();
+
+        await this.server.MethodCancellationObserved.WaitAsync(this.TimeoutToken);
     }
 
     [Fact]
@@ -655,6 +674,8 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
 
         public AsyncManualResetEvent MethodExited { get; } = new AsyncManualResetEvent();
 
+        public AsyncManualResetEvent MethodCancellationObserved { get; } = new AsyncManualResetEvent();
+
         public Task? ArgEnumeratorAfterReturn { get; private set; }
 
         public AsyncManualResetEvent AllowEnumeratorToContinue { get; } = new AsyncManualResetEvent();
@@ -682,6 +703,15 @@ public abstract partial class AsyncEnumerableTests : TestBase, IAsyncLifetime
             => this.GetNumbersAsync(cancellationToken).WithJsonRpcSettings(new JsonRpcEnumerableSettings { MaxReadAhead = MaxReadAhead, MinBatchSize = MinBatchSize });
 
         public IAsyncEnumerable<int> GetNumbersNoCancellationAsync() => this.GetNumbersAsync(CancellationToken.None);
+
+        public async IAsyncEnumerable<int> WaitForCancellationAfterYieldAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            using (cancellationToken.Register(this.MethodCancellationObserved.Set))
+            {
+                yield return 1;
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+        }
 
         public async IAsyncEnumerable<int> GetNumbersAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Cancellation of a remote `IAsyncEnumerable<T>` was only propagated while a `MoveNextAsync` request was active. Long-running server work therefore continued when cancellation occurred between reads.

Register the client enumerator's cancellation token to send a deduplicated `$/enumerator/abort` notification immediately. Server-side generator cleanup is now idempotent so an abort racing with an in-flight `MoveNextAsync` preserves the expected cancellation result. Regression coverage exercises direct and generated proxies across the supported formatters.

Fixes #478