### PR TITLE
Ignore disposal methods in RPC ambiguity checks

### DIFF
--- a/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
+++ b/src/StreamJsonRpc.Analyzers/JsonRpcContractAnalyzer.cs
@@ -486,6 +486,8 @@ public class JsonRpcContractAnalyzer : DiagnosticAnalyzer
         {
             if (method.IsStatic ||
                 method.MethodKind != MethodKind.Ordinary ||
+                SymbolEqualityComparer.Default.Equals(method.ContainingType, knownSymbols.IDisposable) ||
+                (knownSymbols.IAsyncDisposable is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, knownSymbols.IAsyncDisposable)) ||
                 method.GetAttributes().Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, knownSymbols.JsonRpcIgnoreAttribute)) ||
                 !visitedMethods.Add(method))
             {

--- a/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
+++ b/test/StreamJsonRpc.Analyzer.Tests/JsonRpcContractAnalyzerTests.cs
@@ -201,6 +201,30 @@ public class JsonRpcContractAnalyzerTests
     }
 
     [Fact]
+    public async Task AmbiguousMethodOverloads_IgnoresDisposalInterfaceMethods()
+    {
+        await VerifyCS.VerifyAnalyzerAsync("""
+            [RpcMarshalable, TypeShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            public partial interface IFoo : IAsyncDisposable, IDisposable
+            {
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task AmbiguousMethodOverloads_UserDefinedDisposalMethodsAreRpcMethods()
+    {
+        await VerifyCS.VerifyAnalyzerAsync("""
+            [JsonRpcContract, TypeShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            public partial interface IFoo
+            {
+                void {|StreamJsonRpc0010:Dispose|}();
+                ValueTask {|StreamJsonRpc0010:DisposeAsync|}();
+            }
+            """);
+    }
+
+    [Fact]
     public async Task AmbiguousMethodOverloads_InheritedMethods()
     {
         await VerifyCS.VerifyAnalyzerAsync("""


### PR DESCRIPTION
`IDisposable.Dispose` and `IAsyncDisposable.DisposeAsync` normalize to the same RPC method name, causing a false StreamJsonRpc0010 diagnostic even though disposal is handled specially by the RPC layer.

Exclude methods declared by these two framework interfaces from overload ambiguity analysis, matching the proxy generator's existing behavior. The check remains symbol-specific, so user-defined `Dispose` and `DisposeAsync` RPC methods are still diagnosed when ambiguous.

Tests cover both the framework-interface exception and the user-defined method case.