### PR TITLE
Avoid retaining returned PipeReader channels

### DIFF
--- a/src/StreamJsonRpc/FormatterBase.cs
+++ b/src/StreamJsonRpc/FormatterBase.cs
@@ -17,7 +17,7 @@ namespace StreamJsonRpc;
 /// A base class for <see cref="IJsonRpcMessageFormatter"/> implementations
 /// that support exotic types.
 /// </summary>
-public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceContainer, IDisposable
+public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcFormatterStateInternal, IJsonRpcInstanceContainer, IDisposable
 {
     private JsonRpc? rpc;
 
@@ -52,6 +52,8 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
 
     private bool serializingRequest;
 
+    private bool deserializingRequest;
+
     private int nullParamsWarningEmitted;
 
     /// <summary>
@@ -80,6 +82,9 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
 
     /// <inheritdoc  />
     bool IJsonRpcFormatterState.SerializingRequest => this.serializingRequest;
+
+    /// <inheritdoc/>
+    bool IJsonRpcFormatterStateInternal.DeserializingRequest => this.deserializingRequest;
 
     /// <inheritdoc/>
     JsonRpc IJsonRpcInstanceContainer.Rpc
@@ -326,6 +331,7 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
             {
                 formatter.DeserializingMessage = message;
                 formatter.deserializingMessageWithId = (message as IJsonRpcMessageWithId)?.RequestId ?? default;
+                formatter.deserializingRequest = message is JsonRpcRequest;
 
                 // Consider the attribute applied to the particular overload that we're considering right now.
                 formatter.ApplicableMethodAttributeOnDeserializingMethod = message is JsonRpcRequest { Method: not null } request ? formatter.JsonRpc?.GetJsonRpcMethodAttribute(request.Method, parameters) : null;
@@ -342,6 +348,7 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcInstanceCo
             if (this.formatter is not null)
             {
                 this.formatter.deserializingMessageWithId = default;
+                this.formatter.deserializingRequest = false;
                 this.formatter.DeserializingMessage = null;
                 this.formatter.ApplicableMethodAttributeOnDeserializingMethod = null;
             }

--- a/src/StreamJsonRpc/Reflection/IJsonRpcFormatterState.cs
+++ b/src/StreamJsonRpc/Reflection/IJsonRpcFormatterState.cs
@@ -27,3 +27,14 @@ public interface IJsonRpcFormatterState
     /// </remarks>
     public bool SerializingRequest { get; }
 }
+
+/// <summary>
+/// Describes internal formatter state that supports distinguishing requests from responses.
+/// </summary>
+internal interface IJsonRpcFormatterStateInternal
+{
+    /// <summary>
+    /// Gets a value indicating whether a <see cref="Protocol.JsonRpcRequest"/> is being deserialized.
+    /// </summary>
+    bool DeserializingRequest { get; }
+}

--- a/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
+++ b/src/StreamJsonRpc/Reflection/MessageFormatterDuplexPipeTracker.cs
@@ -91,7 +91,9 @@ public class MessageFormatterDuplexPipeTracker : IDisposableObservable
     /// <summary>
     /// Gets the ID of the request currently being deserialized for use as a key in <see cref="inboundRequestChannelMap"/>.
     /// </summary>
-    private RequestId RequestIdBeingDeserialized => this.formatterState.DeserializingMessageWithId;
+    private RequestId RequestIdBeingDeserialized => this.formatterState is IJsonRpcFormatterStateInternal { DeserializingRequest: false }
+        ? default
+        : this.formatterState.DeserializingMessageWithId;
 
     /// <inheritdoc cref="GetULongToken(IDuplexPipe?)"/>
     [return: NotNullIfNotNull("duplexPipe")]

--- a/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
+++ b/test/StreamJsonRpc.Tests/DuplexPipeMarshalingTests.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using Microsoft.VisualStudio.Threading;
@@ -216,6 +217,24 @@ public abstract partial class DuplexPipeMarshalingTests : TestBase, IAsyncLifeti
         }
 
         Assert.Equal<byte>(MemoryBuffer.Take(bytesToReceive), buffer.Take(bytesToReceive));
+    }
+
+    [Fact]
+    public async Task ReturnedPipeReaderIsCollectedAfterCompletion()
+    {
+        WeakReference readerReference = await GetAndCompleteReaderAsync();
+        await this.AssertWeakReferenceGetsCollectedAsync(readerReference);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        async Task<WeakReference> GetAndCompleteReaderAsync()
+        {
+            PipeReader reader = await this.clientRpc.InvokeAsync<PipeReader>(nameof(Server.ServerMethodThatReturnsPipeReader));
+            using var content = new MemoryStream();
+            await reader.CopyToAsync(content, this.TimeoutToken);
+            reader.Complete();
+            Assert.Equal(MemoryBuffer, content.ToArray());
+            return new WeakReference(reader);
+        }
     }
 
     [Theory]
@@ -893,6 +912,14 @@ public abstract partial class DuplexPipeMarshalingTests : TestBase, IAsyncLifeti
         public Task RejectCall(IDuplexPipe pipe) => Task.FromException(new InvalidOperationException("Expected test exception."));
 
         public object ReturnPipeAsObject() => FullDuplexStream.CreatePipePair().Item1;
+
+        public async Task<PipeReader> ServerMethodThatReturnsPipeReader()
+        {
+            var pipe = new Pipe();
+            await pipe.Writer.WriteAsync(MemoryBuffer);
+            pipe.Writer.Complete();
+            return pipe.Reader;
+        }
 
         public Stream ServerMethodThatReturnsStream() => new MemoryStream(Encoding.UTF8.GetBytes("Streamed bits!"));
 


### PR DESCRIPTION
Returned `PipeReader` values were recorded in the inbound request channel map while deserializing RPC responses. Since `ResponseSent` is not raised on the receiving client, completed readers remained strongly referenced and could cause unbounded memory growth.

Track whether the formatter is deserializing a request or a response, and only associate channels with the inbound request cleanup map for actual requests. Add regression coverage that drains and completes a returned reader, then verifies it can be collected across all supported formatters.

Fixes #1146