### PR TITLE
Defer cancellation overload reflection

### DIFF
--- a/src/StreamJsonRpc/FormatterBase.cs
+++ b/src/StreamJsonRpc/FormatterBase.cs
@@ -334,7 +334,7 @@ public abstract class FormatterBase : IJsonRpcFormatterState, IJsonRpcFormatterS
                 formatter.deserializingRequest = message is JsonRpcRequest;
 
                 // Consider the attribute applied to the particular overload that we're considering right now.
-                formatter.ApplicableMethodAttributeOnDeserializingMethod = message is JsonRpcRequest { Method: not null } request ? formatter.JsonRpc?.GetJsonRpcMethodAttribute(request.Method, parameters) : null;
+                formatter.ApplicableMethodAttributeOnDeserializingMethod = message is JsonRpcRequest { Method: not null } request ? formatter.JsonRpc?.GetJsonRpcMethodAttribute(request, parameters) : null;
 
                 this.formatter = formatter;
             }

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1064,12 +1064,20 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     /// <inheritdoc cref="AddLocalRpcMethod(MethodInfo, object?, JsonRpcMethodAttribute?, SynchronizationContext?)"/>
     public void AddLocalRpcMethod(MethodInfo handler, object? target, JsonRpcMethodAttribute? methodRpcSettings) => this.AddLocalRpcMethod(handler, target, methodRpcSettings, synchronizationContext: null);
 
+#pragma warning disable SA1202 // Internal formatter hook must be adjacent to its public counterpart.
+    internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(JsonRpcRequest request, ReadOnlySpan<ParameterInfo> parameters)
+    {
+        Requires.NotNull(request);
+        return this.rpcTargetInfo.GetJsonRpcMethodAttribute(request.Method!, parameters, request);
+    }
+
     /// <inheritdoc cref="RpcTargetInfo.GetJsonRpcMethodAttribute(string, ReadOnlySpan{ParameterInfo})"/>
     public JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(string methodName, ReadOnlySpan<ParameterInfo> parameters)
     {
         Requires.NotNull(methodName, nameof(methodName));
         return this.rpcTargetInfo.GetJsonRpcMethodAttribute(methodName, parameters);
     }
+#pragma warning restore SA1202
 
     /// <summary>
     /// Starts listening to incoming messages.

--- a/src/StreamJsonRpc/JsonRpc.cs
+++ b/src/StreamJsonRpc/JsonRpc.cs
@@ -1065,6 +1065,12 @@ public class JsonRpc : IDisposableObservable, IJsonRpcFormatterCallbacks, IJsonR
     public void AddLocalRpcMethod(MethodInfo handler, object? target, JsonRpcMethodAttribute? methodRpcSettings) => this.AddLocalRpcMethod(handler, target, methodRpcSettings, synchronizationContext: null);
 
 #pragma warning disable SA1202 // Internal formatter hook must be adjacent to its public counterpart.
+    /// <summary>
+    /// Gets the method attribute selected for an incoming request and candidate parameter list.
+    /// </summary>
+    /// <param name="request">The incoming request used to select the applicable target overload.</param>
+    /// <param name="parameters">The candidate parameters currently being deserialized.</param>
+    /// <returns>The applicable method attribute, if one was found.</returns>
     internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(JsonRpcRequest request, ReadOnlySpan<ParameterInfo> parameters)
     {
         Requires.NotNull(request);

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using StreamJsonRpc.Protocol;
 
 namespace StreamJsonRpc;
 
@@ -61,6 +62,22 @@ internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
 
     /// <inheritdoc/>
     public override string ToString() => $"{this.Signature} ({this.Target})";
+
+    internal bool MatchesRequestShape(JsonRpcRequest request)
+    {
+        ReadOnlySpan<ParameterInfo> parameters = this.Signature.ParametersMemory.Span[..this.Signature.TotalParamCountExcludingCancellationToken];
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            string? parameterName = this.ParameterNamesExcludingCancellationToken.IsEmpty ? parameters[i].Name : this.ParameterNamesExcludingCancellationToken[i];
+            if (!request.TryGetArgumentByNameOrIndex(parameterName, i, typeHint: null, out _)
+                && !parameters[i].HasDefaultValue)
+            {
+                return false;
+            }
+        }
+
+        return request.ArgumentCount <= parameters.Length;
+    }
 
     /// <summary>
     /// Gets the RPC parameter names for a method, excluding any <see cref="CancellationToken"/> parameter.

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -71,44 +71,46 @@ internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     internal bool MatchesRequestShape(JsonRpcRequest request)
     {
         ReadOnlySpan<ParameterInfo> parameters = this.Signature.ParametersMemory.Span[..this.Signature.TotalParamCountExcludingCancellationToken];
-        if (this.Attribute?.UseSingleObjectParameterDeserialization == true && parameters.Length == 1 && request.NamedArguments is not null)
+        if (this.Attribute?.UseSingleObjectParameterDeserialization == true && parameters.Length == 1 && request.ArgumentNames is not null)
         {
             return true;
         }
 
-        if (request.NamedArguments is not null)
+        if (request.ArgumentNames is not null)
         {
+            HashSet<string> suppliedParameterNames = new(request.ArgumentNames, StringComparer.Ordinal);
             for (int i = 0; i < parameters.Length; i++)
             {
-                string? parameterName = this.ParameterNamesExcludingCancellationToken.IsEmpty ? parameters[i].Name : this.ParameterNamesExcludingCancellationToken[i];
-                if (parameterName is null || !request.NamedArguments.ContainsKey(parameterName))
+                ParameterInfo parameter = parameters[i];
+                string? parameterName = this.ParameterNamesExcludingCancellationToken.IsEmpty ? parameter.Name : this.ParameterNamesExcludingCancellationToken[i];
+                if (parameterName is null)
+                {
+                    return false;
+                }
+
+                if (!suppliedParameterNames.Contains(parameterName) && !parameter.HasDefaultValue)
                 {
                     return false;
                 }
             }
 
-            return request.NamedArguments.Count <= parameters.Length;
+            return suppliedParameterNames.Count <= parameters.Length;
         }
 
-        if (request.ArgumentsList is null)
-        {
-            return parameters.Length == 0;
-        }
-
-        if (request.ArgumentsList.Count > parameters.Length)
+        if (request.ArgumentCount > parameters.Length)
         {
             return false;
         }
 
         for (int i = 0; i < parameters.Length; i++)
         {
-            if (i >= request.ArgumentsList.Count && !parameters[i].HasDefaultValue)
+            if (i >= request.ArgumentCount && !parameters[i].HasDefaultValue)
             {
                 return false;
             }
         }
 
-        return request.ArgumentCount <= parameters.Length;
+        return true;
     }
 
     /// <summary>

