### PR TITLE
Exclude F# sample binaries from symbol collection

### DIFF
--- a/tools/Get-SymbolFiles.ps1
+++ b/tools/Get-SymbolFiles.ps1
@@ -17,8 +17,8 @@ $ActivityName = "Collecting symbols from $Path"
 Write-Progress -Activity $ActivityName -CurrentOperation "Discovery PDB files"
 $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 
-# Remove samples
-$PDBs = $PDBs | Where-Object { $_.FullName -notmatch "samples" }
+# Remove sample project outputs. Build outputs are grouped by project name rather than source path.
+$PDBs = $PDBs | Where-Object { $_.FullName -notmatch "[\\/](Samples|FSharpSample)[\\/]" }
 
 # Filter PDBs to product OR test related.
 $testregex = "unittest|tests|\.test\.|Benchmarks|UnreachableAssembly"


### PR DESCRIPTION
The symbol collector's plural-only sample exclusion missed `FSharpSample`, causing official CI to pass unsigned, non-shipping sample binaries to BinSkim. Match both sample output directory names explicitly so neither sample is collected in `symbols-Windows`.