### PR TITLE
Prefer cancellable RPC overloads

### DIFF
--- a/docfx/analyzers/StreamJsonRpc0010.md
+++ b/docfx/analyzers/StreamJsonRpc0010.md
@@ -9,6 +9,8 @@ Two methods are considered ambiguous when:
 
 Parameter names and types do not resolve this warning because positional JSON-RPC arguments include neither. StreamJsonRpc may try deserializing arguments into each candidate overload, but the first overload that succeeds is not a reliable way to select a method and adds avoidable overhead.
 
+Overloads that differ only by a trailing <xref:System.Threading.CancellationToken> are not ambiguous. StreamJsonRpc consistently selects the overload with the cancellation token so that incoming request cancellation can be observed.
+
 ## Example violation
 
 Both overloads below accept two serialized arguments.

--- a/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
+++ b/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
@@ -515,7 +515,7 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
             {
                 (IMethodSymbol method, int minimumArgumentCount, int maximumArgumentCount) = methods[i];
                 bool overlaps = methods.Where((_, index) => index != i).Any(other =>
-                    !this.HaveEquivalentContractSignature(method, other.Method) &&
+                    !this.HaveEquivalentRpcSignature(method, other.Method, knownSymbols) &&
                     minimumArgumentCount <= other.MaximumArgumentCount &&
                     other.MinimumArgumentCount <= maximumArgumentCount);
                 if (overlaps)
@@ -531,15 +531,21 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private bool HaveEquivalentContractSignature(IMethodSymbol first, IMethodSymbol second)
+    private bool HaveEquivalentRpcSignature(IMethodSymbol first, IMethodSymbol second, KnownSymbols knownSymbols)
     {
-        if (!SymbolEqualityComparer.Default.Equals(first.ReturnType, second.ReturnType) ||
-            first.Parameters.Length != second.Parameters.Length)
+        if (!SymbolEqualityComparer.Default.Equals(first.ReturnType, second.ReturnType))
         {
             return false;
         }
 
-        for (int i = 0; i < first.Parameters.Length; i++)
+        int firstParameterCount = GetRpcParameterCount(first);
+        int secondParameterCount = GetRpcParameterCount(second);
+        if (firstParameterCount != secondParameterCount)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < firstParameterCount; i++)
         {
             IParameterSymbol firstParameter = first.Parameters[i];
             IParameterSymbol secondParameter = second.Parameters[i];
@@ -551,6 +557,14 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+
+        int GetRpcParameterCount(IMethodSymbol method)
+        {
+            return method.Parameters is [.., { Type: { } type }] &&
+                SymbolEqualityComparer.Default.Equals(type, knownSymbols.CancellationToken)
+                ? method.Parameters.Length - 1
+                : method.Parameters.Length;
+        }
     }
 
     private string GetNormalizedRpcMethodName(IMethodSymbol method, KnownSymbols knownSymbols)

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -297,11 +297,11 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                     this.targetRequestMethodToClrMethodMap.Add(rpcMethodName, existingList = new List<MethodSignatureAndTarget>());
                 }
 