--- a/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
+++ b/src/StreamJsonRpc/Reflection/MethodSignatureAndTarget.cs
@@ -63,14 +63,46 @@ internal class MethodSignatureAndTarget : IEquatable<MethodSignatureAndTarget>
     /// <inheritdoc/>
     public override string ToString() => $"{this.Signature} ({this.Target})";
 
+    /// <summary>
+    /// Determines whether the request has the shape expected by this method without invoking formatter deserialization.
+    /// </summary>
+    /// <param name="request">The request to inspect.</param>
+    /// <returns><see langword="true"/> if the request can match this method's effective parameter names.</returns>
     internal bool MatchesRequestShape(JsonRpcRequest request)
     {
         ReadOnlySpan<ParameterInfo> parameters = this.Signature.ParametersMemory.Span[..this.Signature.TotalParamCountExcludingCancellationToken];
+        if (this.Attribute?.UseSingleObjectParameterDeserialization == true && parameters.Length == 1 && request.NamedArguments is not null)
+        {
+            return true;
+        }
+
+        if (request.NamedArguments is not null)
+        {
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                string? parameterName = this.ParameterNamesExcludingCancellationToken.IsEmpty ? parameters[i].Name : this.ParameterNamesExcludingCancellationToken[i];
+                if (parameterName is null || !request.NamedArguments.ContainsKey(parameterName))
+                {
+                    return false;
+                }
+            }
+
+            return request.NamedArguments.Count <= parameters.Length;
+        }
+
+        if (request.ArgumentsList is null)
+        {
+            return parameters.Length == 0;
+        }
+
+        if (request.ArgumentsList.Count > parameters.Length)
+        {
+            return false;
+        }
+
         for (int i = 0; i < parameters.Length; i++)
         {
-            string? parameterName = this.ParameterNamesExcludingCancellationToken.IsEmpty ? parameters[i].Name : this.ParameterNamesExcludingCancellationToken[i];
-            if (!request.TryGetArgumentByNameOrIndex(parameterName, i, typeHint: null, out _)
-                && !parameters[i].HasDefaultValue)
+            if (i >= request.ArgumentsList.Count && !parameters[i].HasDefaultValue)
             {
                 return false;
             }

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -112,6 +112,11 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                 MethodSignatureAndTarget? firstMatch = null;
                 foreach (MethodSignatureAndTarget entry in existingList)
                 {
+                    if (firstMatch is not null && !ReferenceEquals(entry.Target, firstMatch.Target))
+                    {
+                        continue;
+                    }
+
                     if (entry.Signature.MatchesParametersExcludingCancellationToken(parameters))
                     {
                         if (firstMatch is null)
@@ -125,6 +130,11 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                         {
                             return entry.Attribute;
                         }
+                    }
+
+                    if (firstMatch?.Signature.HasCancellationTokenParameter == true)
+                    {
+                        return firstMatch.Attribute;
                     }
                 }
 

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -109,54 +109,72 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         {
             if (this.targetRequestMethodToClrMethodMap.TryGetValue(methodName, out List<MethodSignatureAndTarget>? existingList))
             {
-                MethodSignatureAndTarget? firstMatch = null;
+                var targets = new List<object?>();
                 foreach (MethodSignatureAndTarget entry in existingList)
                 {
-                    if (firstMatch is not null && !ReferenceEquals(entry.Target, firstMatch.Target))
+                    if (targets.Any(t => ReferenceEquals(t, entry.Target)))
                     {
                         continue;
                     }
 
-                    bool matches;
-                    try
+                    targets.Add(entry.Target);
+                }
+
+                foreach (object? target in targets)
+                {
+                    MethodSignatureAndTarget? firstMatch = null;
+                    foreach (MethodSignatureAndTarget entry in existingList)
                     {
-                        matches = entry.Signature.MatchesParametersExcludingCancellationToken(parameters);
-                    }
-                    catch (FileNotFoundException) when (firstMatch is not null)
-                    {
-                        return firstMatch.Attribute;
-                    }
-                    catch (FileLoadException) when (firstMatch is not null)
-                    {
-                        return firstMatch.Attribute;
-                    }
-                    catch (TypeLoadException) when (firstMatch is not null)
-                    {
-                        return firstMatch.Attribute;
+                        if (!ReferenceEquals(entry.Target, target))
+                        {
+                            continue;
+                        }
+
+                        bool matches;
+                        try
+                        {
+                            matches = entry.Signature.MatchesParametersExcludingCancellationToken(parameters);
+                        }
+                        catch (FileNotFoundException) when (firstMatch is not null)
+                        {
+                            return firstMatch.Attribute;
+                        }
+                        catch (FileLoadException) when (firstMatch is not null)
+                        {
+                            return firstMatch.Attribute;
+                        }
+                        catch (TypeLoadException) when (firstMatch is not null)
+                        {
+                            return firstMatch.Attribute;
+                        }
+
+                        if (matches)
+                        {
+                            if (firstMatch is null)
+                            {
+                                firstMatch = entry;
+                            }
+                            else if (!firstMatch.Signature.HasCancellationTokenParameter &&
+                                entry.Signature.HasCancellationTokenParameter &&
+                                entry.Signature.EqualSignature(firstMatch.Signature))
+                            {
+                                return entry.Attribute;
+                            }
+
+                            if (firstMatch.Signature.HasCancellationTokenParameter)
+                            {
+                                return firstMatch.Attribute;
+                            }
+                        }
                     }
 
-                    if (matches)
-                    {
-                        if (firstMatch is null)
-                        {
-                            firstMatch = entry;
-                        }
-                        else if (!firstMatch.Signature.HasCancellationTokenParameter &&
-                            ReferenceEquals(entry.Target, firstMatch.Target) &&
-                            entry.Signature.HasCancellationTokenParameter &&
-                            entry.Signature.EqualSignature(firstMatch.Signature))
-                        {
-                            return entry.Attribute;
-                        }
-                    }
-
-                    if (firstMatch?.Signature.HasCancellationTokenParameter == true)
+                    if (firstMatch is not null)
                     {
                         return firstMatch.Attribute;
                     }
                 }
 
-                return firstMatch?.Attribute;
+                return null;
             }
         }
 

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -307,7 +307,7 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                     {
                         this.TraceLocalMethodAdded(rpcMethodName, signatureAndTarget);
                         revertAddLocalRpcTarget?.RecordMethodAdded(rpcMethodName, signatureAndTarget);
-                        AddMethodWithCancellationPreference(existingList!, signatureAndTarget);
+                        existingList!.Add(signatureAndTarget);
                     }
                     else
                     {
@@ -319,24 +319,6 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                 }
             }
         }