-                // Only add methods that do not have equivalent signatures to what we already have.
+                // Avoid adding the same metadata twice while allowing distinct wire-equivalent overloads.
                 foreach (RpcTargetMetadata.TargetMethodMetadata newMethod in item.Value)
                 {
                     // Null forgiveness operator in use due to: https://github.com/dotnet/roslyn/issues/73274
-                    if (!alreadyExists || !existingList!.Any(e => e.Signature == newMethod))
+                    if (!alreadyExists || !existingList!.Any(e => ReferenceEquals(e.Signature, newMethod)))
                     {
                         var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -300,10 +300,11 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                 // Avoid adding the same metadata twice while allowing distinct wire-equivalent overloads.
                 foreach (RpcTargetMetadata.TargetMethodMetadata newMethod in item.Value)
                 {
+                    var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
+
                     // Null forgiveness operator in use due to: https://github.com/dotnet/roslyn/issues/73274
-                    if (!alreadyExists || !existingList!.Any(e => ReferenceEquals(e.Signature, newMethod)))
+                    if (!alreadyExists || !existingList!.Any(e => e.Equals(signatureAndTarget)))
                     {
-                        var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);
                         revertAddLocalRpcTarget?.RecordMethodAdded(rpcMethodName, signatureAndTarget);
                         AddMethodWithCancellationPreference(existingList!, signatureAndTarget);
@@ -325,6 +326,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         if (method.Signature.HasCancellationTokenParameter)
         {
             int equivalentNonCancelableMethodIndex = methods.FindIndex(candidate =>
+                ReferenceEquals(candidate.Target, method.Target) &&
                 !candidate.Signature.HasCancellationTokenParameter &&
                 candidate.Signature.EqualSignature(method.Signature));
             if (equivalentNonCancelableMethodIndex >= 0)

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -306,7 +306,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                         var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);
                         revertAddLocalRpcTarget?.RecordMethodAdded(rpcMethodName, signatureAndTarget);
-                        existingList!.Add(signatureAndTarget);
+                        AddMethodWithCancellationPreference(existingList!, signatureAndTarget);
                     }
                     else
                     {
@@ -318,6 +318,23 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                 }
             }
         }
+    }
+
+    private static void AddMethodWithCancellationPreference(List<MethodSignatureAndTarget> methods, MethodSignatureAndTarget method)
+    {
+        if (method.Signature.HasCancellationTokenParameter)
+        {
+            int equivalentNonCancelableMethodIndex = methods.FindIndex(candidate =>
+                !candidate.Signature.HasCancellationTokenParameter &&
+                candidate.Signature.EqualSignature(method.Signature));
+            if (equivalentNonCancelableMethodIndex >= 0)
+            {
+                methods.Insert(equivalentNonCancelableMethodIndex, method);
+                return;
+            }
+        }
+
+        methods.Add(method);
     }
 
     private void TraceLocalMethodAdded(string rpcMethodName, MethodSignatureAndTarget targetMethod)

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -301,7 +301,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                 foreach (RpcTargetMetadata.TargetMethodMetadata newMethod in item.Value)
                 {
                     // Null forgiveness operator in use due to: https://github.com/dotnet/roslyn/issues/73274
-                    if (!alreadyExists || !existingList!.Any(e => e.Equals(newMethod)))
+                    if (!alreadyExists || !existingList!.Any(e => e.Signature == newMethod))
                     {
                         var signatureAndTarget = new MethodSignatureAndTarget(newMethod, target, pseudoAttribute, null, options.ParameterNameTransform);
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);

--- a/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
@@ -186,6 +186,19 @@ public class JsonRpcContractAnalyzerTests
     }
 
     [Fact]
+    public async Task AmbiguousMethodOverloads_DifferOnlyByCancellationToken()
+    {
+        await VerifyCS.VerifyAnalyzerAsync("""
+            [JsonRpcContract, TypeShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            public partial interface IMyRpc
+            {
+                Task ExecuteAsync();
+                Task ExecuteAsync(CancellationToken cancellationToken);
+            }
+            """);
+    }
+
+    [Fact]
     public async Task AmbiguousMethodOverloads_IgnoresNonRpcMethods()
     {
         await VerifyCS.VerifyAnalyzerAsync("""

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -52,6 +52,43 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     }
 
     [Fact]
+    public async Task CancellationPreferencePreservesTargetRegistrationOrder()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2));
+        serverRpc.AddLocalRpcTarget(new FirstTarget());
+        serverRpc.AddLocalRpcTarget(new SecondTarget());
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        string result = await clientRpc.InvokeAsync<string>(nameof(FirstTarget.GetTargetAsync));
+
+        Assert.Equal("first", result);
+    }
+
+    [Fact]
+    public async Task RegisteringSameTargetTypeRetainsDistinctTargets()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2));
+        var firstTarget = new RepeatedTarget("first");
+        var secondTarget = new RepeatedTarget("second");
+        serverRpc.AddLocalRpcTarget(firstTarget, new JsonRpcTargetOptions { ParameterNameTransform = CommonMethodNameTransforms.Prepend("rpc.") });
+        serverRpc.AddLocalRpcTarget(secondTarget);
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        string result = await clientRpc.InvokeWithParameterObjectAsync<string>(
+            nameof(RepeatedTarget.GetTargetAsync),
+            new { argument = "argument" },
+            this.TimeoutToken);
+
+        Assert.Equal("second", result);
+    }
+
+    [Fact]
     public async Task DelegatedDispatcherCanDispatchInReverseOrderBasedOnTopLevelProperty()
     {
         this.serverRpc.EnableBuffering = true;
@@ -114,6 +151,28 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         {
             throw new InvalidProgramException();
         }
+    }
+
+    public class FirstTarget
+    {
+        public Task<string> GetTargetAsync() => Task.FromResult("first");
+    }
+
+    public class SecondTarget
+    {
+        public Task<string> GetTargetAsync(CancellationToken cancellationToken) => Task.FromResult("second");
+    }
+
+    public class RepeatedTarget
+    {
+        private readonly string value;
+
+        public RepeatedTarget(string value)
+        {
+            this.value = value;
+        }
+
+        public Task<string> GetTargetAsync(string argument) => Task.FromResult(this.value);
     }
 
     public class DelegatedJsonRpc : JsonRpc

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Reflection;
 using Microsoft.VisualStudio.Threading;
 
 public class JsonRpcDelegatedDispatchAndSendTests : TestBase
@@ -39,6 +40,15 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         await this.clientRpc.InvokeAsync<string>(nameof(Server.TestMethodAsync));
         Assert.Equal(typeof(Server), this.serverRpc.LastTargetMethodDispatched?.TargetObjectType);
         Assert.Equal(typeof(Server).GetMethod(nameof(Server.TestMethodAsync)), this.serverRpc.LastTargetMethodDispatched?.TargetMethodInfo);
+    }
+
+    [Fact]
+    public async Task DispatchRequestPrefersEquivalentOverloadWithCancellationToken()
+    {
+        await this.clientRpc.InvokeAsync(nameof(Server.PreferCancelableAsync));
+
+        MethodInfo? expectedMethod = typeof(Server).GetMethod(nameof(Server.PreferCancelableAsync), [typeof(CancellationToken)]);
+        Assert.Equal(expectedMethod, this.serverRpc.LastTargetMethodDispatched?.TargetMethodInfo);
     }
 
     [Fact]
@@ -89,6 +99,10 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         {
             return Task.CompletedTask;
         }
+
+        public Task PreferCancelableAsync() => Task.CompletedTask;
+
+        public Task PreferCancelableAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<int> GetCallCountAsync()
         {

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -48,6 +48,7 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         await this.clientRpc.InvokeAsync(nameof(Server.PreferCancelableAsync));
 
         MethodInfo? expectedMethod = typeof(Server).GetMethod(nameof(Server.PreferCancelableAsync), [typeof(CancellationToken)]);
+        Assert.NotNull(expectedMethod);
         Assert.Equal(expectedMethod, this.serverRpc.LastTargetMethodDispatched?.TargetMethodInfo);
     }
 


### PR DESCRIPTION
RPC overloads that differ only by a trailing `CancellationToken` are identical on the wire, but dispatch previously depended on reflection order and StreamJsonRpc0010 reported them as ambiguous.

This change deterministically orders equivalent cancellable overloads ahead of their non-cancellable counterparts, allowing incoming request cancellation to be observed. It also updates StreamJsonRpc0010 to treat these signatures as equivalent and adds runtime and analyzer coverage plus documentation.