-    }
-
-    private static void AddMethodWithCancellationPreference(List<MethodSignatureAndTarget> methods, MethodSignatureAndTarget method)
-    {
-        if (method.Signature.HasCancellationTokenParameter)
-        {
-            int equivalentNonCancelableMethodIndex = methods.FindIndex(candidate =>
-                ReferenceEquals(candidate.Target, method.Target) &&
-                !candidate.Signature.HasCancellationTokenParameter &&
-                candidate.Signature.EqualSignature(method.Signature));
-            if (equivalentNonCancelableMethodIndex >= 0)
-            {
-                methods.Insert(equivalentNonCancelableMethodIndex, method);
-                return;
-            }
-        }
-
-        methods.Add(method);
     }
 
     private void TraceLocalMethodAdded(string rpcMethodName, MethodSignatureAndTarget targetMethod)

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using StreamJsonRpc.Protocol;
 
@@ -104,28 +105,34 @@ internal class RpcTargetInfo : System.IAsyncDisposable
     /// Note this list may omit some special parameters such as a trailing <see cref="CancellationToken"/>.
     /// </param>
     internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(string methodName, ReadOnlySpan<ParameterInfo> parameters)
+        => this.GetJsonRpcMethodAttribute(methodName, parameters, request: null);
+
+    internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(string methodName, ReadOnlySpan<ParameterInfo> parameters, JsonRpcRequest? request)
     {
         lock (this.SyncObject)
         {
             if (this.targetRequestMethodToClrMethodMap.TryGetValue(methodName, out List<MethodSignatureAndTarget>? existingList))
             {
-                var targets = new List<object?>();
+                var targetGroups = new Dictionary<object, List<MethodSignatureAndTarget>>(ReferenceComparer.Instance);
+                var orderedTargetGroups = new List<List<MethodSignatureAndTarget>>();
                 foreach (MethodSignatureAndTarget entry in existingList)
                 {
-                    if (targets.Any(t => ReferenceEquals(t, entry.Target)))
+                    object targetKey = entry.Target ?? NullTarget.Instance;
+                    if (!targetGroups.TryGetValue(targetKey, out List<MethodSignatureAndTarget>? targetGroup))
                     {
-                        continue;
+                        targetGroups.Add(targetKey, targetGroup = []);
+                        orderedTargetGroups.Add(targetGroup);
                     }
 
-                    targets.Add(entry.Target);
+                    targetGroup.Add(entry);
                 }
 
-                foreach (object? target in targets)
+                foreach (List<MethodSignatureAndTarget> targetGroup in orderedTargetGroups)
                 {
                     MethodSignatureAndTarget? firstMatch = null;
-                    foreach (MethodSignatureAndTarget entry in existingList)
+                    foreach (MethodSignatureAndTarget entry in targetGroup)
                     {
-                        if (!ReferenceEquals(entry.Target, target))
+                        if (request is not null && !entry.MatchesRequestShape(request))
                         {
                             continue;
                         }
@@ -497,5 +504,19 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         {
             this.removeEventHandler(this.server, this.registeredHandler);
         }
+    }
+
+    private sealed class NullTarget
+    {
+        internal static readonly object Instance = new();
+    }
+
+    private sealed class ReferenceComparer : IEqualityComparer<object>
+    {
+        internal static readonly ReferenceComparer Instance = new();
+
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -107,6 +107,13 @@ internal class RpcTargetInfo : System.IAsyncDisposable
     internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(string methodName, ReadOnlySpan<ParameterInfo> parameters)
         => this.GetJsonRpcMethodAttribute(methodName, parameters, request: null);
 
+    /// <summary>
+    /// Gets the method attribute for the candidate that best matches the incoming request.
+    /// </summary>
+    /// <param name="methodName">The RPC method name.</param>
+    /// <param name="parameters">The parameters currently being considered by the formatter.</param>
+    /// <param name="request">The incoming request, used to account for effective parameter names.</param>
+    /// <returns>The applicable method attribute, if one was found.</returns>
     internal JsonRpcMethodAttribute? GetJsonRpcMethodAttribute(string methodName, ReadOnlySpan<ParameterInfo> parameters, JsonRpcRequest? request)
     {
         lock (this.SyncObject)
@@ -132,11 +139,6 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                     MethodSignatureAndTarget? firstMatch = null;
                     foreach (MethodSignatureAndTarget entry in targetGroup)
                     {
-                        if (request is not null && !entry.MatchesRequestShape(request))
-                        {
-                            continue;
-                        }
-
                         bool matches;
                         try
                         {
@@ -157,6 +159,11 @@ internal class RpcTargetInfo : System.IAsyncDisposable
 
                         if (matches)
                         {
+                            if (request is not null && !entry.MatchesRequestShape(request))
+                            {
+                                continue;
+                            }
+
                             if (firstMatch is null)
                             {
                                 firstMatch = entry;

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -109,13 +109,20 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         {
             if (this.targetRequestMethodToClrMethodMap.TryGetValue(methodName, out List<MethodSignatureAndTarget>? existingList))
             {
+                JsonRpcMethodAttribute? firstMatch = null;
                 foreach (MethodSignatureAndTarget entry in existingList)
                 {
                     if (entry.Signature.MatchesParametersExcludingCancellationToken(parameters))
                     {
-                        return entry.Attribute;
+                        firstMatch ??= entry.Attribute;
+                        if (entry.Signature.HasCancellationTokenParameter)
+                        {
+                            return entry.Attribute;
+                        }
                     }
                 }
+
+                return firstMatch;
             }
         }
 

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -109,20 +109,25 @@ internal class RpcTargetInfo : System.IAsyncDisposable
         {
             if (this.targetRequestMethodToClrMethodMap.TryGetValue(methodName, out List<MethodSignatureAndTarget>? existingList))
             {
-                JsonRpcMethodAttribute? firstMatch = null;
+                MethodSignatureAndTarget? firstMatch = null;
                 foreach (MethodSignatureAndTarget entry in existingList)
                 {
                     if (entry.Signature.MatchesParametersExcludingCancellationToken(parameters))
                     {
-                        firstMatch ??= entry.Attribute;
-                        if (entry.Signature.HasCancellationTokenParameter)
+                        if (firstMatch is null)
+                        {
+                            firstMatch = entry;
+                        }
+                        else if (ReferenceEquals(entry.Target, firstMatch.Target) &&
+                            entry.Signature.HasCancellationTokenParameter &&
+                            entry.Signature.EqualSignature(firstMatch.Signature))
                         {
                             return entry.Attribute;
                         }
                     }
                 }
 
-                return firstMatch;
+                return firstMatch?.Attribute;
             }
         }
 

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -118,7 +118,8 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                         {
                             firstMatch = entry;
                         }
-                        else if (ReferenceEquals(entry.Target, firstMatch.Target) &&
+                        else if (!firstMatch.Signature.HasCancellationTokenParameter &&
+                            ReferenceEquals(entry.Target, firstMatch.Target) &&
                             entry.Signature.HasCancellationTokenParameter &&
                             entry.Signature.EqualSignature(firstMatch.Signature))
                         {

--- a/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
+++ b/src/StreamJsonRpc/Reflection/RpcTargetInfo.cs
@@ -117,7 +117,25 @@ internal class RpcTargetInfo : System.IAsyncDisposable
                         continue;
                     }
 
-                    if (entry.Signature.MatchesParametersExcludingCancellationToken(parameters))
+                    bool matches;
+                    try
+                    {
+                        matches = entry.Signature.MatchesParametersExcludingCancellationToken(parameters);
+                    }
+                    catch (FileNotFoundException) when (firstMatch is not null)
+                    {
+                        return firstMatch.Attribute;
+                    }
+                    catch (FileLoadException) when (firstMatch is not null)
+                    {
+                        return firstMatch.Attribute;
+                    }
+                    catch (TypeLoadException) when (firstMatch is not null)
+                    {
+                        return firstMatch.Attribute;
+                    }
+
+                    if (matches)
                     {
                         if (firstMatch is null)
                         {

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -36,54 +36,69 @@ public sealed class TargetMethod
 
         ArrayPool<object?> pool = ArrayPool<object?>.Shared;
         List<RpcArgumentDeserializationException>? argumentDeserializationExceptions = null;
-        MethodSignatureAndTarget? selectedCandidateMethod = null;
-        object?[]? selectedArguments = null;
+        List<List<MethodSignatureAndTarget>> targetGroups = [];
         foreach (MethodSignatureAndTarget candidateMethod in candidateMethodTargets)
         {
-            if (selectedCandidateMethod is not null &&
-                (!ReferenceEquals(candidateMethod.Target, selectedCandidateMethod.Target) ||
-                 !candidateMethod.Signature.HasCancellationTokenParameter ||
-                 !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
+            List<MethodSignatureAndTarget>? targetGroup = targetGroups.FirstOrDefault(g => ReferenceEquals(g[0].Target, candidateMethod.Target));
+            if (targetGroup is null)
             {
-                continue;
+                targetGroups.Add(targetGroup = []);
             }
 
-            int parameterCount = candidateMethod.Signature.Parameters.Count;
-            object?[] argumentArray = pool.Rent(parameterCount);
-            try
-            {
-                Span<object?> args = argumentArray.AsSpan(0, parameterCount);
-                if (this.TryGetArguments(request, candidateMethod, args))
-                {
-                    if (candidateMethod.Signature.HasCancellationTokenParameter)
-                    {
-                        selectedCandidateMethod = candidateMethod;
-                        selectedArguments = args.ToArray();
-                        break;
-                    }
-
-                    selectedCandidateMethod ??= candidateMethod;
-                    selectedArguments ??= args.ToArray();
-                }
-            }
-            catch (RpcArgumentDeserializationException ex)
-            {
-                argumentDeserializationExceptions ??= new List<RpcArgumentDeserializationException>();
-                argumentDeserializationExceptions.Add(ex);
-                this.AddErrorMessage(ex.Message);
-            }
-            finally
-            {
-                pool.Return(argumentArray, clearArray: true);
-            }
+            targetGroup.Add(candidateMethod);
         }
 
-        if (selectedCandidateMethod is not null)
+        foreach (List<MethodSignatureAndTarget> targetGroup in targetGroups)
         {
-            this.synchronizationContext = selectedCandidateMethod.SynchronizationContext ?? fallbackSynchronizationContext;
-            this.target = selectedCandidateMethod.Target;
-            this.signature = selectedCandidateMethod.Signature;
-            this.arguments = selectedArguments;
+            MethodSignatureAndTarget? selectedCandidateMethod = null;
+            object?[]? selectedArguments = null;
+            foreach (MethodSignatureAndTarget candidateMethod in targetGroup)
+            {
+                if (selectedCandidateMethod is not null &&
+                    (!candidateMethod.Signature.HasCancellationTokenParameter ||
+                     !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
+                {
+                    continue;
+                }
+
+                int parameterCount = candidateMethod.Signature.Parameters.Count;
+                object?[] argumentArray = pool.Rent(parameterCount);
+                try
+                {
+                    Span<object?> args = argumentArray.AsSpan(0, parameterCount);
+                    if (this.TryGetArguments(request, candidateMethod, args))
+                    {
+                        if (candidateMethod.Signature.HasCancellationTokenParameter)
+                        {
+                            selectedCandidateMethod = candidateMethod;
+                            selectedArguments = args.ToArray();
+                            break;
+                        }
+
+                        selectedCandidateMethod ??= candidateMethod;
+                        selectedArguments ??= args.ToArray();
+                    }
+                }
+                catch (RpcArgumentDeserializationException ex)
+                {
+                    argumentDeserializationExceptions ??= new List<RpcArgumentDeserializationException>();
+                    argumentDeserializationExceptions.Add(ex);
+                    this.AddErrorMessage(ex.Message);
+                }
+                finally
+                {
+                    pool.Return(argumentArray, clearArray: true);
+                }
+            }
+
+            if (selectedCandidateMethod is not null)
+            {
+                this.synchronizationContext = selectedCandidateMethod.SynchronizationContext ?? fallbackSynchronizationContext;
+                this.target = selectedCandidateMethod.Target;
+                this.signature = selectedCandidateMethod.Signature;
+                this.arguments = selectedArguments;
+                break;
+            }
         }
 
         if (argumentDeserializationExceptions is object)

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -40,13 +40,10 @@ public sealed class TargetMethod
         object?[]? selectedArguments = null;
         foreach (MethodSignatureAndTarget candidateMethod in candidateMethodTargets)
         {
-            if (selectedCandidateMethod is not null && !ReferenceEquals(candidateMethod.Target, selectedCandidateMethod.Target))
-            {
-                break;
-            }
-
             if (selectedCandidateMethod is not null &&
-                (!candidateMethod.Signature.HasCancellationTokenParameter || !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
+                (!ReferenceEquals(candidateMethod.Target, selectedCandidateMethod.Target) ||
+                 !candidateMethod.Signature.HasCancellationTokenParameter ||
+                 !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
             {
                 continue;
             }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -38,18 +38,20 @@ public sealed class TargetMethod
         ArrayPool<object?> pool = ArrayPool<object?>.Shared;
         List<RpcArgumentDeserializationException>? argumentDeserializationExceptions = null;
         var targetGroups = new Dictionary<object, List<MethodSignatureAndTarget>>(ReferenceComparer.Instance);
+        var orderedTargetGroups = new List<List<MethodSignatureAndTarget>>();
         foreach (MethodSignatureAndTarget candidateMethod in candidateMethodTargets)
         {
-            Assumes.NotNull(candidateMethod.Target);
-            if (!targetGroups.TryGetValue(candidateMethod.Target, out List<MethodSignatureAndTarget>? targetGroup))
+            object targetKey = candidateMethod.Target ?? NullTarget.Instance;
+            if (!targetGroups.TryGetValue(targetKey, out List<MethodSignatureAndTarget>? targetGroup))
             {
-                targetGroups.Add(candidateMethod.Target, targetGroup = []);
+                targetGroups.Add(targetKey, targetGroup = []);
+                orderedTargetGroups.Add(targetGroup);
             }
 
             targetGroup.Add(candidateMethod);
         }
 
-        foreach (List<MethodSignatureAndTarget> targetGroup in targetGroups.Values)
+        foreach (List<MethodSignatureAndTarget> targetGroup in orderedTargetGroups)
         {
             MethodSignatureAndTarget? selectedCandidateMethod = null;
             object?[]? selectedArguments = null;
@@ -256,5 +258,10 @@ public sealed class TargetMethod
         public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
 
         public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+
+    private sealed class NullTarget
+    {
+        internal static readonly object Instance = new();
     }
 }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using StreamJsonRpc.Protocol;
 
 namespace StreamJsonRpc;
@@ -36,35 +37,36 @@ public sealed class TargetMethod
 
         ArrayPool<object?> pool = ArrayPool<object?>.Shared;
         List<RpcArgumentDeserializationException>? argumentDeserializationExceptions = null;
-        List<List<MethodSignatureAndTarget>> targetGroups = [];
+        var targetGroups = new Dictionary<object, List<MethodSignatureAndTarget>>(ReferenceComparer.Instance);
         foreach (MethodSignatureAndTarget candidateMethod in candidateMethodTargets)
         {
-            List<MethodSignatureAndTarget>? targetGroup = targetGroups.FirstOrDefault(g => ReferenceEquals(g[0].Target, candidateMethod.Target));
-            if (targetGroup is null)
+            Assumes.NotNull(candidateMethod.Target);
+            if (!targetGroups.TryGetValue(candidateMethod.Target, out List<MethodSignatureAndTarget>? targetGroup))
             {
-                targetGroups.Add(targetGroup = []);
+                targetGroups.Add(candidateMethod.Target, targetGroup = []);
             }
 
             targetGroup.Add(candidateMethod);
         }
 
-        foreach (List<MethodSignatureAndTarget> targetGroup in targetGroups)
+        foreach (List<MethodSignatureAndTarget> targetGroup in targetGroups.Values)
         {
             MethodSignatureAndTarget? selectedCandidateMethod = null;
             object?[]? selectedArguments = null;
             foreach (MethodSignatureAndTarget candidateMethod in targetGroup)
             {
-                if (selectedCandidateMethod is not null &&
-                    (!candidateMethod.Signature.HasCancellationTokenParameter ||
-                     !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
-                {
-                    continue;
-                }
-
-                int parameterCount = candidateMethod.Signature.Parameters.Count;
-                object?[] argumentArray = pool.Rent(parameterCount);
+                object?[]? argumentArray = null;
                 try
                 {
+                    if (selectedCandidateMethod is not null &&
+                        (!candidateMethod.Signature.HasCancellationTokenParameter ||
+                         !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
+                    {
+                        continue;
+                    }
+
+                    int parameterCount = candidateMethod.Signature.Parameters.Count;
+                    argumentArray = pool.Rent(parameterCount);
                     Span<object?> args = argumentArray.AsSpan(0, parameterCount);
                     if (this.TryGetArguments(request, candidateMethod, args))
                     {
@@ -85,9 +87,24 @@ public sealed class TargetMethod
                     argumentDeserializationExceptions.Add(ex);
                     this.AddErrorMessage(ex.Message);
                 }
+                catch (FileNotFoundException) when (selectedCandidateMethod is not null)
+                {
+                    break;
+                }
+                catch (FileLoadException) when (selectedCandidateMethod is not null)
+                {
+                    break;
+                }
+                catch (TypeLoadException) when (selectedCandidateMethod is not null)
+                {
+                    break;
+                }
                 finally
                 {
-                    pool.Return(argumentArray, clearArray: true);
+                    if (argumentArray is not null)
+                    {
+                        pool.Return(argumentArray, clearArray: true);
+                    }
                 }
             }
 
@@ -230,5 +247,14 @@ public sealed class TargetMethod
             default:
                 return false;
         }
+    }
+
+    private sealed class ReferenceComparer : IEqualityComparer<object>
+    {
+        internal static readonly ReferenceComparer Instance = new();
+
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/StreamJsonRpc/Reflection/TargetMethod.cs
+++ b/src/StreamJsonRpc/Reflection/TargetMethod.cs
@@ -36,8 +36,21 @@ public sealed class TargetMethod
 
         ArrayPool<object?> pool = ArrayPool<object?>.Shared;
         List<RpcArgumentDeserializationException>? argumentDeserializationExceptions = null;
+        MethodSignatureAndTarget? selectedCandidateMethod = null;
+        object?[]? selectedArguments = null;
         foreach (MethodSignatureAndTarget candidateMethod in candidateMethodTargets)
         {
+            if (selectedCandidateMethod is not null && !ReferenceEquals(candidateMethod.Target, selectedCandidateMethod.Target))
+            {
+                break;
+            }
+
+            if (selectedCandidateMethod is not null &&
+                (!candidateMethod.Signature.HasCancellationTokenParameter || !candidateMethod.Signature.EqualSignature(selectedCandidateMethod.Signature)))
+            {
+                continue;
+            }
+
             int parameterCount = candidateMethod.Signature.Parameters.Count;
             object?[] argumentArray = pool.Rent(parameterCount);
             try
@@ -45,11 +58,15 @@ public sealed class TargetMethod
                 Span<object?> args = argumentArray.AsSpan(0, parameterCount);
                 if (this.TryGetArguments(request, candidateMethod, args))
                 {
-                    this.synchronizationContext = candidateMethod.SynchronizationContext ?? fallbackSynchronizationContext;
-                    this.target = candidateMethod.Target;
-                    this.signature = candidateMethod.Signature;
-                    this.arguments = args.ToArray();
-                    break;
+                    if (candidateMethod.Signature.HasCancellationTokenParameter)
+                    {
+                        selectedCandidateMethod = candidateMethod;
+                        selectedArguments = args.ToArray();
+                        break;
+                    }
+
+                    selectedCandidateMethod ??= candidateMethod;
+                    selectedArguments ??= args.ToArray();
                 }
             }
             catch (RpcArgumentDeserializationException ex)
@@ -62,6 +79,14 @@ public sealed class TargetMethod
             {
                 pool.Return(argumentArray, clearArray: true);
             }
+        }
+
+        if (selectedCandidateMethod is not null)
+        {
+            this.synchronizationContext = selectedCandidateMethod.SynchronizationContext ?? fallbackSynchronizationContext;
+            this.target = selectedCandidateMethod.Target;
+            this.signature = selectedCandidateMethod.Signature;
+            this.arguments = selectedArguments;
         }
 
         if (argumentDeserializationExceptions is object)

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using Microsoft.VisualStudio.Threading;
+#if NET
 using StreamJsonRpc.Tests;
+#endif
 
 public class JsonRpcDelegatedDispatchAndSendTests : TestBase
 {

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -37,6 +37,12 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         Assert.Equal("StreamJsonRpc.JsonMessageFormatter+InboundJsonRpcRequest", this.serverRpc.LastRequestDispatched?.GetType().FullName);
     }
 
+#pragma warning disable SA1201 // StaticTarget is a test helper used by methods above and below.
+    public static class StaticTarget
+    {
+        public static string GetValue(string value) => "static:" + value;
+    }
+
     [Fact]
     public async Task DispatchRequestTargetMethod()
     {
@@ -87,6 +93,21 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         string result = await clientRpc.InvokeAsync<string>(nameof(IInterleavedTargetWithoutCancellation.GetValue), "value");
 
         Assert.Equal("cancelable", result);
+    }
+
+    [Fact]
+    public async Task DispatchesStaticLocalMethodWithNullTarget()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2));
+        serverRpc.AddLocalRpcMethod(typeof(StaticTarget).GetMethod(nameof(StaticTarget.GetValue))!, null, null);
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        string result = await clientRpc.InvokeAsync<string>(nameof(StaticTarget.GetValue), "value");
+
+        Assert.Equal("static:value", result);
     }
 
 #if NET

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -96,6 +96,21 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     }
 
     [Fact]
+    public async Task DispatchRequestAllowsOmittedOptionalNamedParameterBeforeEquivalentCancellationOverload()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2));
+        serverRpc.AddLocalRpcTarget(new OptionalParameterTarget());
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        string result = await clientRpc.InvokeWithParameterObjectAsync<string>(nameof(OptionalParameterTarget.GetValue), new { }, this.TimeoutToken);
+
+        Assert.Equal("default", result);
+    }
+
+    [Fact]
     public async Task DispatchesStaticLocalMethodWithNullTarget()
     {
         var streams = Nerdbank.FullDuplexStream.CreateStreams();
@@ -261,6 +276,13 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     }
 
 #endif
+
+    public class OptionalParameterTarget
+    {
+        public string GetValue(string value = "default") => value;
+
+        public string GetValue(string value, CancellationToken cancellationToken) => "cancelable:" + value;
+    }
 
     public class RepeatedTarget
     {

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc.Tests;
 
 public class JsonRpcDelegatedDispatchAndSendTests : TestBase
 {
@@ -67,6 +68,18 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
 
         Assert.Equal("first", result);
     }
+
+#if NET
+    [Fact]
+    public void AddLocalRpcTargetDoesNotInspectOverloadParameters()
+    {
+        UnreachableAssemblyTools.VerifyUnreachableAssembly();
+
+        using var rpc = new JsonRpc(Stream.Null);
+        rpc.AddLocalRpcTarget(new TargetWithUnreachableParameterTypes());
+    }
+
+#endif
 
     [Fact]
     public async Task RegisteringSameTargetTypeRetainsDistinctTargets()
@@ -163,6 +176,20 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     {
         public Task<string> GetTargetAsync(CancellationToken cancellationToken) => Task.FromResult("second");
     }
+
+#if NET
+    public class TargetWithUnreachableParameterTypes
+    {
+        public void Method(UnreachableAssembly.SomeUnreachableClass value)
+        {
+        }
+
+        public void Method(UnreachableAssembly.SomeUnreachableClass value, string other)
+        {
+        }
+    }
+
+#endif
 
     public class RepeatedTarget
     {

--- a/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
+++ b/test/StreamJsonRpc.Tests/JsonRpcDelegatedDispatchAndSendTests.cs
@@ -71,6 +71,24 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
         Assert.Equal("first", result);
     }
 
+    [Fact]
+    public async Task CancellationPreferencePreservesInterleavedTargetRegistrationOrder()
+    {
+        var streams = Nerdbank.FullDuplexStream.CreateStreams();
+        using var clientRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item1));
+        using var serverRpc = new DelegatedJsonRpc(new HeaderDelimitedMessageHandler(streams.Item2));
+        var target = new InterleavedTarget();
+        serverRpc.AddLocalRpcTarget(typeof(IInterleavedTargetWithoutCancellation), target, null);
+        serverRpc.AddLocalRpcTarget(typeof(IInterleavedOtherTarget), new OtherTarget(), null);
+        serverRpc.AddLocalRpcTarget(typeof(IInterleavedTargetWithCancellation), target, null);
+        clientRpc.StartListening();
+        serverRpc.StartListening();
+
+        string result = await clientRpc.InvokeAsync<string>(nameof(IInterleavedTargetWithoutCancellation.GetValue), "value");
+
+        Assert.Equal("cancelable", result);
+    }
+
 #if NET
     [Fact]
     public void AddLocalRpcTargetDoesNotInspectOverloadParameters()
@@ -144,6 +162,24 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     }
 
 #pragma warning disable CA1801 // use all parameters
+#pragma warning disable SA1201 // interfaces are grouped with the test fixtures below
+    public interface IInterleavedTargetWithoutCancellation
+    {
+        Task<string> GetValue(string value);
+    }
+
+    public interface IInterleavedTargetWithCancellation
+    {
+        Task<string> GetValue(string value, CancellationToken cancellationToken);
+    }
+
+    public interface IInterleavedOtherTarget
+    {
+        Task<string> GetValue(string value);
+    }
+
+#pragma warning restore SA1201
+
     public class Server
     {
         private int callCounter = 0;
@@ -177,6 +213,18 @@ public class JsonRpcDelegatedDispatchAndSendTests : TestBase
     public class SecondTarget
     {
         public Task<string> GetTargetAsync(CancellationToken cancellationToken) => Task.FromResult("second");
+    }
+
+    public class InterleavedTarget : IInterleavedTargetWithoutCancellation, IInterleavedTargetWithCancellation
+    {
+        Task<string> IInterleavedTargetWithoutCancellation.GetValue(string value) => Task.FromResult("non-cancelable");
+
+        Task<string> IInterleavedTargetWithCancellation.GetValue(string value, CancellationToken cancellationToken) => Task.FromResult("cancelable");
+    }
+
+    public class OtherTarget : IInterleavedOtherTarget
+    {
+        Task<string> IInterleavedOtherTarget.GetValue(string value) => Task.FromResult("other");
     }
 
 #if NET


### PR DESCRIPTION
## Why

Registering RPC targets with overloads currently inspects method parameters while building the dispatch table. That reflection can load assemblies that are not needed unless an invocation actually needs overload selection.

## What changed

- Preserve registration order without probing cancellation-token parameters.
- Apply the cancellable-overload preference during dispatch, after a candidate has matched and parameter metadata is already required.
- Add a regression test using the unreachable-assembly fixture to ensure target registration remains parameter-lazy.

Validated with the targeted `JsonRpcDelegatedDispatchAndSendTests` tests on .NET 8 and .NET 9.